### PR TITLE
Consistent tracking IDs for GitHub and Docs links

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -280,7 +280,7 @@ export default function Home() {
                     <Link 
                       to="https://notebook.objectiv.io/lab?path=product_analytics.ipynb" 
                       {...tagLink({
-                          id: 'docs', 
+                          id: 'demo-notebook', 
                           href: 'https://notebook.objectiv.io/lab?path=product_analytics.ipynb', 
                           text: 'Live Demo Notebook',
                           options: {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -46,7 +46,7 @@ export default function Home() {
               <Link 
                 to="https://github.com/objectiv/objectiv-analytics" 
                 {...tagLink({
-                    id: 'cta-repo-button', 
+                    id: 'github', 
                     href: 'https://github.com/objectiv/objectiv-analytics', 
                     text: 'Objectiv on GitHub',
                     options: {
@@ -143,8 +143,8 @@ export default function Home() {
                     <Link 
                       to={url + "docs/taxonomy/"}
                       {...tagLink({
-                          id: 'cta-docs-taxonomy', 
-                          href: '/docs/taxonomy/', 
+                          id: 'docs', 
+                          href: '/docs/taxonomy/',
                           text: 'Docs - Taxonomy',
                           options: {
                             trackClicks: {
@@ -187,7 +187,7 @@ export default function Home() {
                     <Link 
                       to={url + "docs/tracking/"}
                       {...tagLink({
-                          id: 'cta-docs-tracking', 
+                          id: 'docs', 
                           href: '/docs/tracking/', 
                           text: 'Docs - Tracking',
                           options: {
@@ -239,7 +239,7 @@ export default function Home() {
                     <Link 
                       to={url + "docs/tracking/core-concepts/locations"} 
                       {...tagLink({
-                          id: 'cta-docs-location-stack', 
+                          id: 'docs', 
                           href: '/docs/taxonomy', 
                           text: 'Docs - Location Stack',
                           options: {
@@ -280,7 +280,7 @@ export default function Home() {
                     <Link 
                       to="https://notebook.objectiv.io/lab?path=product_analytics.ipynb" 
                       {...tagLink({
-                          id: 'cta-docs-demo-notebook', 
+                          id: 'docs', 
                           href: 'https://notebook.objectiv.io/lab?path=product_analytics.ipynb', 
                           text: 'Live Demo Notebook',
                           options: {
@@ -334,7 +334,7 @@ export default function Home() {
                     <Link 
                       to={url + "docs/modeling/"} 
                       {...tagLink({
-                          id: 'cta-docs-reuse', 
+                          id: 'docs', 
                           href: '/docs/modeling/', 
                           text: 'Docs - Modeling',
                           options: {

--- a/src/pages/jobs.tsx
+++ b/src/pages/jobs.tsx
@@ -46,9 +46,9 @@ export default function Jobs() {
                 <Link
                   to="https://github.com/objectiv/objectiv-analytics" 
                   {...tagLink({
-                      id: 'github-repo', 
+                      id: 'github', 
                       href: 'https://github.com/objectiv/objectiv-analytics', 
-                      text: 'Docs - Taxonomy',
+                      text: 'GitHub repo',
                       options: {
                         trackClicks: {
                           waitUntilTracked: true

--- a/src/theme/NavbarItem/DefaultNavbarItem.tsx
+++ b/src/theme/NavbarItem/DefaultNavbarItem.tsx
@@ -20,7 +20,7 @@ export default function DefaultNavbarItem({
   return (
     <OriginalDefaultNavbarItem 
       {...props}
-      {...tagLink({ id: props.label, text: props.label, href: props.href ? props.href : props.to })}
+      {...tagLink({ id: props.label.toLowerCase(), text: props.label, href: props.href ? props.href : props.to })}
     />
   );
 }


### PR DESCRIPTION
Changes:
- Every link to GitHub has `id` 'github'.
- Every link to the docs (regardless of the subsection) has `id` 'docs'.
- All the links in the main nav are lower capital.