### PR TITLE
Add command to update pre-installs

### DIFF
--- a/docs/docs/quickstart-guide.md
+++ b/docs/docs/quickstart-guide.md
@@ -20,6 +20,7 @@ Assuming you have [Docker](https://www.docker.com/) and [Curl](https://curl.se) 
 curl -o docker-compose.yaml https://raw.githubusercontent.com/objectiv/objectiv-analytics/main/docker-compose.yaml
 ```
 ```bash
+docker-compose pull
 docker-compose up
 ```
 


### PR DESCRIPTION
Add `docker compose pull` to demo guides to prevent issues for users who've already installed te demos before.