### PR TITLE
Fix homepage link styling

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -115,7 +115,7 @@ const config = {
             position: 'right',
             to: websiteUrl,
             target: '_self',
-            class: 'navbar__item navbar__link go-homepage'
+            className: 'navbar__item navbar__link go-homepage'
           }
         ],
       },


### PR DESCRIPTION
Fixes the icon behind the 'Objectiv.io' navigation link not showing in builds. 

Cause: In dev mode it works to use the `class` parameter, but the build ignores it and uses `className` instead.