### PR TITLE
add FAQ to top navbar on site

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -93,6 +93,12 @@ const config = {
           label: 'Jobs',
         },
         {
+          label: 'FAQ',
+          to: envConfig.websiteUrl + '/docs/the-project/faq', // ensure Docusaurus redirects to standalone docs
+          target: '_self',
+          waitUntilTracked: true
+        },
+        {
           label: 'Docs',
           to: envConfig.websiteUrl + '/docs', // ensure Docusaurus redirects to standalone docs
           target: '_self',


### PR DESCRIPTION
This adds the FAQ link to the top navbar on objectiv.io