### PR TITLE
Swizzle DocSidebar fully to fix its scrolling behavior

### DIFF
--- a/docs/src/theme/DocSidebar/index.tsx
+++ b/docs/src/theme/DocSidebar/index.tsx
@@ -5,16 +5,138 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import React, {useState} from 'react';
+import clsx from 'clsx';
+import {
+  useThemeConfig,
+  useAnnouncementBar,
+  MobileSecondaryMenuFiller,
+  MobileSecondaryMenuComponent,
+  ThemeClassNames,
+  useScrollPosition,
+} from '@docusaurus/theme-common';
+import useWindowSize from '@theme/hooks/useWindowSize';
+import Logo from '@theme/Logo';
+import IconArrow from '@theme/IconArrow';
+import {translate} from '@docusaurus/Translate';
+import {DocSidebarItems} from '@theme/DocSidebarItem';
+import type {Props} from '@theme/DocSidebar';
 import { tagElement } from '@objectiv-analytics/tracker-browser';
-import OriginalDocSidebar from '@theme-original/DocSidebar';
-import React from 'react';
 
-export default function DocSidebar(props): JSX.Element {
+import styles from './styles.module.css';
+
+function useShowAnnouncementBar() {
+  const {isActive} = useAnnouncementBar();
+  const [showAnnouncementBar, setShowAnnouncementBar] = useState(isActive);
+
+  useScrollPosition(
+    ({scrollY}) => {
+      if (isActive) {
+        setShowAnnouncementBar(scrollY === 0);
+      }
+    },
+    [isActive],
+  );
+  return isActive && showAnnouncementBar;
+}
+
+function HideableSidebarButton({onClick}: {onClick: React.MouseEventHandler}) {
+  return (
+    <button
+      type="button"
+      title={translate({
+        id: 'theme.docs.sidebar.collapseButtonTitle',
+        message: 'Collapse sidebar',
+        description: 'The title attribute for collapse button of doc sidebar',
+      })}
+      aria-label={translate({
+        id: 'theme.docs.sidebar.collapseButtonAriaLabel',
+        message: 'Collapse sidebar',
+        description: 'The title attribute for collapse button of doc sidebar',
+      })}
+      className={clsx(
+        'button button--secondary button--outline',
+        styles.collapseSidebarButton,
+      )}
+      onClick={onClick}>
+      <IconArrow className={styles.collapseSidebarButtonIcon} />
+    </button>
+  );
+}
+
+function DocSidebarDesktop({path, sidebar, onCollapse, isHidden}: Props) {
+  const showAnnouncementBar = useShowAnnouncementBar();
+  const {
+    navbar: {hideOnScroll},
+    hideableSidebar,
+  } = useThemeConfig();
+
+  return (
+    <div
+      className={clsx(styles.sidebar, {
+        [styles.sidebarWithHideableNavbar]: hideOnScroll,
+        [styles.sidebarHidden]: isHidden,
+      })}
+      {...tagElement({id: 'docs-sidebar'})}>
+      {hideOnScroll && <Logo tabIndex={-1} className={styles.sidebarLogo} />}
+      <nav
+        className={clsx('menu thin-scrollbar', styles.menu, {
+          [styles.menuWithAnnouncementBar]: showAnnouncementBar,
+        })}>
+        <ul className={clsx(ThemeClassNames.docs.docSidebarMenu, 'menu__list')}>
+          <DocSidebarItems items={sidebar} activePath={path} level={1} />
+        </ul>
+      </nav>
+      {hideableSidebar && <HideableSidebarButton onClick={onCollapse} />}
+    </div>
+  );
+}
+
+const DocSidebarMobileSecondaryMenu: MobileSecondaryMenuComponent<Props> = ({
+  toggleSidebar,
+  sidebar,
+  path,
+}) => {
+  return (
+    <div {...tagElement({ id: 'docs-sidebar' })}>
+      <ul className={clsx(ThemeClassNames.docs.docSidebarMenu, 'menu__list')}>
+        <DocSidebarItems
+          items={sidebar}
+          activePath={path}
+          onItemClick={() => toggleSidebar()}
+          level={1}
+        />
+      </ul>
+    </div>
+  );
+};
+
+function DocSidebarMobile(props: Props) {
+  return (
+    <MobileSecondaryMenuFiller
+      component={DocSidebarMobileSecondaryMenu}
+      props={props}
+    />
+  );
+}
+
+const DocSidebarDesktopMemo = React.memo(DocSidebarDesktop);
+const DocSidebarMobileMemo = React.memo(DocSidebarMobile);
+
+export default function DocSidebar(props: Props): JSX.Element {
+  const windowSize = useWindowSize();
+
+  // Desktop sidebar visible on hydration: need SSR rendering
+  const shouldRenderSidebarDesktop =
+    windowSize === 'desktop' || windowSize === 'ssr';
+
+  // Mobile sidebar not visible on hydration: can avoid SSR rendering
+  const shouldRenderSidebarMobile = windowSize === 'mobile';
+
   return (
     <>
-      <div {...tagElement({id: 'docs-sidebar'})}>
-        <OriginalDocSidebar {...props} />
-      </div>
+      {shouldRenderSidebarDesktop && <DocSidebarDesktopMemo {...props} />}
+      {shouldRenderSidebarMobile && <DocSidebarMobileMemo {...props} />}
     </>
   );
 }


### PR DESCRIPTION
Issue: the sidebar lost its sticky behavior. 

Problem: we added tracking by wrapping the sidebar in another div, which interfered with the `position: sticky` CSS applied to the specific order of sidebar/content containers.

Solution in this PR: swizzle the DocSidebar component, remove the wrapper for tracking, and add tracking inline.