### PR TITLE
Update collector docs -> use images from dockerhub 

### DIFF
--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -28,7 +28,6 @@ Check out [objectiv.io](https://www.objectiv.io) to learn more.
 
 1. [Play with Objectiv](https://notebook.objectiv.io/lab?path=product_analytics.ipynb) in our Live Demo Notebook
 2. [Test drive Objectiv locally](/quickstart-guide) with a fully functional demo pipeline
-3. [Spin up a local development setup](/how-to-guides/collector/getting-started) with just the essentials and no demo data
 
 ## Running Objectiv in production
 A detailed How-to guide is coming soon. 


### PR DESCRIPTION
@jansenbob also requires this one: https://github.com/objectiv/objectiv-analytics/pull/309/files to be merged to fix the docker-compose file


I've chosen to use the full checkout for this doc, as that makes more sense from a dev perspective (to me). But we could ofcourse also go for the curl approach for the sake of consistency.