### PR TITLE
Fix active state styling for Taxonomy diagrams

### DIFF
--- a/docs/docs/taxonomy/reference/events/ApplicationLoadedEvent.md
+++ b/docs/docs/taxonomy/reference/events/ApplicationLoadedEvent.md
@@ -9,6 +9,7 @@ import Mermaid from '@theme/Mermaid';
         AbstractEvent["AbstractEvent<br><span class='requires_context'>requires:<br />ApplicationContext<span class='properties'>location_stack: array<br />global_contexts: array<br />_type: string<br />id: string<br />time: integer</span></span>"];
         AbstractEvent --> NonInteractiveEvent;
         NonInteractiveEvent --> ApplicationLoadedEvent;
+    class AbstractEvent diagramDisabled;
     class ApplicationLoadedEvent diagramActive;
 `} 
   caption="Diagram: ApplicationLoadedEvent" 

--- a/docs/docs/taxonomy/reference/events/FailureEvent.md
+++ b/docs/docs/taxonomy/reference/events/FailureEvent.md
@@ -10,6 +10,7 @@ import Mermaid from '@theme/Mermaid';
         AbstractEvent["AbstractEvent<br><span class='requires_context'>requires:<br />ApplicationContext<span class='properties'>location_stack: array<br />global_contexts: array<br />_type: string<br />id: string<br />time: integer</span></span>"];
         AbstractEvent --> NonInteractiveEvent;
         NonInteractiveEvent --> FailureEvent["FailureEvent<br><span class='properties'>message: string</span>"];
+    class AbstractEvent diagramDisabled;
     class FailureEvent diagramActive;
 `} 
   caption="Diagram: NonInteractiveEvent" 

--- a/docs/docs/taxonomy/reference/events/HiddenEvent.md
+++ b/docs/docs/taxonomy/reference/events/HiddenEvent.md
@@ -9,6 +9,7 @@ import Mermaid from '@theme/Mermaid';
         AbstractEvent["AbstractEvent<br><span class='requires_context'>requires:<br />ApplicationContext<span class='properties'>location_stack: array<br />global_contexts: array<br />_type: string<br />id: string<br />time: integer</span></span>"];
         AbstractEvent --> NonInteractiveEvent;
         NonInteractiveEvent --> HiddenEvent["HiddenEvent<br /><span class='properties'>requires:<br />AbstractLocationContext</span>"];
+    class AbstractEvent diagramDisabled;
     class HiddenEvent diagramActive;
 `} 
   caption="Diagram: HiddenEvent" 

--- a/docs/docs/taxonomy/reference/events/InputChangeEvent.md
+++ b/docs/docs/taxonomy/reference/events/InputChangeEvent.md
@@ -9,6 +9,7 @@ import Mermaid from '@theme/Mermaid';
         AbstractEvent["AbstractEvent<br><span class='requires_context'>requires:<br />ApplicationContext<span class='properties'>location_stack: array<br />global_contexts: array<br />_type: string<br />id: string<br />time: integer</span></span>"];
         AbstractEvent --> InteractiveEvent;
         InteractiveEvent --> InputChangeEvent["InputChangeEvent<br /><span class='properties'>requires:<br />InputContext</span>"];
+    class AbstractEvent diagramDisabled;
     class InputChangeEvent diagramActive;
 `} 
   caption="Diagram: InputChangeEvent" 

--- a/docs/docs/taxonomy/reference/events/InteractiveEvent.md
+++ b/docs/docs/taxonomy/reference/events/InteractiveEvent.md
@@ -11,6 +11,7 @@ import Mermaid from '@theme/Mermaid';
         InteractiveEvent["InteractiveEvent<br /><span class='properties'>requires:<br />AbstractLocationContext</span>"];
         InteractiveEvent --> PressEvent["PressEvent<br /><span class='properties'>requires:<br />PressableContext</span>"];
         InteractiveEvent --> InputChangeEvent["InputChangeEvent<br /><span class='properties'>requires:<br />InputContext</span>"];
+    class AbstractEvent diagramDisabled;
     class InteractiveEvent diagramActive;
 `} 
   caption="Diagram: InteractiveEvent" 

--- a/docs/docs/taxonomy/reference/events/MediaEvent.md
+++ b/docs/docs/taxonomy/reference/events/MediaEvent.md
@@ -13,6 +13,7 @@ import Mermaid from '@theme/Mermaid';
         MediaEvent --> MediaPauseEvent;
         MediaEvent --> MediaStartEvent;
         MediaEvent --> MediaStopEvent;
+    class AbstractEvent diagramDisabled;
     class MediaEvent diagramActive;
 `} 
   caption="Diagram: MediaEvent" 

--- a/docs/docs/taxonomy/reference/events/MediaLoadEvent.md
+++ b/docs/docs/taxonomy/reference/events/MediaLoadEvent.md
@@ -10,6 +10,7 @@ import Mermaid from '@theme/Mermaid';
         AbstractEvent --> NonInteractiveEvent;
         NonInteractiveEvent --> MediaEvent["MediaEvent<br /><span class='requires_context'>requires:<br />MediaPlayerContext</span>"];
         MediaEvent --> MediaLoadEvent;
+    class AbstractEvent diagramDisabled;
     class MediaLoadEvent diagramActive;
 `} 
   caption="Diagram: MediaLoadEvent" 

--- a/docs/docs/taxonomy/reference/events/MediaPauseEvent.md
+++ b/docs/docs/taxonomy/reference/events/MediaPauseEvent.md
@@ -10,6 +10,7 @@ import Mermaid from '@theme/Mermaid';
         AbstractEvent --> NonInteractiveEvent;
         NonInteractiveEvent --> MediaEvent["MediaEvent<br /><span class='requires_context'>requires:<br />MediaPlayerContext</span>"];
         MediaEvent --> MediaPauseEvent;
+    class AbstractEvent diagramDisabled;
     class MediaPauseEvent diagramActive;
 `} 
   caption="Diagram: MediaPauseEvent" 

--- a/docs/docs/taxonomy/reference/events/MediaStartEvent.md
+++ b/docs/docs/taxonomy/reference/events/MediaStartEvent.md
@@ -10,6 +10,7 @@ import Mermaid from '@theme/Mermaid';
         AbstractEvent --> NonInteractiveEvent;
         NonInteractiveEvent --> MediaEvent["MediaEvent<br /><span class='requires_context'>requires:<br />MediaPlayerContext</span>"];
         MediaEvent --> MediaStartEvent;
+    class AbstractEvent diagramDisabled;
     class MediaStartEvent diagramActive;
 `} 
   caption="Diagram: MediaStartEvent" 

--- a/docs/docs/taxonomy/reference/events/MediaStopEvent.md
+++ b/docs/docs/taxonomy/reference/events/MediaStopEvent.md
@@ -10,6 +10,7 @@ import Mermaid from '@theme/Mermaid';
         AbstractEvent --> NonInteractiveEvent;
         NonInteractiveEvent --> MediaEvent["MediaEvent<br /><span class='requires_context'>requires:<br />MediaPlayerContext</span>"];
         MediaEvent --> MediaStopEvent;
+    class AbstractEvent diagramDisabled;
     class MediaStopEvent diagramActive;
 `} 
   caption="Diagram: MediaStopEvent" 

--- a/docs/docs/taxonomy/reference/events/NonInteractiveEvent.md
+++ b/docs/docs/taxonomy/reference/events/NonInteractiveEvent.md
@@ -18,6 +18,7 @@ import Mermaid from '@theme/Mermaid';
         MediaEvent --> MediaPauseEvent;
         MediaEvent --> MediaStartEvent;
         MediaEvent --> MediaStopEvent;
+    class AbstractEvent diagramDisabled;
     class NonInteractiveEvent diagramActive;
 `} 
   caption="Diagram: NonInteractiveEvent" 

--- a/docs/docs/taxonomy/reference/events/PressEvent.md
+++ b/docs/docs/taxonomy/reference/events/PressEvent.md
@@ -10,6 +10,7 @@ import Mermaid from '@theme/Mermaid';
         AbstractEvent --> InteractiveEvent;
         InteractiveEvent["InteractiveEvent<br /><span class='properties'>requires:<br />ContentContext</span>"] --> PressEvent;
         PressEvent["PressEvent<br /><span class='properties'>requires:<br />PressableContext</span>"];
+    class AbstractEvent diagramDisabled;
     class PressEvent diagramActive;
 `} 
   caption="Diagram: PressEvent" 

--- a/docs/docs/taxonomy/reference/events/SuccessEvent.md
+++ b/docs/docs/taxonomy/reference/events/SuccessEvent.md
@@ -9,6 +9,7 @@ import Mermaid from '@theme/Mermaid';
         AbstractEvent["AbstractEvent<br><span class='requires_context'>requires:<br />ApplicationContext<span class='properties'>location_stack: array<br />global_contexts: array<br />_type: string<br />id: string<br />time: integer</span></span>"];
         AbstractEvent --> NonInteractiveEvent;
         NonInteractiveEvent --> SuccessEvent["SuccessEvent<br><span class='properties'>message: string</span>"];
+    class AbstractEvent diagramDisabled;
     class SuccessEvent diagramActive;
 `} 
   caption="Diagram: SuccessEvent" 

--- a/docs/docs/taxonomy/reference/events/VisibleEvent.md
+++ b/docs/docs/taxonomy/reference/events/VisibleEvent.md
@@ -9,6 +9,7 @@ import Mermaid from '@theme/Mermaid';
         AbstractEvent["AbstractEvent<br><span class='requires_context'>requires:<br />ApplicationContext<span class='properties'>location_stack: array<br />global_contexts: array<br />_type: string<br />id: string<br />time: integer</span></span>"];
         AbstractEvent --> NonInteractiveEvent;
         NonInteractiveEvent --> VisibleEvent["VisibleEvent<br /><span class='properties'>requires:<br />AbstractLocationContext</span>"];
+    class AbstractEvent diagramDisabled;
     class VisibleEvent diagramActive;
 `} 
   caption="Diagram: VisibleEvent" 

--- a/docs/docs/taxonomy/reference/events/overview.md
+++ b/docs/docs/taxonomy/reference/events/overview.md
@@ -30,20 +30,7 @@ Describe interactive and non-interactive events.
         MediaEvent --> MediaPauseEvent;
         MediaEvent --> MediaStartEvent;
         MediaEvent --> MediaStopEvent;
-    class InteractiveEvent diagramActive;
-    class PressEvent diagramActive;
-    class InputChangeEvent diagramActive;
-    class NonInteractiveEvent diagramActive;
-    class ApplicationLoadedEvent diagramActive;
-    class FailureEvent diagramActive;
-    class VisibleEvent diagramActive;
-    class HiddenEvent diagramActive;
-    class SuccessEvent diagramActive;
-    class MediaEvent diagramActive;
-    class MediaLoadEvent diagramActive;
-    class MediaPauseEvent diagramActive;
-    class MediaStartEvent diagramActive;
-    class MediaStopEvent diagramActive;
+    class AbstractEvent diagramActive;
 `} 
   caption="Diagram: Events" 
   baseColor="blue" 

--- a/docs/docs/taxonomy/reference/global-contexts/ApplicationContext.md
+++ b/docs/docs/taxonomy/reference/global-contexts/ApplicationContext.md
@@ -8,6 +8,7 @@ A [GlobalContext](/taxonomy/reference/global-contexts/overview.md) describing in
 	graph LR 
         AbstractContext["AbstractContext<br><span class='properties'>id: string<br />_type: string</span>"] --> AbstractGlobalContext;
         AbstractGlobalContext --> ApplicationContext;
+    class AbstractContext diagramDisabled;
     class ApplicationContext diagramActive;
 `} 
   caption="Diagram: ApplicationContext inheritance" 

--- a/docs/docs/taxonomy/reference/global-contexts/CookieIdContext.md
+++ b/docs/docs/taxonomy/reference/global-contexts/CookieIdContext.md
@@ -8,6 +8,7 @@ import Mermaid from '@theme/Mermaid';
 	graph LR
         AbstractContext["AbstractContext<br><span class='properties'>id: string<br />_type: string</span>"] --> AbstractGlobalContext;
         AbstractGlobalContext --> CookieIdContext["CookieIdContext<br><span class='properties'>cookie_id: string</span>"];
+    class AbstractContext diagramDisabled;
     class CookieIdContext diagramActive;
 `} 
   caption="Diagram: CookieIdContext inheritance" 

--- a/docs/docs/taxonomy/reference/global-contexts/HttpContext.md
+++ b/docs/docs/taxonomy/reference/global-contexts/HttpContext.md
@@ -8,6 +8,7 @@ import Mermaid from '@theme/Mermaid';
 	graph LR
         AbstractContext["AbstractContext<br><span class='properties'>id: string<br />_type: string</span>"] --> AbstractGlobalContext;
         AbstractGlobalContext --> HttpContext["HttpContext<br><span class='properties'>referer: string<br>user_agent: string<br>remote_address: string</span>"];
+    class AbstractContext diagramDisabled;
     class HttpContext diagramActive;
 `} 
   caption="Diagram: HttpContext inheritance" 

--- a/docs/docs/taxonomy/reference/global-contexts/PathContext.md
+++ b/docs/docs/taxonomy/reference/global-contexts/PathContext.md
@@ -8,6 +8,7 @@ import Mermaid from '@theme/Mermaid';
 	graph LR
 	    AbstractContext["AbstractContext<br><span class='properties'>id: string<br />_type: string</span>"] --> AbstractGlobalContext;
         AbstractGlobalContext --> PathContext;
+    class AbstractContext diagramDisabled;
     class PathContext diagramActive;
 `} 
   caption="Diagram: PathContext inheritance" 

--- a/docs/docs/taxonomy/reference/global-contexts/SessionContext.md
+++ b/docs/docs/taxonomy/reference/global-contexts/SessionContext.md
@@ -8,6 +8,7 @@ import Mermaid from '@theme/Mermaid';
 	graph LR
         AbstractContext["AbstractContext<br><span class='properties'>id: string<br />_type: string</span>"] --> AbstractGlobalContext;
         AbstractGlobalContext --> SessionContext["SessionContext<br><span class='properties'>hit_number: integer</span>"];
+    class AbstractContext diagramDisabled;
     class SessionContext diagramActive;
 `} 
   caption="Diagram: SessionContext inheritance" 

--- a/docs/docs/taxonomy/reference/global-contexts/overview.md
+++ b/docs/docs/taxonomy/reference/global-contexts/overview.md
@@ -18,11 +18,8 @@ Global Contexts add general information to an [Event](/tracking/core-concepts/ev
         AbstractGlobalContext --> HttpContext["HttpContext<br><span class='properties'>referer: string<br>user_agent: string<br>remote_address: string</span>"];
         AbstractGlobalContext --> PathContext;
         AbstractGlobalContext --> SessionContext["SessionContext<br><span class='properties'>hit_number: integer</span>"];
-    class ApplicationContext diagramActive;
-    class CookieIdContext diagramActive;
-    class HttpContext diagramActive;
-    class PathContext diagramActive;
-    class SessionContext diagramActive;
+    class AbstractContext diagramDisabled;
+    class AbstractGlobalContext diagramActive;
 `} 
   caption="Diagram: Global Contexts" 
   baseColor="blue" 

--- a/docs/docs/taxonomy/reference/location-contexts/ContentContext.md
+++ b/docs/docs/taxonomy/reference/location-contexts/ContentContext.md
@@ -8,6 +8,7 @@ import Mermaid from '@theme/Mermaid';
 	graph LR
 		AbstractContext["AbstractContext<br><span class='properties'>id: string<br />_type: string</span>"] --> AbstractLocationContext;
 		AbstractLocationContext --> ContentContext;
+    class AbstractContext diagramDisabled;
     class ContentContext diagramActive;
 `} 
   caption="Diagram: ContentContext inheritance" 

--- a/docs/docs/taxonomy/reference/location-contexts/ExpandableContext.md
+++ b/docs/docs/taxonomy/reference/location-contexts/ExpandableContext.md
@@ -8,6 +8,7 @@ import Mermaid from '@theme/Mermaid';
 	graph LR
 		AbstractContext["AbstractContext<br><span class='properties'>id: string<br />_type: string</span>"] --> AbstractLocationContext;
 		AbstractLocationContext --> ExpandableContext;
+    class AbstractContext diagramDisabled;
     class ExpandableContext diagramActive;
 `} 
   caption="Diagram: ExpandableContext inheritance" 

--- a/docs/docs/taxonomy/reference/location-contexts/InputContext.md
+++ b/docs/docs/taxonomy/reference/location-contexts/InputContext.md
@@ -8,6 +8,7 @@ import Mermaid from '@theme/Mermaid';
 	graph LR
 		AbstractContext["AbstractContext<br><span class='properties'>id: string<br />_type: string</span>"] --> AbstractLocationContext;
         AbstractLocationContext --> InputContext;
+    class AbstractContext diagramDisabled;
     class InputContext diagramActive;
 `} 
   caption="Diagram: InputContext inheritance" 

--- a/docs/docs/taxonomy/reference/location-contexts/LinkContext.md
+++ b/docs/docs/taxonomy/reference/location-contexts/LinkContext.md
@@ -9,6 +9,7 @@ import Mermaid from '@theme/Mermaid';
 		AbstractContext["AbstractContext<br><span class='properties'>id: string<br />_type: string</span>"] --> AbstractLocationContext;
 		AbstractLocationContext --> PressableContext;
         PressableContext --> LinkContext["LinkContext<br><span class='properties'>href: string"];
+    class AbstractContext diagramDisabled;
     class LinkContext diagramActive;
 `} 
   caption="Diagram: LinkContext inheritance" 

--- a/docs/docs/taxonomy/reference/location-contexts/MediaPlayerContext.md
+++ b/docs/docs/taxonomy/reference/location-contexts/MediaPlayerContext.md
@@ -8,6 +8,7 @@ import Mermaid from '@theme/Mermaid';
 	graph LR
 		AbstractContext["AbstractContext<br><span class='properties'>id: string<br />_type: string</span>"] --> AbstractLocationContext;
 		AbstractLocationContext --> MediaPlayerContext;
+    class AbstractContext diagramDisabled;
     class MediaPlayerContext diagramActive;
 `} 
   caption="Diagram: MediaPlayerContext inheritance" 

--- a/docs/docs/taxonomy/reference/location-contexts/NavigationContext.md
+++ b/docs/docs/taxonomy/reference/location-contexts/NavigationContext.md
@@ -8,6 +8,7 @@ import Mermaid from '@theme/Mermaid';
 	graph LR
 		AbstractContext["AbstractContext<br><span class='properties'>id: string<br />_type: string</span>"] --> AbstractLocationContext;
 		AbstractLocationContext --> NavigationContext;
+    class AbstractContext diagramDisabled;
     class NavigationContext diagramActive;
 `} 
   caption="Diagram: NavigationContext inheritance" 

--- a/docs/docs/taxonomy/reference/location-contexts/OverlayContext.md
+++ b/docs/docs/taxonomy/reference/location-contexts/OverlayContext.md
@@ -8,6 +8,7 @@ import Mermaid from '@theme/Mermaid';
 	graph LR
 		AbstractContext["AbstractContext<br><span class='properties'>id: string<br />_type: string</span>"] --> AbstractLocationContext;
 		AbstractLocationContext --> OverlayContext;
+    class AbstractContext diagramDisabled;
     class OverlayContext diagramActive;
 `} 
   caption="Diagram: OverlayContext inheritance" 

--- a/docs/docs/taxonomy/reference/location-contexts/PressableContext.md
+++ b/docs/docs/taxonomy/reference/location-contexts/PressableContext.md
@@ -9,6 +9,7 @@ import Mermaid from '@theme/Mermaid';
 		AbstractContext["AbstractContext<br><span class='properties'>id: string<br />_type: string</span>"] --> AbstractLocationContext;
         AbstractLocationContext --> PressableContext;
         PressableContext --> LinkContext;
+    class AbstractContext diagramDisabled;
     class PressableContext diagramActive;
 `} 
   caption="Diagram: PressableContext inheritance" 

--- a/docs/docs/taxonomy/reference/location-contexts/RootLocationContext.md
+++ b/docs/docs/taxonomy/reference/location-contexts/RootLocationContext.md
@@ -8,6 +8,7 @@ import Mermaid from '@theme/Mermaid';
 	graph LR
 		AbstractContext["AbstractContext<br><span class='properties'>id: string<br />_type: string</span>"] --> AbstractLocationContext;
 		AbstractLocationContext --> RootLocationContext;
+    class AbstractContext diagramDisabled;
     class RootLocationContext diagramActive;
 `} 
   caption="Diagram: RootLocationContext inheritance" 

--- a/docs/docs/taxonomy/reference/location-contexts/overview.md
+++ b/docs/docs/taxonomy/reference/location-contexts/overview.md
@@ -22,15 +22,8 @@ Location Contexts are meant to describe where an event originated from in the vi
         AbstractLocationContext --> PressableContext;
         PressableContext --> LinkContext;
         AbstractLocationContext --> RootLocationContext;
-    class ContentContext diagramActive;
-    class ExpandableContext diagramActive;
-    class InputContext diagramActive;
-    class MediaPlayerContext diagramActive;
-    class NavigationContext diagramActive;
-    class OverlayContext diagramActive;
-    class PressableContext diagramActive;
-    class LinkContext diagramActive;
-    class RootLocationContext diagramActive;
+    class AbstractContext diagramDisabled;
+    class AbstractLocationContext diagramActive;
 `} 
   caption="Diagram: Location Contexts" 
   baseColor="blue" 

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -364,6 +364,10 @@ dl blockquote {
   fill: #ABE9FE !important;
   stroke: #006496 !important;
 }
+.diagramDisabled rect {
+  fill: #fff !important;
+  stroke: #64C8FA !important;
+}
 .diagram-pink rect {
   fill: #fba99dff !important;
   stroke: rgb(200, 50, 25) !important;


### PR DESCRIPTION
I noticed the active states for elements in the Taxonomy diagrams got a bit lost here and there, so I updated them.

@jansenbob came up with a style for the new contexts/events that cannot be clicked.