### PR TITLE
Enable trailingSlash setting

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -22,7 +22,7 @@ const config = {
 
   onBrokenLinks: 'log',
   onBrokenMarkdownLinks: 'throw',
-  trailingSlash: false,
+  trailingSlash: true,
 
   presets: [
     [


### PR DESCRIPTION
Enables the `trailingSlash` setting, so that links like https://objectiv.io/privacy/ will not result in a directory listing, but show the intended page instead.

Need to test carefully whether this breaks any links to the standalone docs.