### PR TITLE
Small copy changes to Taxonomy Intro for consistency

### DIFF
--- a/docs/docs/taxonomy/introduction.md
+++ b/docs/docs/taxonomy/introduction.md
@@ -17,17 +17,17 @@ Objectiv's [Tracker](/tracking/introduction.md), [Collector](/tracking/core-conc
 
 <img src={useBaseUrl('/img/objectiv-pipeline-taxonomy.svg')} alt="Objectiv Pipeline" class="img-l" />
 
-## Core Principles
-To help ensure that the open taxonomy will meet its goals, we’ve created a set of core principles.
+## Principles
+To help ensure that the open taxonomy will meet its goals, we’ve created a set of principles to guide our development decisions.
 
-[Read up on the Core Principles](./core-principles.md)
+[Read up on the Principles](./core-principles.md)
 
 ## Core Concepts
 To understand in more detail how the Taxonomy works, read about the underlying core concepts.
 
 [Read up on the Core Concepts](./core-concepts.md)
 
-## Reference
+## Taxonomy Reference
 To implement the taxonomy, all Contexts and Events are open and documented. 
 
 [Check out the Reference](./reference/overview.md)

--- a/docs/docs/taxonomy/introduction.md
+++ b/docs/docs/taxonomy/introduction.md
@@ -28,7 +28,7 @@ To understand in more detail how the Taxonomy works, read about the underlying c
 [Read up on the Core Concepts](./core-concepts.md)
 
 ## Taxonomy Reference
-To implement the taxonomy, all Contexts and Events are open and documented. 
+Find out everything about the taxonomy: all Contexts and Events are open and documented. 
 
 [Check out the Reference](./reference/overview.md)
 


### PR DESCRIPTION
- Remove the word 'core' from core principles in taxonomy intro
- Small change to the description of the principles section
- Add the word 'Tracker' to 'Reference', to make it more discerning.