### PR TITLE
Add cautions for Apple M1 users

### DIFF
--- a/docs/docs/quickstart-guide.md
+++ b/docs/docs/quickstart-guide.md
@@ -22,6 +22,11 @@ curl -o docker-compose.yaml https://raw.githubusercontent.com/objectiv/objectiv-
 ```bash
 docker-compose up
 ```
+
+:::caution
+There are know issues when running Docker on Apple devices with the new ARM-based M1 chip. We're working on making the demo available to M1 users as well. In the meanwhile, please use a device that support X86 instructions natively. 
+:::
+
 This will spin up the following containers
 
 * `objectiv_website` A local version of the objectiv.io website, instrumented with the **Objectiv Tracker** 

--- a/docs/docs/tracking/how-to-guides/collector/getting-started.md
+++ b/docs/docs/tracking/how-to-guides/collector/getting-started.md
@@ -31,7 +31,7 @@ docker-compose -f docker-compose-dev.yaml up -d
 docker-compose -f docker-compose-dev.yaml ps
 ```
 :::caution
-There are know issues when running Docker on Apple devices with the new ARM-based M1 chip. We're working on making the this setup available to M1 users as well. In the meanwhile, please use a device that support X86 instructions natively. 
+There are known issues when running Docker on Apple devices with the new ARM-based M1 chip. We're working on making the this setup available to M1 users as well. In the meanwhile, please use a device that supports X86 instructions natively. 
 :::
 
 This will spin up two images:

--- a/docs/docs/tracking/how-to-guides/collector/getting-started.md
+++ b/docs/docs/tracking/how-to-guides/collector/getting-started.md
@@ -30,6 +30,9 @@ docker-compose -f docker-compose-dev.yaml up -d
 # Verify the status:
 docker-compose -f docker-compose-dev.yaml ps
 ```
+:::caution
+There are know issues when running Docker on Apple devices with the new ARM-based M1 chip. We're working on making the this setup available to M1 users as well. In the meanwhile, please use a device that support X86 instructions natively. 
+:::
 
 This will spin up two images:
 


### PR DESCRIPTION
- Add cautions for Apple M1 users to the quickstart guide and collector guide.

@borft we could add a link to the live notebook demo in this warning if that does work on an M1 mac. Do you know if it does?