### PR TITLE
Use staging and enable trailingSlash

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -68,7 +68,7 @@ const config = {
     'https://cdn.jsdelivr.net/npm/glightbox/dist/css/glightbox.min.css',
   ],
   customFields: {
-    trackerDocsApplicationId: (isProductionEnv || isStagingEnv) ? 'objectiv-docs' : 'objectiv-docs-dev',
+    trackerDocsApplicationId: isProductionEnv ? 'objectiv-docs' : (isStagingEnv ? 'objectiv-docs-staging' : 'objectiv-docs-dev'),
     trackerEndPoint: (isProductionEnv || isStagingEnv) ? 'https://collector.objectiv.io' : 'http://localhost:5000',
     slackJoinLink: slackJoinLink,
     trackerConsoleEnabled: !isProductionEnv
@@ -134,5 +134,6 @@ const config = {
 
 module.exports = config;
 
+console.log("USING OBJECTIV TRACKER APPLICATION ID:", config.customFields.trackerApplicationId);
 console.log("USING OBJECTIV TRACKER ENDPOINT:", config.customFields.trackerEndPoint);
 console.log("USING BASEURL:", config.baseUrl);

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -17,8 +17,8 @@ const config = {
   title: 'Objectiv Docs - creating the ultimate workflow for data scientists',
   titleDelimiter: '|',
   tagline: 'Objectiv is a data collection & modeling library that puts the data scientist first.',
-  url: 'https://objectiv.io/',
-  baseUrl: isProductionEnv ? '/docs/' : '/',
+  url: isStagingEnv ? 'https://staging.objectiv.io/' : 'https://objectiv.io/',
+  baseUrl: (isProductionEnv || isStagingEnv) ? '/docs/' : '/',
   favicon: 'img/favicon/favicon.ico',
   organizationName: 'objectiv', // Usually your GitHub org/user name.
   projectName: 'objectiv.io', // Usually your repo name.
@@ -68,8 +68,8 @@ const config = {
     'https://cdn.jsdelivr.net/npm/glightbox/dist/css/glightbox.min.css',
   ],
   customFields: {
-    trackerDocsApplicationId: isProductionEnv ? 'objectiv-docs' : 'objectiv-docs-dev',
-    trackerEndPoint: isProductionEnv ? 'https://collector.objectiv.io' : 'http://localhost:5000',
+    trackerDocsApplicationId: (isProductionEnv || isStagingEnv) ? 'objectiv-docs' : 'objectiv-docs-dev',
+    trackerEndPoint: (isProductionEnv || isStagingEnv) ? 'https://collector.objectiv.io' : 'http://localhost:5000',
     slackJoinLink: slackJoinLink,
     trackerConsoleEnabled: !isProductionEnv
   },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -62,7 +62,7 @@ const config = {
     },
   ],
   customFields: {
-    trackerApplicationId: (isProductionEnv || isStagingEnv) ? 'objectiv-website' : 'objectiv-website-dev',
+    trackerApplicationId: isProductionEnv ? 'objectiv-website' : (isStagingEnv ? 'objectiv-website-staging' : 'objectiv-website-dev'),
     trackerEndPoint: (isProductionEnv || isStagingEnv) ? 'https://collector.objectiv.io' : 'http://localhost:5000',
     slackJoinLink: slackJoinLink,
     trackerConsoleEnabled: !isProductionEnv

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -14,15 +14,15 @@ const config = {
   title: 'Objectiv - creating the ultimate workflow for data scientists',
   titleDelimiter: '|',
   tagline: 'A data collection & modeling library that puts the data scientist first.', //meta description, and og:description
-  baseUrl: isStagingEnv ? '/staging/' : '/',
-  url: isStagingEnv ? 'https://objectiv.io/staging/' : 'https://objectiv.io/',
+  baseUrl: '/',
+  url: isStagingEnv ? 'https://staging.objectiv.io/' : 'https://objectiv.io/',
   favicon: 'img/favicon/favicon.ico',
   organizationName: 'objectiv', // Usually your GitHub org/user name.
   projectName: 'objectiv.io', // Usually your repo name.
 
   onBrokenLinks: 'log',
   onBrokenMarkdownLinks: 'throw',
-  trailingSlash: false,
+  trailingSlash: true,
 
   presets: [
     [
@@ -62,8 +62,8 @@ const config = {
     },
   ],
   customFields: {
-    trackerApplicationId: isProductionEnv ? 'objectiv-website' : 'objectiv-website-dev',
-    trackerEndPoint: isProductionEnv ? 'https://collector.objectiv.io' : 'http://localhost:5000',
+    trackerApplicationId: (isProductionEnv || isStagingEnv) ? 'objectiv-website' : 'objectiv-website-dev',
+    trackerEndPoint: (isProductionEnv || isStagingEnv) ? 'https://collector.objectiv.io' : 'http://localhost:5000',
     slackJoinLink: slackJoinLink,
     trackerConsoleEnabled: !isProductionEnv
   },
@@ -84,7 +84,7 @@ const config = {
       items: [
         {
           label: 'Docs',
-          to: 'https://objectiv.io/docs/',
+          to: '/docs/',
           target: '_self'
         },
         {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -50,7 +50,7 @@ const config = {
   ],
   plugins: [
     path.resolve(__dirname, 'src/plugins/favicons/'),
-    path.resolve(__dirname, 'src/plugins/post-build/'),
+    !isStagingEnv ? path.resolve(__dirname, 'src/plugins/post-build/') : (function noPlugin() { return null }),
     require.resolve('docusaurus-plugin-image-zoom')
   ],
   scripts: [

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -148,4 +148,6 @@ const config = {
 
 module.exports = config;
 
+console.log("USING OBJECTIV TRACKER APPLICATION ID:", config.customFields.trackerApplicationId);
 console.log("USING OBJECTIV TRACKER ENDPOINT:", config.customFields.trackerEndPoint);
+console.log("USING BASEURL:", config.baseUrl);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,7 +10,7 @@ import styles from './styles.module.css';
 
 export default function Home() {
   const context = useDocusaurusContext();
-  const {tagline, customFields} = context.siteConfig;
+  const {url, tagline, customFields} = context.siteConfig;
 
   return (
     <div {...tagElement({id: 'page-home'})}>
@@ -141,7 +141,7 @@ export default function Home() {
                   </p>
                   <div className={clsx(styles.solutionRowCta)}>
                     <Link 
-                      to="https://objectiv.io/docs/taxonomy/" 
+                      to={url + "docs/taxonomy/"}
                       {...tagLink({
                           id: 'cta-docs-taxonomy', 
                           href: '/docs/taxonomy/', 
@@ -185,7 +185,7 @@ export default function Home() {
                     you to catch errors before data starts flowing in.</p>
                   <div className={clsx(styles.solutionRowCta)}>
                     <Link 
-                      to="https://objectiv.io/docs/tracking/" 
+                      to={url + "docs/tracking/"}
                       {...tagLink({
                           id: 'cta-docs-tracking', 
                           href: '/docs/tracking/', 
@@ -237,7 +237,7 @@ export default function Home() {
                     modeling with minimal additional gruntwork.</p>
                   <div className={clsx(styles.solutionRowCta)}>
                     <Link 
-                      to="https://objectiv.io/docs/tracking/core-concepts/locations" 
+                      to={url + "docs/tracking/core-concepts/locations"} 
                       {...tagLink({
                           id: 'cta-docs-location-stack', 
                           href: '/docs/taxonomy', 
@@ -332,7 +332,7 @@ export default function Home() {
                     your main site by changing a single line of code.</p>
                   <div className={clsx(styles.solutionRowCta)}>
                     <Link 
-                      to="https://objectiv.io/docs/modeling/" 
+                      to={url + "docs/modeling/"} 
                       {...tagLink({
                           id: 'cta-docs-reuse', 
                           href: '/docs/modeling/', 


### PR DESCRIPTION
- Use our staging environment, and generate URLs for it.
- Enable `trailingSlash` setting

TODO:
- [x] Disable .htaccess plugin for staging.
- [x] Set different tracking applicationId for staging.

Supersedes #113. Need to test carefully whether this breaks any links to the standalone docs.