### PR TITLE
Fix slug for /tracking/how-to-guides

### DIFF
--- a/docs/docs/tracking/how-to-guides/overview.md
+++ b/docs/docs/tracking/how-to-guides/overview.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-slug: /how-to-guides
+slug: /tracking/how-to-guides/
 title: Overview
 ---
 


### PR DESCRIPTION
@jansenbob This fixes the slug for the main How-To Guides page for the Tracking section. Instead of https://objectiv.io/tracking/how-to-guides/ it was using https://objectiv.io/how-to-guides/, which also breaks the link from the objectiv-analytics repo README.