### PR TITLE
Updates to announcement bar & nav tracking

### DIFF
--- a/src/components/announcement-bar/index.tsx
+++ b/src/components/announcement-bar/index.tsx
@@ -15,7 +15,17 @@ function AnnouncementBar({title, content, ctaLink, ctaText}) {
         {content}&nbsp;
         <Link 
           to={ctaLink}
-          {...tagLink({ id: 'announcement-cta', text: ctaText, href: ctaLink })}
+          {...tagLink({ 
+              id: 'announcement', 
+              text: ctaText, 
+              href: ctaLink, 
+              options: {
+                trackClicks: {
+                  waitUntilTracked: true
+                }
+              }
+            })
+          }
         >
           {ctaText}
         </Link>

--- a/src/theme/NavbarItem/DefaultNavbarItem.tsx
+++ b/src/theme/NavbarItem/DefaultNavbarItem.tsx
@@ -20,7 +20,17 @@ export default function DefaultNavbarItem({
   return (
     <OriginalDefaultNavbarItem 
       {...props}
-      {...tagLink({ id: props.label.toLowerCase(), text: props.label, href: props.href ? props.href : props.to })}
+      {...tagLink({ 
+          id: props.label.toLowerCase(), 
+          text: props.label, 
+          href: props.href ? props.href : props.to,
+          options: {
+            trackClicks: {
+              waitUntilTracked: true
+            }
+          }
+        })
+      }
     />
   );
 }


### PR DESCRIPTION
- Remove 'cta' from announcement bar `id` in tracking.
- Add `waitUntilTracked` for main nav links.