### PR TITLE
Overhaul quickstart guide, move to separate section

### DIFF
--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -18,61 +18,17 @@ structure and validate data. With Objectiv, you create a
 [contextual layer for your application](tracking/core-concepts/overview.md) by mapping it to the taxonomy, 
 with the goal of collecting better data and more effective modeling.
 
+<img src={useBaseUrl('/img/objectiv-pipeline.svg')} alt="Objectiv Pipeline" class="img-l" />
 
 With [Objectiv Bach](https://www.objectiv.io/docs/modeling/) (our data modeling library), you can use familiar Pandas-like DataFrame operations on your full SQL dataset. It includes extensions for effective feature creation for datasets that embrace the [taxonomy](/taxonomy).
 
 Check out [objectiv.io](https://www.objectiv.io) to learn more.
 
-- - -
-## Play with Objectiv
-We’ve set up a [Live Demo Notebook](https://notebook.objectiv.io/lab?path=product_analytics.ipynb)  with real data from [objectiv.io](https://www.objectiv.io) for you to 
-play with. Give it a try and see what Objectiv can do.
+## Getting Started
 
-## Running Objectiv locally - Quickstart 
-In order to run Objectiv for local development, we'll help you set up the following components:
-
-* The **Objectiv Tracker** to track user behavior from your website or web application. 
-* The **Objectiv Collector** and a **PostgreSQL data store** to collect, validate & store event data from the tracker.
-* A **Notebook** with the **Objectiv Bach** modeling library to explore and model your data.  
-
-<img src={useBaseUrl('/img/objectiv-pipeline.svg')} alt="Objectiv Pipeline" class="img-l" />
-
-
-To get the latest stable build, run the following commands:
-```bash
-git clone git@github.com:objectiv/objectiv-analytics.git
-cd objectiv-analytics
-docker-compose pull  # pull pre-built images from gcr
-```
-
-Now, let's get started.
-
-### 1. Spin up the Collector & PostgreSQL
-Run the following command:
-```bash
-docker-compose up objectiv_collector
-```
-This will spin up the Collector backend and a PostgresQL data store, creating an endpoint for the tracker to send data to.
-
-
-**Security Warning:** The above `docker-compose` command starts a postgres container that allows connections
-without verifying passwords. Do not use this in production or on a shared system!
-
-### 2. Instrument the Tracker
-The Tracker is available for multiple platforms. Follow one of the [step-by-step Tracking How-to Guides](/tracking/how-to-guides/overview.md) for your preferred platform to continue. 
-
-### 3. Spin up a Notebook with Objectiv Bach
-Run the following command: 
-```bash
-docker-compose up objectiv_notebook
-```
-This will spin up a notebook with the Objectiv Bach modeling library that enables you to analyze the data that you've collected. Check out the [modeling section](/modeling) for detailed instructions on using Objectiv Bach.
-
-
-:::info
-if you want to run step 1 and 3 in one go, just run `docker-compose up`.
-:::
----
+1. [Play with Objectiv](https://notebook.objectiv.io/lab?path=product_analytics.ipynb) in our Live Demo Notebook
+2. [Test drive Objectiv locally](/quickstart-guide) with a fully functional demo pipeline
+3. [Spin up a local development setup](/how-to-guides/collector/getting-started) with just the essentials and no demo data
 
 ## Running Objectiv in production
 A detailed How-to guide is coming soon. 

--- a/docs/docs/quickstart-guide.md
+++ b/docs/docs/quickstart-guide.md
@@ -31,9 +31,6 @@ This will spin up the following containers
 
 <img src={useBaseUrl('/img/objectiv-pipeline.svg')} alt="Objectiv Pipeline" class="img-l" />
 
-**Security Warning:** The above `docker-compose` command starts a postgres container that allows connections
-without verifying passwords. Do not use this in production or on a shared system!
-
 The initial startup may take a bit longer because the image is quite big (~2GB) and needs to be downloaded first.
 
 ### Exploring the data
@@ -43,7 +40,6 @@ To explore the data in the demo notebook, go to:
 ```bash
 http://localhost:8888/lab/tree/product_analytics.ipynb?token=objectiv
 ```
-
 For detailed modeling instructions, check out our [modeling docs](/modeling).
 
 ### Generating Events
@@ -53,8 +49,11 @@ To generate event data yourself, simply go to the local version of the objectiv 
 http://localhost:8080/
 ```
 
-When you trigger an event, you can see a request show up in your docker logs. If you used a terminal to spin up the containers, it shows there as well. If you rerun the models in your notebook, the new event data is now included.
+When you trigger an event, you can see a request show up in your docker logs. If you used a terminal to spin up the containers, it shows there as well. 
 
+:::info
+Please note that all events have a UTC timestamp. To see/use your new events in the Demo Notebook, please rebuild the full dataframe in the third cell of the notebook and re-run all cells up to 'Set the timeframe'
+:::
 ### Next Steps
 
 We hope you enjoy playing around with Objectiv. If you want to learn more about tracking & modeling with Objectiv, or about the open taxonomy, check out the rest of the Docs:

--- a/docs/docs/quickstart-guide.md
+++ b/docs/docs/quickstart-guide.md
@@ -1,0 +1,70 @@
+---
+sidebar_position: 2
+slug: /quickstart-guide
+title: Quickstart Guide
+---
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+This quickstart guide will show you how to spin up a fully functional Objectiv demo pipeline. It includes everything you need to test drive Objectiv locally.
+
+:::info Looking for a local development setup?
+If you just want the Collector and a data store without the demo data, website and notebook, [follow this guide](/how-to-guides/collector/getting-started).
+:::
+
+## Running Objectiv Dockerized
+
+Assuming you have [Docker](https://www.docker.com/) and [Curl](https://curl.se) installed, run the following commands:
+
+```bash
+curl https://raw.githubusercontent.com/objectiv/objectiv-analytics/main/docker-compose.yaml
+```
+```bash
+docker-compose up
+```
+This will spin up the following containers
+
+* `objectiv_website` A local version of the objectiv.io website, instrumented with the **Objectiv Tracker** 
+* `objectiv_collector` An **Objectiv Collector** to validate & store event data from the tracker
+* `objectiv_postgres` A PostgreSQL database, pre-filled with anonymized demo user data
+* `objectiv_notebook` A demo Notebook with the **Objectiv Bach** modeling library to explore and model the demo data  
+
+<img src={useBaseUrl('/img/objectiv-pipeline.svg')} alt="Objectiv Pipeline" class="img-l" />
+
+**Security Warning:** The above `docker-compose` command starts a postgres container that allows connections
+without verifying passwords. Do not use this in production or on a shared system!
+
+The initial startup may take a bit longer because the image is quite big (~2GB) and needs to be downloaded first.
+
+### Exploring the data
+
+To explore the data in the demo notebook, go to:
+
+```bash
+http://localhost:8888/lab/tree/product_analytics.ipynb?token=objectiv
+```
+
+For detailed modeling instructions, check out our [modeling docs](/modeling).
+
+### Generating Events
+To generate event data yourself, simply go to the local version of the objectiv website and click around:
+
+```bash
+http://localhost:8080/
+```
+
+When you trigger an event, you can see a request show up in your docker logs. If you used a terminal to spin up the containers, it shows there as well. If you rerun the models in your notebook, the new event data is now included.
+
+### Next Steps
+
+We hope you enjoy playing around with Objectiv. If you want to learn more about tracking & modeling with Objectiv, or about the open taxonomy, check out the rest of the Docs:
+
+* [Tracking with Objectiv](/tracking)
+* [Modeling with Objectiv Bach](/modeling)
+* [The open taxonomy of analytics](/taxonomy)
+
+You can use `docker-compose down` to stop and remove the running containers properly.
+
+If you have any questions or feedback, please [join us on Slack](https://join.slack.com/t/objectiv-io/shared_invite/zt-u6xma89w-DLDvOB7pQer5QUs5B_~5pg).
+
+

--- a/docs/docs/quickstart-guide.md
+++ b/docs/docs/quickstart-guide.md
@@ -52,7 +52,7 @@ http://localhost:8080/
 When you trigger an event, you can see a request show up in your docker logs. If you used a terminal to spin up the containers, it shows there as well. 
 
 :::info
-Please note that all events have a UTC timestamp. To see/use your new events in the Demo Notebook, please rebuild the full dataframe in the third cell of the notebook and re-run all cells up to 'Set the timeframe'
+Please note that all events have a UTC timestamp. To see/use your new events in the Demo Notebook, just rerun the 'Explore the data' cell.
 :::
 ### Next Steps
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -15,6 +15,11 @@
       label: 'Introduction',
     },
     {
+      type: 'doc',
+      id: 'quickstart-guide',
+      label: 'Quickstart Guide',
+    },
+    {
       type: 'category',
       label: 'The Project',
       collapsed: false,


### PR DESCRIPTION
- Move the quickstart guide to a separate MD
- Rewrite quickstart to cover demo data 
- Remove old quickstart guide from introduction
- Link to collector how-to guide for installation instructions for a dev environment