### PR TITLE
Add why tagging section to tracking core concepts

### DIFF
--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -15,7 +15,7 @@ import Mermaid from '@theme/Mermaid';
 Objectiv is a data collection & modeling library that puts the data scientist first. It is built around 
 [the open taxonomy of analytics](/taxonomy/introduction.md), which is our proposal for a common way to collect, 
 structure and validate data. With Objectiv, you create a 
-[contextual layer for your application](tracking/core-concepts/tagging.md) by mapping it to the taxonomy, 
+[contextual layer for your application](tracking/core-concepts/overview.md) by mapping it to the taxonomy, 
 with the goal of collecting better data and more effective modeling.
 
 

--- a/docs/docs/tracking/core-concepts/overview.md
+++ b/docs/docs/tracking/core-concepts/overview.md
@@ -1,12 +1,16 @@
 ---
 sidebar_position: 1
 slug: /tracking/core-concepts
-title: Overview
+title: Introduction
 ---
 
 # Tracking Core Concepts
 
-High level overview of all concepts enabling tracking:
+While most trackers simply track everything by inserting a simple script, the data they collect is often incomplete or overcomplete, unstructured and ambiguous. Significant gruntwork is typically required before it can be used for modeling. 
+
+Objectiv asks you to map your application to the [open taxonomy of analytics](/taxonomy). This is done by [tagging](/tracking/core-concepts/tagging.md) interactive elements and [locations](/tracking/core-concepts/locations.md) in your application’s UI. It will create a contextual layer for your application that Objectiv's tracker uses to collect clean, well-structured data that is ready for modeling with minimal gruntwork. 
+
+#### Learn more about Objectiv's tracking concepts:
 * [Tagging](/tracking/core-concepts/tagging.md) of Elements to track.
 * [Events](/tracking/core-concepts/events.md) triggered based on tags.
 * [Locations](/tracking/core-concepts/locations.md) that describe the exact UI position for an 

--- a/docs/docs/tracking/core-concepts/tagging.md
+++ b/docs/docs/tracking/core-concepts/tagging.md
@@ -3,6 +3,9 @@ sidebar_position: 2
 title: Tagging
 slug: tagging
 ---
+:::info why tagging?
+If you want to know why we ask you to tag your elements, take a look at the [Core Concepts Introduction](/tracking/core-concepts).
+:::
 
 To understand **tagging**, we first need to know what we mean by **Elements**. 
 

--- a/docs/docs/tracking/how-to-guides/angular/tracking-locations.md
+++ b/docs/docs/tracking/how-to-guides/angular/tracking-locations.md
@@ -6,6 +6,10 @@ sidebar_position: 3
 
 Now that the [Tracker is up and running](/tracking/how-to-guides/angular/getting-started.md) we can start thinking about Tagging some [Elements](/tracking/core-concepts/tagging.md#elements) as [LocationContexts](/taxonomy/reference/location-contexts/overview.md) using [Location Taggers](/tracking/api-reference/locationTaggers/overview.md).  
 
+:::info why tagging?
+If you want to know why we ask you to tag your elements, take a look at the [Core Concepts Introduction](/tracking/core-concepts).
+:::
+
 ## Tagging Interactive Elements
 A good rule of thumb is to start by identifying all interactive Elements in the Application. 
 

--- a/docs/docs/tracking/how-to-guides/react/tracking-locations.md
+++ b/docs/docs/tracking/how-to-guides/react/tracking-locations.md
@@ -9,6 +9,10 @@ thinking about Tagging some [Elements](/tracking/core-concepts/tagging.md#elemen
 [LocationContexts](/taxonomy/reference/location-contexts/overview.md) using 
 [Location Taggers](/tracking/api-reference/locationTaggers/overview.md).  
 
+:::info why tagging?
+If you want to know why we ask you to tag your elements, take a look at the [Core Concepts Introduction](/tracking/core-concepts).
+:::
+
 ## Tagging Interactive Elements
 A good rule of thumb is to start by identifying all interactive Elements in the Application. 
 

--- a/docs/docs/tracking/introduction.md
+++ b/docs/docs/tracking/introduction.md
@@ -13,22 +13,14 @@ Objectiv comes with a set of tools that help you set up error-free user behavior
 
 <img src={useBaseUrl('/img/objectiv-pipeline-tracking.svg')} alt="Objectiv Pipeline" class="img-l" />
 
-Instrumentation involves mapping your application to the [open taxonomy for analytics](/taxonomy) to ensure the collected data is clean, well-structured and ready for modeling.
+Instrumentation involves mapping your application to the [open taxonomy for analytics](/taxonomy) to ensure the collected data is clean, well-structured and ready for modeling. [Learn more](/tracking/core-concepts/overview.md).
 
 ## How-to Guides
-To immediately jump into instrumenting your application, follow the step-by-step How-to Guides.
-
 A number of web & mobile platforms and frameworks are currently supported, such as JS, React, React Native, 
-and Angular - with more support coming.
-
-[Follow the How-to Guides](/tracking/how-to-guides/overview.md)
+and Angular - with more support coming. To immediately jump into instrumenting your application, [follow the step-by-step How-to Guides](/tracking/how-to-guides/overview.md).
 
 ## Core Concepts
-To understand in more detail how the tracking works, read about the underlying core concepts.
-
-[Read up on the Core Concepts](/tracking/core-concepts/overview.md)
+For more details on how our tracker works and the rationale behind it, [read about the underlying core concepts](/tracking/core-concepts/overview.md).
 
 ## API Reference
-To implement low-level functionality and configuration of the Trackers, all core APIs are open and documented. 
-
-[Check out the API Reference](/tracking/api-reference/overview.mdx)
+To implement low-level functionality and configuration of the Trackers, all core APIs are open and documented. [Check out the API Reference](/tracking/api-reference/overview.mdx)


### PR DESCRIPTION
- Add section why you need to tag in objectiv to core concepts overview
- Renamed `Core Concepts / Overview` to `Core Concepts / Introduction` in Tracking menu to be more descriptive
- Add links to this section from various places where taxonomy mapping was mentioned (Howto's, Tracking introduction, Tagging, Objectiv Introduction)