### PR TITLE
WIP: Enable trailingSlash for docs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -31,7 +31,7 @@ const config = {
 
   onBrokenLinks: 'log',
   onBrokenMarkdownLinks: 'throw',
-  trailingSlash: false,
+  trailingSlash: true,
 
   presets: [
     [
@@ -92,15 +92,15 @@ const config = {
         items: [
           {
             label: 'Tracking',
-            to: '/tracking//',
+            to: '/tracking/',
           },
           {
             label: 'Modeling',
-            to: '/modeling//',
+            to: '/modeling/',
           },
           {
             label: 'Taxonomy',
-            to: '/taxonomy//',
+            to: '/taxonomy/',
           },
           {
             label: 'Objectiv.io \u{1F855}',


### PR DESCRIPTION
Sets the `trailingSlash` setting for the docs to `true`, and removes the workaround with double slashes for the top navigation.

To do:

- [ ] Update auto-generation/sphinx-page component to add a trailing slash to all URLs, e.g.: `/modeling/reference/DataFrame#getting-setting-columns` ==> `/modeling/reference/DataFrame/#getting-setting-columns`