### PR TITLE
Add ContentContext to Reusable Models in home page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -146,7 +146,9 @@ export default function Home() {
             </div>
           </div>
 
-          <div className={clsx(styles.pageSection)}>
+          <TrackedDiv
+            id={'reusable-models'}
+            className={clsx(styles.pageSection)}>
             <div className={clsx("container", styles.contentContainer, styles.reusableModels)}>
               <IconHeader title="Chain reusable models together" icon="icon-reusable-models-chained" />
               <div className={clsx(styles.valueRowRight)}>
@@ -207,7 +209,7 @@ export default function Home() {
                 </TrackedLink>
               </div>
             </div>
-          </div>
+          </TrackedDiv>
 
           <div className={clsx(styles.pageSection, styles.pageSectionBlue)}>
             <TrackedDiv


### PR DESCRIPTION
@jansenbob FYI: this is a tiny change that hopefully will not bother you. As mentioned by Vincent in chat the Reusable Models section in home page did not have any ContentContext around it. 