### PR TITLE
Fix link to quickstart from Open Model Hub page

### DIFF
--- a/docs/docs/open-model-hub.md
+++ b/docs/docs/open-model-hub.md
@@ -61,5 +61,5 @@ Once you are done building a model, you can output it to an open-source BI tool 
 
 ## Demo
 :::info see the open model hub in action
-You can easily run the full Objectiv pipeline in a docker demo, see the [quickstart guide](./quickstart-guide/).
+You can easily run the full Objectiv pipeline in a docker demo, see the [quickstart guide](./quickstart-guide.md).
 :::


### PR DESCRIPTION
This fixes the link to the quickstart quide from the model hub page. It was missing the `.md` extension, so it was using a relative URL instead.