### PR TITLE
Alias default route to

### DIFF
--- a/docs/src/theme/RootLocationContextFromURLPlugin.ts
+++ b/docs/src/theme/RootLocationContextFromURLPlugin.ts
@@ -29,7 +29,7 @@ export class RootLocationContextFromURLPlugin implements TrackerPluginInterface 
    */
   beforeTransport(contexts: Required<ContextsConfig>): void {
     const pathname = location.pathname;
-    const rootLocationContextId = pathname === '/' ? 'introduction' : pathname.split('/')[1].trim().toLowerCase();
+    const rootLocationContextId = pathname === '/' ? 'home' : pathname.split('/')[1].trim().toLowerCase();
     if(rootLocationContextId){
       contexts.location_stack.unshift(makeRootLocationContext({ id: rootLocationContextId }));
     } else {


### PR DESCRIPTION
A small tweak to have a more generic, cross-platform, name for root locations that are auto generated when there's no url