### PR TITLE
Fix Algolia crawling http URLs instead of https

### DIFF
--- a/docs/.htaccess
+++ b/docs/.htaccess
@@ -1,9 +1,18 @@
+# redirect to https
+RewriteEngine On
+RewriteCond %{HTTP_HOST} ^objectiv.io [NC]
+RewriteCond %{HTTP:X-Forwarded-Proto} !https
+RewriteCond %{HTTPS} off
+RewriteRule ^(.*)$ https://objectiv.io/$1 [R,L]
+
+# set hsts header, to prevent client from returning to http
+Header set Strict-Transport-Security "max-age=31536000" env=HTTPS
+
 # docusaurus doesn't create proper directory indexes. This takes care of the following case:
 #
 # /docs/modeling/ -> /docs/modeling.html
 # as othwerwise it would show a directory index.
 
-RewriteEngine On
 # make sure the request ends in /
 RewriteCond %{REQUEST_URI} ^.*?/$
 # only do this if there's no index.html on disk

--- a/docs/.htaccess
+++ b/docs/.htaccess
@@ -1,9 +1,8 @@
 # redirect to https
 RewriteEngine On
-RewriteCond %{HTTP_HOST} ^objectiv.io [NC]
 RewriteCond %{HTTP:X-Forwarded-Proto} !https
 RewriteCond %{HTTPS} off
-RewriteRule ^(.*)$ https://objectiv.io/$1 [R,L]
+RewriteRule ^(.*)$ https://%{HTTP_HOST}/$1 [R,L]
 
 # set hsts header, to prevent client from returning to http
 Header set Strict-Transport-Security "max-age=31536000" env=HTTPS


### PR DESCRIPTION
The Algolia logs showed a lot of HTTP URLs being crawled instead of HTTPS, due to redirects in the docs. This change is an attempt to fix that with the .htaccess.

@borft Could you review? We should test this carefully on production.