### PR TITLE
Docs: ReactTracker Render Props

### DIFF
--- a/docs/docs/tracking/browser/api-reference/core/GlobalContexts.md
+++ b/docs/docs/tracking/browser/api-reference/core/GlobalContexts.md
@@ -2,7 +2,7 @@
 
 An array of [GlobalContext](/taxonomy/reference/global-contexts/overview.md) instances
 
-```typescript jsx
+```jsx
 type GlobalContexts = AbstractGlobalContext[]
 ```
 

--- a/docs/docs/tracking/browser/api-reference/core/LocationStack.md
+++ b/docs/docs/tracking/browser/api-reference/core/LocationStack.md
@@ -2,7 +2,7 @@
 
 An array of [LocationContext](/taxonomy/reference/location-contexts/overview.md) instances
 
-```typescript jsx
+```jsx
 type LocationStack = AbstractLocationContext[]
 ```
 

--- a/docs/docs/tracking/browser/api-reference/definitions/TagLocationOptions.md
+++ b/docs/docs/tracking/browser/api-reference/definitions/TagLocationOptions.md
@@ -36,7 +36,7 @@ Custom values can be specified as well:
 
 In the following example we are instructing our [Mutation Observer](/tracking/browser/api-reference/mutationObserver/overview.md) to attach a [Click Event handler](https://developer.mozilla.org/en-US/docs/Web/Events/Event_handlers#eventtarget.addeventlistener) that will attempt to wait for up to 3 seconds, polling every 100ms and flushing the `TrackerQueue` only on timeout. 
 
-```typescript jsx
+```jsx
 <link
   {...tagLink({
     id: 'external',
@@ -85,7 +85,7 @@ Used to override how the parent of a [Tagged Element](/tracking/core-concepts/br
 
 A practical is to track dynamically placed nodes in the DOM, such as React Portals. 
 
-```typescript jsx
+```jsx
 const parentDiv = tagContent({ id: 'section' });
 
 <div {...parentDiv}>

--- a/docs/docs/tracking/browser/api-reference/definitions/TagLocationReturnValue.md
+++ b/docs/docs/tracking/browser/api-reference/definitions/TagLocationReturnValue.md
@@ -2,7 +2,7 @@
 
 [LocationTaggers](/tracking/browser/api-reference/locationTaggers/overview.md) APIs return either a set of [TaggingAttributes](/tracking/browser/api-reference/definitions/TaggingAttribute.md) or `undefined`. The latter occurs whenever an Error is thrown. 
 
-```typescript jsx
+```jsx
 
 type TagLocationReturnValue = TagLocationAttributes | undefined; 
 

--- a/docs/docs/tracking/browser/api-reference/definitions/TrackClicksAttribute.md
+++ b/docs/docs/tracking/browser/api-reference/definitions/TrackClicksAttribute.md
@@ -6,7 +6,7 @@ When a `boolean` is specified it either disables the feature entirely or applies
 
 The same applies to `waitUntilTracked`. Either it's left out, set to `true` for sensible defaults or a custom set of options can be specified. 
 
-```typescript jsx
+```jsx
 type TrackClicksAttribute = boolean | {
   waitUntilTracked: true | WaitUntilTrackedOptions
 };

--- a/docs/docs/tracking/browser/api-reference/definitions/TrackClicksOptions.md
+++ b/docs/docs/tracking/browser/api-reference/definitions/TrackClicksOptions.md
@@ -3,7 +3,7 @@
 [TaggingAttribute.trackClicks](/tracking/browser/api-reference/definitions/TaggingAttribute.md#taggingattributetrackclicks) are parsed onto this object via [parseTrackClickAttribute](/tracking/browser/api-reference/common/parsers/parseTrackClicks.md).  
 
 
-```typescript jsx
+```jsx
 type TrackClicksOptions = undefined | {
   waitForQueue?: WaitForQueueOptions;
   flushQueue?: FlushQueueOptions;

--- a/docs/docs/tracking/browser/api-reference/definitions/TrackVisibilityAttribute.md
+++ b/docs/docs/tracking/browser/api-reference/definitions/TrackVisibilityAttribute.md
@@ -4,7 +4,7 @@ The definition of [TaggingAttribute.trackVisibility](/tracking/browser/api-refer
 
 Supports two modes currently. 
 
-```typescript jsx
+```jsx
 type TrackClicksAttribute = { mode: 'auto' } | { mode: 'manual', isVisible: boolean };
 ```
 

--- a/docs/docs/tracking/browser/api-reference/definitions/TrackerErrorHandlerCallback.md
+++ b/docs/docs/tracking/browser/api-reference/definitions/TrackerErrorHandlerCallback.md
@@ -2,7 +2,7 @@
 
 The `onError` parameter of [Location Taggers](/tracking/browser/api-reference/locationTaggers/overview.md) APIs is a callback that gets invoked when Errors are caught during tracking. 
 
-```typescript jsx
+```jsx
 
 type TrackerErrorHandlerCallback = <T = unknown>(error: unknown, parameters?: T) => void
 

--- a/docs/docs/tracking/browser/api-reference/definitions/ValidateAttribute.md
+++ b/docs/docs/tracking/browser/api-reference/definitions/ValidateAttribute.md
@@ -2,7 +2,7 @@
 
 The definition of [TaggingAttribute.validate](/tracking/browser/api-reference/definitions/TaggingAttribute.md#taggingattributevalidate).
 
-```typescript jsx
+```jsx
 type TrackClicksAttribute = {
   locationUniqueness?: boolean;
 };

--- a/docs/docs/tracking/browser/api-reference/definitions/WaitForQueueOptions.md
+++ b/docs/docs/tracking/browser/api-reference/definitions/WaitForQueueOptions.md
@@ -2,7 +2,7 @@
 
 Options to configure how [TaggingAttribute.trackClicks](/tracking/browser/api-reference/definitions/TaggingAttribute.md#taggingattributetrackclicks) handles TrackerQueue waiting. 
 
-```typescript jsx
+```jsx
 type WaitForQueueOptions = {
   intervalMs?: number;
   timeoutMs?: number;

--- a/docs/docs/tracking/browser/api-reference/definitions/WaitUntilTrackedOptions.md
+++ b/docs/docs/tracking/browser/api-reference/definitions/WaitUntilTrackedOptions.md
@@ -2,7 +2,7 @@
 
 Options to configure how [TaggingAttribute.trackClicks](/tracking/browser/api-reference/definitions/TaggingAttribute.md#taggingattributetrackclicks) handles waiting for TrackerQueue and possibly flushing it.
 
-```typescript jsx
+```jsx
 type WaitUntilTrackedOptions = {
   intervalMs?: number;
   timeoutMs?: number;

--- a/docs/docs/tracking/browser/api-reference/eventTrackers/trackApplicationLoadedEvent.md
+++ b/docs/docs/tracking/browser/api-reference/eventTrackers/trackApplicationLoadedEvent.md
@@ -30,11 +30,11 @@ trackApplicationLoadedEvent = (parameters: {
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { trackApplicationLoadedEvent } from '@objectiv/tracker-browser';
 ```
 
-```typescript jsx
+```jsx
 <head>
   ...
   <script>
@@ -43,7 +43,7 @@ import { trackApplicationLoadedEvent } from '@objectiv/tracker-browser';
 </head>
 ```
 
-```typescript jsx
+```jsx
 const App = () => {
   ...
   

--- a/docs/docs/tracking/browser/api-reference/eventTrackers/trackEvent.md
+++ b/docs/docs/tracking/browser/api-reference/eventTrackers/trackEvent.md
@@ -30,11 +30,11 @@ trackEvent = (parameters: {
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { trackEvent, makePressEvent } from '@objectiv/tracker-browser';
 ```
 
-```typescript jsx
+```jsx
 export const trackPressEvent = (parameters: {
   element: TaggableElement | EventTarget;
   tracker?: BrowserTracker;

--- a/docs/docs/tracking/browser/api-reference/eventTrackers/trackFailureEvent.md
+++ b/docs/docs/tracking/browser/api-reference/eventTrackers/trackFailureEvent.md
@@ -27,11 +27,11 @@ trackFailureEvent = (parameters: {
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { trackFailurEvent, trackSuccessEvent } from '@objectiv/tracker-browser';
 ```
 
-```typescript jsx
+```jsx
 <form onSubmit={() => {
   sendFormAsync()
     .then(

--- a/docs/docs/tracking/browser/api-reference/eventTrackers/trackHiddenEvent.md
+++ b/docs/docs/tracking/browser/api-reference/eventTrackers/trackHiddenEvent.md
@@ -30,11 +30,11 @@ trackHiddenEvent = (parameters: {
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { trackHiddenEvent } from '@objectiv/tracker-browser';
 ```
 
-```typescript jsx
+```jsx
 <Modal
   onShow={(event) => {
     trackVisibleEvent({ element: event.target })
@@ -47,7 +47,7 @@ import { trackHiddenEvent } from '@objectiv/tracker-browser';
 </Modal>
 ```
 
-```typescript jsx
+```jsx
 const elementRef = createRef();
 ...
 useEffect(() => {

--- a/docs/docs/tracking/browser/api-reference/eventTrackers/trackInputChangeEvent.md
+++ b/docs/docs/tracking/browser/api-reference/eventTrackers/trackInputChangeEvent.md
@@ -30,11 +30,11 @@ trackInputChangeEvent = (parameters: {
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { trackInputChangeEvent } from '@objectiv/tracker-browser';
 ```
 
-```typescript jsx
+```jsx
 <input
   onBlur={(event) => {
     trackInputChangeEvent({ element: event.target })
@@ -42,7 +42,7 @@ import { trackInputChangeEvent } from '@objectiv/tracker-browser';
 />
 ```
 
-```typescript jsx
+```jsx
 <select
   onChange={(event) => {
     trackInputChangeEvent({ element: event.target })
@@ -52,7 +52,7 @@ import { trackInputChangeEvent } from '@objectiv/tracker-browser';
 </select>
 ```
 
-```typescript jsx
+```jsx
 <TextField
   onBlur={(event) => {
     trackInputChangeEvent({ element: event.target })

--- a/docs/docs/tracking/browser/api-reference/eventTrackers/trackMediaEvent.md
+++ b/docs/docs/tracking/browser/api-reference/eventTrackers/trackMediaEvent.md
@@ -26,11 +26,11 @@ trackMediaEvent = (parameters: {
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { trackMediaEvent } from '@objectiv/tracker-browser';
 ```
 
-```typescript jsx
+```jsx
 <video
   onLoad={(event) => {
     trackMediaEvent({ element: event.target })
@@ -38,7 +38,7 @@ import { trackMediaEvent } from '@objectiv/tracker-browser';
 />
 ```
 
-```typescript jsx
+```jsx
 <YouTube
   onCustomEvent={({ target: youTubePlayerInstance }) => {
     trackMediaEvent({ element: youTubePlayerInstance.getIframe() })

--- a/docs/docs/tracking/browser/api-reference/eventTrackers/trackMediaLoadEvent.md
+++ b/docs/docs/tracking/browser/api-reference/eventTrackers/trackMediaLoadEvent.md
@@ -26,11 +26,11 @@ trackMediaLoadEvent = (parameters: {
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { trackMediaLoadEvent } from '@objectiv/tracker-browser';
 ```
 
-```typescript jsx
+```jsx
 <video
   onLoad={(event) => {
     trackMediaLoadEvent({ element: event.target })
@@ -38,7 +38,7 @@ import { trackMediaLoadEvent } from '@objectiv/tracker-browser';
 />
 ```
 
-```typescript jsx
+```jsx
 <YouTube
   onLoad={({ target: youTubePlayerInstance }) => {
     trackMediaLoadEvent({ element: youTubePlayerInstance.getIframe() })

--- a/docs/docs/tracking/browser/api-reference/eventTrackers/trackMediaPauseEvent.md
+++ b/docs/docs/tracking/browser/api-reference/eventTrackers/trackMediaPauseEvent.md
@@ -26,11 +26,11 @@ trackMediaPauseEvent = (parameters: {
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { trackMediaPauseEvent } from '@objectiv/tracker-browser';
 ```
 
-```typescript jsx
+```jsx
 <video
   play={(event) => {
     trackMediaPauseEvent({ element: event.target })
@@ -41,7 +41,7 @@ import { trackMediaPauseEvent } from '@objectiv/tracker-browser';
 />
 ```
 
-```typescript jsx
+```jsx
 <YouTube
   onPlay={({ target: youTubePlayerInstance }) => {
     trackMediaStartEvent({ element: youTubePlayerInstance.getIframe() })

--- a/docs/docs/tracking/browser/api-reference/eventTrackers/trackMediaStartEvent.md
+++ b/docs/docs/tracking/browser/api-reference/eventTrackers/trackMediaStartEvent.md
@@ -26,11 +26,11 @@ trackMediaStartEvent = (parameters: {
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { trackMediaStartEvent } from '@objectiv/tracker-browser';
 ```
 
-```typescript jsx
+```jsx
 <video
   play={(event) => {
     trackMediaStartEvent({ element: event.target })
@@ -41,7 +41,7 @@ import { trackMediaStartEvent } from '@objectiv/tracker-browser';
 />
 ```
 
-```typescript jsx
+```jsx
 <YouTube
   onPlay={({ target: youTubePlayerInstance }) => {
     trackMediaStartEvent({ element: youTubePlayerInstance.getIframe() })

--- a/docs/docs/tracking/browser/api-reference/eventTrackers/trackMediaStopEvent.md
+++ b/docs/docs/tracking/browser/api-reference/eventTrackers/trackMediaStopEvent.md
@@ -26,11 +26,11 @@ trackMediaStopEvent = (parameters: {
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { trackMediaStopEvent } from '@objectiv/tracker-browser';
 ```
 
-```typescript jsx
+```jsx
 <video
   onStop={(event) => {
     trackMediaStopEvent({ element: event.target })
@@ -38,7 +38,7 @@ import { trackMediaStopEvent } from '@objectiv/tracker-browser';
 />
 ```
 
-```typescript jsx
+```jsx
 <YouTube
   onStop={({ target: youTubePlayerInstance }) => {
     trackMediaStopEvent({ element: youTubePlayerInstance.getIframe() })

--- a/docs/docs/tracking/browser/api-reference/eventTrackers/trackPressEvent.md
+++ b/docs/docs/tracking/browser/api-reference/eventTrackers/trackPressEvent.md
@@ -30,11 +30,11 @@ trackPressEvent = (parameters: {
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { trackPressEvent } from '@objectiv/tracker-browser';
 ```
 
-```typescript jsx
+```jsx
 <div
   onClick={(event) => {
     trackPressEvent({ element: event.target })
@@ -42,7 +42,7 @@ import { trackPressEvent } from '@objectiv/tracker-browser';
 />
 ```
 
-```typescript jsx
+```jsx
 <Accordion
   onClick={(event) => {
     trackPressEvent({ element: event.target })

--- a/docs/docs/tracking/browser/api-reference/eventTrackers/trackSuccessEvent.md
+++ b/docs/docs/tracking/browser/api-reference/eventTrackers/trackSuccessEvent.md
@@ -27,11 +27,11 @@ trackSuccessEvent = (parameters: {
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { trackSuccessEvent } from '@objectiv/tracker-browser';
 ```
 
-```typescript jsx
+```jsx
 <form onSubmit={() => {
   sendFormAsync().then(
     () => trackSuccessEvent({ message: 'Yes!', element: form })

--- a/docs/docs/tracking/browser/api-reference/eventTrackers/trackVisibility.md
+++ b/docs/docs/tracking/browser/api-reference/eventTrackers/trackVisibility.md
@@ -29,11 +29,11 @@ trackVisibility = (parameters: {
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { trackVisibility } from '@objectiv/tracker-browser';
 ```
 
-```typescript jsx
+```jsx
 <Accordion
   onChange={(event, expanded) => {
     trackVisibility({ element: event.target, isVisible: expanded })

--- a/docs/docs/tracking/browser/api-reference/eventTrackers/trackVisibleEvent.md
+++ b/docs/docs/tracking/browser/api-reference/eventTrackers/trackVisibleEvent.md
@@ -30,11 +30,11 @@ trackVisibleEvent = (parameters: {
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { trackVisibleEvent } from '@objectiv/tracker-browser';
 ```
 
-```typescript jsx
+```jsx
 <Modal
   onShow={(event) => {
     trackVisibleEvent({ element: event.target })
@@ -47,7 +47,7 @@ import { trackVisibleEvent } from '@objectiv/tracker-browser';
 </Modal>
 ```
 
-```typescript jsx
+```jsx
 const elementRef = createRef();
 ...
 useEffect(() => {

--- a/docs/docs/tracking/browser/api-reference/general/getTracker.md
+++ b/docs/docs/tracking/browser/api-reference/general/getTracker.md
@@ -24,15 +24,15 @@ If not `trackerId` is specified, the default [BrowserTracker](/tracking/browser/
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { getTracker } from '@objectiv/tracker-browser';
 ```
 
-```typescript jsx
+```jsx
 const tracker = getTracker();
 ```
 
-```typescript jsx
+```jsx
 const defaultTracker = getTracker();
 const secondaryTracker = getTracker('secondary-tracker');
 ```

--- a/docs/docs/tracking/browser/api-reference/general/makeTracker.md
+++ b/docs/docs/tracking/browser/api-reference/general/makeTracker.md
@@ -43,18 +43,18 @@ When providing only `endpoint`, the Tracker will automatically create a Transpor
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { makeTracker } from '@objectiv/tracker-browser';
 ```
 
-```typescript jsx
+```jsx
 makeTracker({
   applicationId: 'awesome-app',
   endpoint: 'https://collector.awesome-app.dev' 
 })
 ```
 
-```typescript jsx
+```jsx
 makeTracker({
   applicationId: 'awesome-app',
   transport: CustomTransport,

--- a/docs/docs/tracking/browser/api-reference/general/setDefaultTracker.md
+++ b/docs/docs/tracking/browser/api-reference/general/setDefaultTracker.md
@@ -20,11 +20,11 @@ setDefaultTracker = (trackerId: string) => void
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { setDefaultTracker } from '@objectiv/tracker-browser';
 ```
 
-```typescript jsx
+```jsx
 setDefaultTracker('secondary-tracker');
 ```
 

--- a/docs/docs/tracking/browser/api-reference/locationTaggers/tagChildren.md
+++ b/docs/docs/tracking/browser/api-reference/locationTaggers/tagChildren.md
@@ -34,11 +34,11 @@ tagChild = (parameters: ChildrenTaggingQuery) => TagLocationReturnValue
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { tagChildren, tagPressable } from '@objectiv/tracker-browser';
 ```
 
-```typescript jsx
+```jsx
 <div
   {...tagChildren([
     {

--- a/docs/docs/tracking/browser/api-reference/locationTaggers/tagContent.md
+++ b/docs/docs/tracking/browser/api-reference/locationTaggers/tagContent.md
@@ -22,11 +22,11 @@ tagContent = (parameters: {
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { tagContent } from '@objectiv/tracker-browser';
 ```
 
-```typescript jsx
+```jsx
 <Layout {...tagContent({ id: 'layout' })}>
   <div {...tagContent({ id: 'section' })}>
     ...

--- a/docs/docs/tracking/browser/api-reference/locationTaggers/tagExpandable.md
+++ b/docs/docs/tracking/browser/api-reference/locationTaggers/tagExpandable.md
@@ -29,17 +29,17 @@ Unless customized via the `options` parameter, automatically triggers:
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { tagExpandable } from '@objectiv/tracker-browser';
 ```
 
-```typescript jsx
+```jsx
 <div {...tagExpandable({ id: 'faq-item-id' })}>
   ...
 </div>
 ```
 
-```typescript jsx
+```jsx
 <Accordion {...tagExpandable({ id: 'accordion-id' })}>
   ...
 </Accordion>

--- a/docs/docs/tracking/browser/api-reference/locationTaggers/tagInput.md
+++ b/docs/docs/tracking/browser/api-reference/locationTaggers/tagInput.md
@@ -27,15 +27,15 @@ Unless customized via the `options` parameter, automatically triggers:
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { tagInput } from '@objectiv/tracker-browser';
 ```
 
-```typescript jsx
+```jsx
 <input {...tagInput({ id: 'search' })} />
 ```
 
-```typescript jsx
+```jsx
 <Search {...tagInput({ id: 'search' })} />
 ```
 

--- a/docs/docs/tracking/browser/api-reference/locationTaggers/tagLink.md
+++ b/docs/docs/tracking/browser/api-reference/locationTaggers/tagLink.md
@@ -29,15 +29,15 @@ Unless customized via the `options` parameter, automatically triggers:
 
 ## Usage examples
 
-```typescript jsx
+```jsx
 import { tagLink } from '@objectiv/tracker-browser';
 ```
 
-```typescript jsx
+```jsx
 <a {...tagLink({ id: 'lnk-id', href: '/path' })} href="/path">Go!</a>
 ```
 
-```typescript jsx
+```jsx
 <LinkComponent {...tagLink({ id: 'lnk-id', href: '/path' })} to="/path">Go!</LinkComponent>
 ```
 

--- a/docs/docs/tracking/browser/api-reference/locationTaggers/tagLocation.md
+++ b/docs/docs/tracking/browser/api-reference/locationTaggers/tagLocation.md
@@ -40,11 +40,11 @@ Unless customized via the `options` parameter, the given `instance` determines w
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { tagLocation } from '@objectiv/tracker-browser';
 ```
 
-```typescript jsx
+```jsx
 <Layout {...tagLocation({ instance: makeContentContext({ id: 'layout' }) })}>
   <div {...tagLocation({ instance: makeOverlayContext({ id: 'modal' }) })}>
     ...

--- a/docs/docs/tracking/browser/api-reference/locationTaggers/tagMediaPlayer.md
+++ b/docs/docs/tracking/browser/api-reference/locationTaggers/tagMediaPlayer.md
@@ -21,17 +21,17 @@ tagMediaPlayer = (parameters: {
 [TagLocationReturnValue](/tracking/browser/api-reference/definitions/TagLocationReturnValue.md)
 
 ## Examples
-```typescript jsx
+```jsx
 import { tagMediaPlayer } from '@objectiv/tracker-browser';
 ```
 
-```typescript jsx
+```jsx
 <div {...tagMediaPlayer({ id: 'player-id' })}>
   <iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" />  
 </div>
 ```
 
-```typescript jsx
+```jsx
 <Player {...tagMediaPlayer({ id: 'player-id' })}>
   <iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" />
 </Player>

--- a/docs/docs/tracking/browser/api-reference/locationTaggers/tagNavigation.md
+++ b/docs/docs/tracking/browser/api-reference/locationTaggers/tagNavigation.md
@@ -22,17 +22,17 @@ tagNavigation = (parameters: {
 
 ## Examples
 
-```typescript jsx
+```jsx
 import { tagNavigation } from '@objectiv/tracker-browser';
 ```
 
-```typescript jsx
+```jsx
 <nav {...tagNavigation({ id: 'navigation-id' })}>
   ...
 </nav>
 ```
 
-```typescript jsx
+```jsx
 <TopNav {...tagNavigation({ id: 'navigation-id' })}>
   ...
 </TopNav>

--- a/docs/docs/tracking/browser/api-reference/locationTaggers/tagOverlay.md
+++ b/docs/docs/tracking/browser/api-reference/locationTaggers/tagOverlay.md
@@ -28,17 +28,17 @@ Unless customized via the `options` parameter, automatically triggers:
 
 ## Examples
 
-```typescript jsx
+```jsx
 import { tagOverlay } from '@objectiv/tracker-browser';
 ```
 
-```typescript jsx
+```jsx
 <div {...tagOverlay({ id: 'modal-id' })}>
   ...
 </div>
 ```
 
-```typescript jsx
+```jsx
 <Modal {...tagOverlay({ id: 'modal-id' })}>
   ...
 </Modal>

--- a/docs/docs/tracking/browser/api-reference/locationTaggers/tagPressable.md
+++ b/docs/docs/tracking/browser/api-reference/locationTaggers/tagPressable.md
@@ -28,15 +28,15 @@ Unless customized via the `options` parameter, automatically triggers:
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { tagPressable } from '@objectiv/tracker-browser';
 ```
 
-```typescript jsx
+```jsx
 <button {...tagPressable({ id: 'button-id' })}>Click Me!</button>
 ```
 
-```typescript jsx
+```jsx
 <Submit {...tagPressable({ id: 'submit' })}>Do It!</Submit>
 ```
 

--- a/docs/docs/tracking/browser/api-reference/locationTaggers/tagRootLocation.md
+++ b/docs/docs/tracking/browser/api-reference/locationTaggers/tagRootLocation.md
@@ -28,17 +28,17 @@ import TabItem from '@theme/TabItem';
 <Tabs>
   <TabItem value="react" label="React" default>
 
-```typescript jsx
+```jsx
 import { tagRootLocation } from '@objectiv/tracker-browser';
 ```
 
-```typescript jsx
+```jsx
 <body {...tagRootLocation({ id: 'page' })}>
   ...
 </body>
 ```
 
-```typescript jsx
+```jsx
 <Layout {...tagRootLocation({ id: 'page' })}>
   ...
 </Layout>
@@ -49,7 +49,7 @@ import { tagRootLocation } from '@objectiv/tracker-browser';
 
 Taggers only work by installing the [Taggers Directive](/tracking/browser/how-to-guides/getting-started.md#optional---configure-taggers-directive).
 
-```typescript jsx
+```jsx
 <main [tagRootLocation]="{ id: 'page' }">
   ...
 </main>

--- a/docs/docs/tracking/browser/how-to-guides/tagging-locations.md
+++ b/docs/docs/tracking/browser/how-to-guides/tagging-locations.md
@@ -19,7 +19,7 @@ A good rule of thumb is to start by identifying all interactive Elements in the 
 ### Buttons
 Anything that the user can interact with, but does not cause a URL change, can be considered a Button. 
 
-```typescript jsx
+```jsx
 // a button tag 
 <button {...tagPressable({ id: 'button-1' })}>Click Me!</button>
 
@@ -38,7 +38,7 @@ Currently it's necessary to specify `text` manually. We are working on improveme
 ### Links
 Links are interactive elements that cause, directly or indirectly, a change in the current URL.
 
-```typescript jsx
+```jsx
 // a link tag 
 <a {...tagLink({ id: 'link-1', href:"/somewhere" })} href="/somewhere">Go!</a>
 
@@ -56,7 +56,7 @@ easier.
 Elements that cause other Elements, usually their children, to be expanded and displayed to the user, such as 
 Accordions and collapsible Menus. 
 
-```typescript jsx
+```jsx
 // an Accordion-like component 
 <FAQItem {...tagExpandable({ id: 'how-to-1' })} description="How to track Accordions?">
   Some content here that will be displayed on click

--- a/docs/docs/tracking/browser/how-to-guides/troubleshooting.md
+++ b/docs/docs/tracking/browser/how-to-guides/troubleshooting.md
@@ -36,7 +36,7 @@ Nonetheless, it's still highly recommended covering all complex trackers with te
 ### Example of Component using Portals
 The `Menu` component renders its contents in a [React Portal](https://reactjs.org/docs/portals.html). 
 
-```typescript jsx
+```jsx
 <Card>
   <Menu>
     <MenuItem>Item A</MenuItem>
@@ -51,7 +51,7 @@ It's easier to tag siblings via [tagChildren](/tracking/browser/api-reference/lo
 
 Unknowingly we may attempt to tag it by adding our [Location Taggers](/tracking/browser/api-reference/locationTaggers/overview.md) as follows:
 
-```typescript jsx
+```jsx
 <Card {...tagContent({ id: 'card' })}>
   <Menu {...tagOverlay({ id: 'menu' })}>
     <MenuItem {...tagPressable({ id: 'menu-item-a' })}>Item A</MenuItem>
@@ -80,7 +80,7 @@ The solution is to specify the parent [Location Tagger](/tracking/browser/api-re
 
 This tells the [Event Tracker](/tracking/browser/api-reference/eventTrackers/overview.md) to ignore the DOM and, when processing the `Menu` Location, to simply continue with and from its parent.
 
-```typescript jsx
+```jsx
 const parent = tagContent({ id: 'card' });
 ...
 <Card {...cardTracker}>
@@ -118,7 +118,7 @@ We can now attempt to fix the issue in two ways:
 ### Props forwarding - own Components
 Consider the following component:
 
-```typescript jsx
+```jsx
 const Button = ({ children, onClick }) => (
   <button onClick={onClick}>{children}</button>
 )
@@ -128,12 +128,12 @@ const Button = ({ children, onClick }) => (
 ```
 
 If we try to tag it as we normally do:
-```typescript jsx
+```jsx
 <Button {...tagPressable({ id: 'button-do-it' })} onClick={doSomething}>Yes!</Button>
 ```
 
 It would not work, because extra props are not being forwarded to the `<button>` tag. Let's fix that:
-```typescript jsx
+```jsx
 const Button = ({ children, onClick, ...otherProps }) => (
   <button onClick={onClick} {...otherProps}>{children}</button>
 )
@@ -146,7 +146,7 @@ Third party components, especially UI libraries, usually allow specifying custom
 It's worth verifying by checking the documentation.
 
 Let's look at an example with [InputBase](https://mui.com/api/input-base/) from [Material UI](https://mui.com/). This is a search input box.
-```typescript jsx
+```jsx
 <InputBase
   id={'search'}
   placeholder="Search..."
@@ -154,7 +154,7 @@ Let's look at an example with [InputBase](https://mui.com/api/input-base/) from 
 ```
 
 If InputBase would forwards props we could simply:
-```typescript jsx
+```jsx
 <InputBase
   {...tagInput({ id: 'search' })}
   id={'search'}
@@ -167,7 +167,7 @@ provides us with a specific property called `inputProps` that is directly forwar
 
 Now we can fix the issue by simply using it to apply our [Tagging Attributes](/tracking/browser/api-reference/definitions/TaggingAttribute.md):
 
-```typescript jsx
+```jsx
 <InputBase
   id={'search'}
   placeholder="Search..."
@@ -179,7 +179,7 @@ Now we can fix the issue by simply using it to apply our [Tagging Attributes](/t
 Sometimes properties for passing extra attributes are already used, and we can't assign directly to them as done above.    
 Simply spread the [Tagging Attributes](/tracking/browser/api-reference/definitions/TaggingAttribute.md) and merge them up with the existing props:
 
-```typescript jsx
+```jsx
 <InputBase
   id={'search'}
   placeholder="Search..."
@@ -215,14 +215,14 @@ Let's look at a hypothetical component that does not allow forwarding props to i
 We want to track a list of FAQ Items and we use this 3rd party component for that. It's an expandable element that, 
 on Click, will display its content / children to the user with an animation. 
 
-```typescript jsx
+```jsx
 <FAQItem title={'How do I track 3rd party components?'}>
   Some explanatory text to be displayed on click
 </FAQItem>
 ```
 
 Objectiv Taxonomy has a Context specifically meant for tracking expandable elements, let's use that:
-```typescript jsx
+```jsx
 <FAQItem
   {...tagExpandable({ id: 'faq-track-3rd-party-components' })}
   title={'How do I track 3rd party components?'}
@@ -234,7 +234,7 @@ Objectiv Taxonomy has a Context specifically meant for tracking expandable eleme
 Unfortunately after some testing we discover that `FAQItem` has its own internal event handling and doesn't allow clicks to bubble out for us to track.
 
 Again, checking the documentation is our friend here. Turns out there are event handlers we can hook onto:
-```typescript jsx
+```jsx
  <FAQItem
   {...tagExpandable({ id: 'faq-track-3rd-party-components' })}
   onClick={(event) => {
@@ -252,7 +252,7 @@ Visibility Events can be difficult to detect due to the nature of DOM and the co
 By default, we track when components mount or unmount from the DOM but it's not efficient to check for actual visibility. 
 
 Consider this menu:
-```typescript jsx
+```jsx
 <Menu
   {...tagOverlay({ id: 'menu' })}
   open={isMenuOpen}
@@ -266,7 +266,7 @@ If during testing we detect that we cannot automatically detect when the menu is
 
 Luckily the menu it's driven by the state variable `isMenuOpen`. We can use that to track its state. To do so we switch visibility tracking from automatic to manual and we tell the tracker what to monitor.
 
-```typescript jsx
+```jsx
 <Menu
   {...tagOverlay({
      id: 'menu',
@@ -284,7 +284,7 @@ The `isMenuOpen` variable is now driving both the menu visibility and the tracke
 ### Tracking Visibility via 3rd party handlers
 Sometimes we can also leverage 3rd party event callbacks, like so:
 
-```typescript jsx
+```jsx
 <Accordion
   {...tagExpandable({ id: 'fix' })}
   onChange={(event, expanded) => {

--- a/docs/docs/tracking/core-concepts/browser/tagging.md
+++ b/docs/docs/tracking/core-concepts/browser/tagging.md
@@ -165,7 +165,7 @@ These are **Taggable Elements** that have been already decorated with the
 
 A **tagChildren** example in React:
 
-```typescript jsx
+```jsx
 <div
   {...tagChildren([
     {

--- a/docs/docs/tracking/react/api-reference/eventTrackers/overview.md
+++ b/docs/docs/tracking/react/api-reference/eventTrackers/overview.md
@@ -5,7 +5,13 @@ title: Event Trackers
 
 :::caution
 Using low-level event trackers directly requires extra attention to the LocationStack and its composition.  
-It's easy to instrument a callback and forget to wrap the triggering Component in a LocationContext.
+It's easy to instrument a callback and forget to wrap the triggering Component in a LocationContext.  
+Make sure to always use Render Props when wrapping and tracking inline in the same JSX.
+:::
+
+:::tip
+These APIs work best in combination with [LocationWrappers](/tracking/react/api-reference/overview.md#location-wrappers) Render Props.  
+Check the Render Props Usage section in any of them for examples on how to combine the two.  
 :::
 
 - [trackApplicationLoadedEvent](/tracking/react/api-reference/eventTrackers/trackApplicationLoadedEvent.md)

--- a/docs/docs/tracking/react/api-reference/eventTrackers/overview.md
+++ b/docs/docs/tracking/react/api-reference/eventTrackers/overview.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Low-level Event Trackers
+sidebar_label: Overview
 title: Event Trackers
 ---
 

--- a/docs/docs/tracking/react/api-reference/eventTrackers/overview.md
+++ b/docs/docs/tracking/react/api-reference/eventTrackers/overview.md
@@ -6,12 +6,8 @@ title: Event Trackers
 :::caution
 Using low-level event trackers directly requires extra attention to the LocationStack and its composition.  
 It's easy to instrument a callback and forget to wrap the triggering Component in a LocationContext.  
-Make sure to always use Render Props when wrapping and tracking inline in the same JSX.
-:::
 
-:::tip
-These APIs work best in combination with [LocationWrappers](/tracking/react/api-reference/overview.md#location-wrappers) Render Props.  
-Check the Render Props Usage section in any of them for examples on how to combine the two.  
+Take a loot at this [how to build your own Custom Tracked Components](/tracking/react/how-to-guides/custom-components.md) guide for more info.
 :::
 
 - [trackApplicationLoadedEvent](/tracking/react/api-reference/eventTrackers/trackApplicationLoadedEvent.md)

--- a/docs/docs/tracking/react/api-reference/eventTrackers/trackApplicationLoadedEvent.md
+++ b/docs/docs/tracking/react/api-reference/eventTrackers/trackApplicationLoadedEvent.md
@@ -17,16 +17,55 @@ This is a lower-level API.
 [Event Tracking Hooks](/tracking/react/api-reference/hooks/eventTrackers/overview.md) are preferable as they automate retrieving both the Tracker instance and LocationStack. In fact, the do use these lower-level APIs internally.
 :::
 
+:::info
+Under normal circumstances [ObjectivTracker](/tracking/react/api-reference/common/providers/ObjectivProvider.md) tracks this event automatically, unless disabled via its options.
+:::
+
 ## Parameters
-|          |                | type              | default value |
-|:--------:|:---------------|:------------------|:--------------|
-| required | **tracker**    | ReactTracker      |               |
-| optional | options        | TrackEventOptions |               |
-| optional | locationStack  | LocationStack     |               |
-| optional | globalContexts | GlobalContexts    |               |
+|          |                | type              |
+|:--------:|:---------------|:------------------|
+| required | **tracker**    | ReactTracker      |
+| optional | options        | TrackEventOptions |
+| optional | locationStack  | LocationStack     |
+| optional | globalContexts | GlobalContexts    |
 
 ## Returns
 `Promise<TrackerEvent>`
+
+## Usage
+```ts
+import { 
+  ReactTracker,
+  trackApplicationLoadedEvent, 
+  TrackingContextProvider, 
+  useOnMount
+} from '@objectiv/tracker-react';
+```
+
+```tsx
+import { useOnMount } from "@objectiv/tracker-react";
+
+const App = ({ children }) => {
+  const tracker = new ReactTracker({
+    endpoint: '/collector',
+    applicationId: 'app-id'
+  })
+
+  useOnMount(() => {
+    trackApplicationLoadedEvent({ tracker });
+  })
+
+  return (
+    <TrackingContextProvider tracker={tracker}>
+      {children}
+    </TrackingContextProvider>
+  );
+}
+```
+
+:::tip
+The code above is actually very similar to what [ObjectivProvider](/tracking/react/api-reference/common/providers/ObjectivProvider.md) does internally. Check the [source on GitHub](https://github.com/objectiv/objectiv-analytics/blob/main/tracker/trackers/react/src/common/providers/ObjectivProvider.tsx).
+:::
 
 <br />
 

--- a/docs/docs/tracking/react/api-reference/eventTrackers/trackFailureEvent.md
+++ b/docs/docs/tracking/react/api-reference/eventTrackers/trackFailureEvent.md
@@ -18,15 +18,18 @@ This is a lower-level API.
 :::
 
 ## Parameters
-|          |                | type              | default value |
-|:--------:|:---------------|:------------------|:--------------|
-| required | **tracker**    | ReactTracker      |               |
-| optional | options        | TrackEventOptions |               |
-| optional | locationStack  | LocationStack     |               |
-| optional | globalContexts | GlobalContexts    |               |
+|          |                | type              |
+|:--------:|:---------------|:------------------|
+| required | **tracker**    | ReactTracker      |
+| optional | options        | TrackEventOptions |
+| optional | locationStack  | LocationStack     |
+| optional | globalContexts | GlobalContexts    |
 
 ## Returns
 `Promise<TrackerEvent>`
+
+## Usage
+- [PressableContextWrapper](/tracking/react/api-reference/locationWrappers/PressableContextWrapper.md#tracking-via-render-props) documentation has a practical usage example of this Event Tracker.
 
 <br />
 

--- a/docs/docs/tracking/react/api-reference/eventTrackers/trackHiddenEvent.md
+++ b/docs/docs/tracking/react/api-reference/eventTrackers/trackHiddenEvent.md
@@ -18,15 +18,19 @@ This is a lower-level API.
 :::
 
 ## Parameters
-|          |                | type              | default value |
-|:--------:|:---------------|:------------------|:--------------|
-| required | **tracker**    | ReactTracker      |               |
-| optional | options        | TrackEventOptions |               |
-| optional | locationStack  | LocationStack     |               |
-| optional | globalContexts | GlobalContexts    |               |
+|          |                | type              |
+|:--------:|:---------------|:------------------|
+| required | **tracker**    | ReactTracker      |
+| optional | options        | TrackEventOptions |
+| optional | locationStack  | LocationStack     |
+| optional | globalContexts | GlobalContexts    |
 
 ## Returns
 `Promise<TrackerEvent>`
+
+## Usage
+- [NavigationContextWrapper](/tracking/react/api-reference/locationWrappers/NavigationContextWrapper.md#tracking-via-render-props) documentation has a practical usage example of this Event Tracker.
+- [RootLocationContextWrapper](/tracking/react/api-reference/locationWrappers/RootLocationContextWrapper.md#tracking-via-render-props) documentation has a practical usage example of this Event Tracker.
 
 <br />
 

--- a/docs/docs/tracking/react/api-reference/eventTrackers/trackInputChangeEvent.md
+++ b/docs/docs/tracking/react/api-reference/eventTrackers/trackInputChangeEvent.md
@@ -18,7 +18,7 @@ This is a lower-level API.
 :::
 
 ## Parameters
-|          |                | type              | default value |
+|          |                | type              |
 |:--------:|:---------------|:------------------|:--------------|
 | required | **tracker**    | ReactTracker      |               |
 | optional | options        | TrackEventOptions |               |
@@ -27,6 +27,9 @@ This is a lower-level API.
 
 ## Returns
 `Promise<TrackerEvent>`
+
+## Usage
+- [InputContextWrapper](/tracking/react/api-reference/locationWrappers/InputContextWrapper.md#tracking-via-render-props) documentation has a practical usage example of this Event Tracker. 
 
 <br />
 

--- a/docs/docs/tracking/react/api-reference/eventTrackers/trackMediaLoadEvent.md
+++ b/docs/docs/tracking/react/api-reference/eventTrackers/trackMediaLoadEvent.md
@@ -18,15 +18,18 @@ This is a lower-level API.
 :::
 
 ## Parameters
-|          |                | type              | default value |
-|:--------:|:---------------|:------------------|:--------------|
-| required | **tracker**    | ReactTracker      |               |
-| optional | options        | TrackEventOptions |               |
-| optional | locationStack  | LocationStack     |               |
-| optional | globalContexts | GlobalContexts    |               |
+|          |                | type              |
+|:--------:|:---------------|:------------------|
+| required | **tracker**    | ReactTracker      |
+| optional | options        | TrackEventOptions |
+| optional | locationStack  | LocationStack     |
+| optional | globalContexts | GlobalContexts    |
 
 ## Returns
 `Promise<TrackerEvent>`
+
+## Usage
+- [MediaPlayerContextWrapper](/tracking/react/api-reference/locationWrappers/MediaPlayerContextWrapper.md#tracking-via-render-props) documentation has a practical usage example of this Event Tracker.
 
 <br />
 

--- a/docs/docs/tracking/react/api-reference/eventTrackers/trackMediaPauseEvent.md
+++ b/docs/docs/tracking/react/api-reference/eventTrackers/trackMediaPauseEvent.md
@@ -18,15 +18,18 @@ This is a lower-level API.
 :::
 
 ## Parameters
-|          |                | type              | default value |
-|:--------:|:---------------|:------------------|:--------------|
-| required | **tracker**    | ReactTracker      |               |
-| optional | options        | TrackEventOptions |               |
-| optional | locationStack  | LocationStack     |               |
-| optional | globalContexts | GlobalContexts    |               |
+|          |                | type              |
+|:--------:|:---------------|:------------------|
+| required | **tracker**    | ReactTracker      |
+| optional | options        | TrackEventOptions |
+| optional | locationStack  | LocationStack     |
+| optional | globalContexts | GlobalContexts    |
 
 ## Returns
 `Promise<TrackerEvent>`
+
+## Usage
+- [MediaPlayerContextWrapper](/tracking/react/api-reference/locationWrappers/MediaPlayerContextWrapper.md#tracking-via-render-props) documentation has a practical usage example of this Event Tracker.
 
 <br />
 

--- a/docs/docs/tracking/react/api-reference/eventTrackers/trackMediaStartEvent.md
+++ b/docs/docs/tracking/react/api-reference/eventTrackers/trackMediaStartEvent.md
@@ -18,15 +18,18 @@ This is a lower-level API.
 :::
 
 ## Parameters
-|          |                | type              | default value |
-|:--------:|:---------------|:------------------|:--------------|
-| required | **tracker**    | ReactTracker      |               |
-| optional | options        | TrackEventOptions |               |
-| optional | locationStack  | LocationStack     |               |
-| optional | globalContexts | GlobalContexts    |               |
+|          |                | type              |
+|:--------:|:---------------|:------------------|
+| required | **tracker**    | ReactTracker      |
+| optional | options        | TrackEventOptions |
+| optional | locationStack  | LocationStack     |
+| optional | globalContexts | GlobalContexts    |
 
 ## Returns
 `Promise<TrackerEvent>`
+
+## Usage
+- [MediaPlayerContextWrapper](/tracking/react/api-reference/locationWrappers/MediaPlayerContextWrapper.md#tracking-via-render-props) documentation has a practical usage example of this Event Tracker.
 
 <br />
 

--- a/docs/docs/tracking/react/api-reference/eventTrackers/trackMediaStopEvent.md
+++ b/docs/docs/tracking/react/api-reference/eventTrackers/trackMediaStopEvent.md
@@ -18,15 +18,18 @@ This is a lower-level API.
 :::
 
 ## Parameters
-|          |                | type              | default value |
-|:--------:|:---------------|:------------------|:--------------|
-| required | **tracker**    | ReactTracker      |               |
-| optional | options        | TrackEventOptions |               |
-| optional | locationStack  | LocationStack     |               |
-| optional | globalContexts | GlobalContexts    |               |
+|          |                | type              |
+|:--------:|:---------------|:------------------|
+| required | **tracker**    | ReactTracker      |
+| optional | options        | TrackEventOptions |
+| optional | locationStack  | LocationStack     |
+| optional | globalContexts | GlobalContexts    |
 
 ## Returns
 `Promise<TrackerEvent>`
+
+## Usage
+- [MediaPlayerContextWrapper](/tracking/react/api-reference/locationWrappers/MediaPlayerContextWrapper.md#tracking-via-render-props) documentation has a practical usage example of this Event Tracker.
 
 <br />
 

--- a/docs/docs/tracking/react/api-reference/eventTrackers/trackPressEvent.md
+++ b/docs/docs/tracking/react/api-reference/eventTrackers/trackPressEvent.md
@@ -18,15 +18,23 @@ This is a lower-level API.
 :::
 
 ## Parameters
-|          |                | type              | default value |
-|:--------:|:---------------|:------------------|:--------------|
-| required | **tracker**    | ReactTracker      |               |
-| optional | options        | TrackEventOptions |               |
-| optional | locationStack  | LocationStack     |               |
-| optional | globalContexts | GlobalContexts    |               |
+|          |                | type              |
+|:--------:|:---------------|:------------------|
+| required | **tracker**    | ReactTracker      |
+| optional | options        | TrackEventOptions |
+| optional | locationStack  | LocationStack     |
+| optional | globalContexts | GlobalContexts    |
 
 ## Returns
 `Promise<TrackerEvent>`
+
+## Usage
+- [ContentContextWrapper](/tracking/react/api-reference/locationWrappers/ContentContextWrapper.md#tracking-via-render-props) documentation has a practical usage example of this Event Tracker.
+- [ExpandableContextWrapper](/tracking/react/api-reference/locationWrappers/ExpandableContextWrapper.md#tracking-via-render-props) documentation has a practical usage example of this Event Tracker.
+- [LinkContextWrapper](/tracking/react/api-reference/locationWrappers/LinkContextWrapper.md#tracking-via-render-props) documentation has a practical usage example of this Event Tracker.
+- [LocationContextWrapper](/tracking/react/api-reference/locationWrappers/LocationContextWrapper.md#tracking-via-render-props) documentation has a practical usage example of this Event Tracker.
+- [PressableContextWrapper](/tracking/react/api-reference/locationWrappers/PressableContextWrapper.md#tracking-via-render-props) documentation has a practical usage example of this Event Tracker.
+- [OverlayContextWrapper](/tracking/react/api-reference/locationWrappers/OverlayContextWrapper.md#tracking-via-render-props) documentation has a practical usage example of this Event Tracker.
 
 <br />
 

--- a/docs/docs/tracking/react/api-reference/eventTrackers/trackSuccessEvent.md
+++ b/docs/docs/tracking/react/api-reference/eventTrackers/trackSuccessEvent.md
@@ -18,15 +18,18 @@ This is a lower-level API.
 :::
 
 ## Parameters
-|          |                | type              | default value |
-|:--------:|:---------------|:------------------|:--------------|
-| required | **tracker**    | ReactTracker      |               |
-| optional | options        | TrackEventOptions |               |
-| optional | locationStack  | LocationStack     |               |
-| optional | globalContexts | GlobalContexts    |               |
+|          |                | type              |
+|:--------:|:---------------|:------------------|
+| required | **tracker**    | ReactTracker      |
+| optional | options        | TrackEventOptions |
+| optional | locationStack  | LocationStack     |
+| optional | globalContexts | GlobalContexts    |
 
 ## Returns
 `Promise<TrackerEvent>`
+
+## Usage
+- [PressableContextWrapper](/tracking/react/api-reference/locationWrappers/PressableContextWrapper.md#tracking-via-render-props) documentation has a practical usage example of this Event Tracker.
 
 <br />
 

--- a/docs/docs/tracking/react/api-reference/eventTrackers/trackVisibility.md
+++ b/docs/docs/tracking/react/api-reference/eventTrackers/trackVisibility.md
@@ -30,8 +30,11 @@ This is a lower-level API.
 ## Returns
 `Promise<TrackerEvent>`
 
-<br />
+## Usage
+- [ExpandableContextWrapper](/tracking/react/api-reference/locationWrappers/ExpandableContextWrapper.md#tracking-via-render-props) documentation has a practical usage example of this Event Tracker.
+- [OverlayContextWrapper](/tracking/react/api-reference/locationWrappers/OverlayContextWrapper.md#tracking-via-render-props) documentation has a practical usage example of this Event Tracker.
 
+<br />
 
 :::info See also
 - [trackApplicationLoadedEvent](/tracking/react/api-reference/eventTrackers/trackApplicationLoadedEvent.md)

--- a/docs/docs/tracking/react/api-reference/eventTrackers/trackVisibility.md
+++ b/docs/docs/tracking/react/api-reference/eventTrackers/trackVisibility.md
@@ -19,13 +19,13 @@ This is a lower-level API.
 :::
 
 ## Parameters
-|          |                | type              | default value |
-|:--------:|:---------------|:------------------|:--------------|
-| required | **tracker**    | ReactTracker      |               |
-| required | **isVisible**  | boolean           |               |
-| optional | options        | TrackEventOptions |               |
-| optional | locationStack  | LocationStack     |               |
-| optional | globalContexts | GlobalContexts    |               |
+|          |                | type              |
+|:--------:|:---------------|:------------------|
+| required | **tracker**    | ReactTracker      |
+| required | **isVisible**  | boolean           |
+| optional | options        | TrackEventOptions |
+| optional | locationStack  | LocationStack     |
+| optional | globalContexts | GlobalContexts    |
 
 ## Returns
 `Promise<TrackerEvent>`

--- a/docs/docs/tracking/react/api-reference/eventTrackers/trackVisibleEvent.md
+++ b/docs/docs/tracking/react/api-reference/eventTrackers/trackVisibleEvent.md
@@ -18,15 +18,19 @@ This is a lower-level API.
 :::
 
 ## Parameters
-|          |                | type              | default value |
-|:--------:|:---------------|:------------------|:--------------|
-| required | **tracker**    | ReactTracker      |               |
-| optional | options        | TrackEventOptions |               |
-| optional | locationStack  | LocationStack     |               |
-| optional | globalContexts | GlobalContexts    |               |
+|          |                | type              |
+|:--------:|:---------------|:------------------|
+| required | **tracker**    | ReactTracker      |
+| optional | options        | TrackEventOptions |
+| optional | locationStack  | LocationStack     |
+| optional | globalContexts | GlobalContexts    |
 
 ## Returns
 `Promise<TrackerEvent>`
+
+## Usage
+- [NavigationContextWrapper](/tracking/react/api-reference/locationWrappers/NavigationContextWrapper.md#tracking-via-render-props) documentation has a practical usage example of this Event Tracker.
+- [RootLocationContextWrapper](/tracking/react/api-reference/locationWrappers/RootLocationContextWrapper.md#tracking-via-render-props) documentation has a practical usage example of this Event Tracker.
 
 <br />
 

--- a/docs/docs/tracking/react/api-reference/hooks/eventTrackers/overview.md
+++ b/docs/docs/tracking/react/api-reference/hooks/eventTrackers/overview.md
@@ -6,6 +6,13 @@ sidebar_position: 1
 
 These hooks can be used to obtain ready-to-trigger callbacks for all [Taxonomy Events](/taxonomy/reference/events/overview.md).
 
+:::danger
+Be careful when using [LocationWrappers](/tracking/react/api-reference/overview.md#location-wrappers) and Event Tracking hooks in the same Component. 
+Calling a hook-generated event tracking callback in the JSX of the same Component will not produce a valid Location Stack.
+
+Take a loot at this [how to build your own Custom Tracked Components](/tracking/react/how-to-guides/custom-components.md) guide for more info. 
+:::
+
 - [useApplicationLoadedEventTracker](/tracking/react/api-reference/hooks/eventTrackers/useApplicationLoadedEventTracker.md)
 - [useFailureEventTracker](/tracking/react/api-reference/hooks/eventTrackers/useFailureEventTracker.md)
 - [useHiddenEventTracker](/tracking/react/api-reference/hooks/eventTrackers/useHiddenEventTracker.md)

--- a/docs/docs/tracking/react/api-reference/locationWrappers/ContentContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/ContentContextWrapper.md
@@ -21,7 +21,7 @@ ReactElement.
 ## Usage examples
 
 
-### Enrich Tracked Components Locations
+### Enrich Locations
 ```jsx
 import { ContentContextWrapper, TrackedLink } from '@objectiv/tracker-react';
 ```
@@ -40,7 +40,7 @@ import { ContentContextWrapper, TrackedLink } from '@objectiv/tracker-react';
 </ContentContextWrapper>
 ```
 
-### Track interactive &lt;div&gt; via Render Props
+### Render Props inline tracking
 ```jsx
 import { ContentContextWrapper, trackPressEvent } from '@objectiv/tracker-react';
 ```
@@ -50,7 +50,7 @@ import { ContentContextWrapper, trackPressEvent } from '@objectiv/tracker-react'
   <div>
     <ContentContextWrapper id={'sub-content'}>
       {(trackingContext) => (
-        <div onClick={ () => trackPressEvent(trackingContext) }>
+        <div onClick={() => trackPressEvent(trackingContext)}>
           Hi!, I'm interactive
         </div>
       )}

--- a/docs/docs/tracking/react/api-reference/locationWrappers/ContentContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/ContentContextWrapper.md
@@ -17,7 +17,7 @@ ContentContextWrapper: (props: {
 | required | **id**       | string                                                   |
 
 ## Returns
-ReactElement.
+`ReactElement`
 
 ## Usage examples
 

--- a/docs/docs/tracking/react/api-reference/locationWrappers/ContentContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/ContentContextWrapper.md
@@ -1,33 +1,36 @@
 # ContentContextWrapper
 
-Wraps its children in a [ContentContext](/taxonomy/reference/location-contexts/ContentContext.md).
+Wraps its children in a [ContentContext](/taxonomy/reference/location-contexts/ContentContext.md). Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).   
 
 ```tsx
 ContentContextWrapper: (props: { 
-  children: ReactNode, 
+  children: ReactNode | ((parameters: TrackingContext) => void), 
   id: string
 }) => ReactElement
 ```
 
 ## Parameters
-|          |              | type      | default value |
-|:--------:|:-------------|:----------|:--------------|
-| required | **children** | ReactNode |               |
-| required | **id**       | string    |               |
+|          |              | type                                                     | default value |
+|:--------:|:-------------|:---------------------------------------------------------|:--------------|
+| required | **children** | ReactNode &vert; ((parameters: TrackingContext) => void) |               |
+| required | **id**       | string                                                   |               |
 
 ## Returns
 ReactElement.
 
 ## Usage example
 
-```typescript jsx
-import { ContentContextWrapper } from '@objectiv/tracker-react';
+```jsx
+import { ContentContextWrapper, TrackedLink } from '@objectiv/tracker-react';
 ```
 
-```typescript jsx
+```jsx
 <ContentContextWrapper id={'content'}>
   <div>
-    ...
+    <ContentContextWrapper id={'sub-content'}>
+      ...
+      <TrackedLink href={'/new-location'}>Go!</TrackedLink>
+    </ContentContextWrapper>
   </div>
   <span>
     ...

--- a/docs/docs/tracking/react/api-reference/locationWrappers/ContentContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/ContentContextWrapper.md
@@ -18,8 +18,10 @@ ContentContextWrapper: (props: {
 ## Returns
 ReactElement.
 
-## Usage example
+## Usage examples
 
+
+### Enrich Tracked Components Locations
 ```jsx
 import { ContentContextWrapper, TrackedLink } from '@objectiv/tracker-react';
 ```
@@ -37,6 +39,29 @@ import { ContentContextWrapper, TrackedLink } from '@objectiv/tracker-react';
   </span>
 </ContentContextWrapper>
 ```
+
+### Track interactive &lt;div&gt; via Render Props
+```jsx
+import { ContentContextWrapper, trackPressEvent } from '@objectiv/tracker-react';
+```
+
+```jsx
+<ContentContextWrapper id={'content'}>
+  <div>
+    <ContentContextWrapper id={'sub-content'}>
+      {(trackingContext) => (
+        <div onClick={ () => trackPressEvent(trackingContext) }>
+          Hi!, I'm interactive
+        </div>
+      )}
+    </ContentContextWrapper>
+  </div>
+  <span>
+    ...
+  </span>
+</ContentContextWrapper>
+```
+
 
 <br />
 

--- a/docs/docs/tracking/react/api-reference/locationWrappers/ContentContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/ContentContextWrapper.md
@@ -1,6 +1,7 @@
 # ContentContextWrapper
 
-Wraps its children in a [ContentContext](/taxonomy/reference/location-contexts/ContentContext.md). Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).   
+Wraps its children in a [ContentContext](/taxonomy/reference/location-contexts/ContentContext.md).  
+Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).   
 
 ```tsx
 ContentContextWrapper: (props: { 
@@ -10,10 +11,10 @@ ContentContextWrapper: (props: {
 ```
 
 ## Parameters
-|          |              | type                                                     | default value |
-|:--------:|:-------------|:---------------------------------------------------------|:--------------|
-| required | **children** | ReactNode &vert; ((parameters: TrackingContext) => void) |               |
-| required | **id**       | string                                                   |               |
+|          |              | type                                                     |
+|:--------:|:-------------|:---------------------------------------------------------|
+| required | **children** | ReactNode &vert; ((parameters: TrackingContext) => void) |
+| required | **id**       | string                                                   |
 
 ## Returns
 ReactElement.
@@ -23,7 +24,7 @@ ReactElement.
 
 ### Enrich Locations
 ```jsx
-import { ContentContextWrapper, TrackedLink } from '@objectiv/tracker-react';
+import { ContentContextWrapper } from '@objectiv/tracker-react';
 ```
 
 ```jsx
@@ -31,7 +32,7 @@ import { ContentContextWrapper, TrackedLink } from '@objectiv/tracker-react';
   <div>
     <ContentContextWrapper id={'sub-content'}>
       ...
-      <TrackedLink href={'/new-location'}>Go!</TrackedLink>
+      <a href={'/new-location'}>Go!</a>
     </ContentContextWrapper>
   </div>
   <span>
@@ -40,9 +41,12 @@ import { ContentContextWrapper, TrackedLink } from '@objectiv/tracker-react';
 </ContentContextWrapper>
 ```
 
-### Render Props inline tracking
+### Tracking via Render Props
 ```jsx
-import { ContentContextWrapper, trackPressEvent } from '@objectiv/tracker-react';
+import { 
+  ContentContextWrapper, 
+  trackPressEvent
+} from '@objectiv/tracker-react';
 ```
 
 ```jsx
@@ -51,7 +55,7 @@ import { ContentContextWrapper, trackPressEvent } from '@objectiv/tracker-react'
     <ContentContextWrapper id={'sub-content'}>
       {(trackingContext) => (
         <div onClick={() => trackPressEvent(trackingContext)}>
-          Hi!, I'm interactive
+          Hi!
         </div>
       )}
     </ContentContextWrapper>

--- a/docs/docs/tracking/react/api-reference/locationWrappers/ExpandableContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/ExpandableContextWrapper.md
@@ -1,30 +1,30 @@
 # ExpandableContextWrapper
 
-Wraps its children in a [ExpandableContext](/taxonomy/reference/location-contexts/ExpandableContext.md).
+Wraps its children in a [ExpandableContext](/taxonomy/reference/location-contexts/ExpandableContext.md). Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).
 
 ```tsx
-ExpandableContextWrapper: (props: { 
-  children: ReactNode, 
+ExpandableContextWrapper: (props: {
+  children: ReactNode | ((parameters: TrackingContext) => void), 
   id: string
 }) => ReactElement
 ```
 
 ## Parameters
-|          |              | type      | default value |
-|:--------:|:-------------|:----------|:--------------|
-| required | **children** | ReactNode |               |
-| required | **id**       | string    |               |
+|          |              | type                                                     | default value |
+|:--------:|:-------------|:---------------------------------------------------------|:--------------|
+| required | **children** | ReactNode &vert; ((parameters: TrackingContext) => void) |               |
+| required | **id**       | string                                                   |               |
 
 ## Returns
 ReactElement.
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { ExpandableContextWrapper } from '@objectiv/tracker-react';
 ```
 
-```typescript jsx
+```jsx
 <ExpandableContextWrapper id={'tooltip'}>
   <Tooltip>
     ...

--- a/docs/docs/tracking/react/api-reference/locationWrappers/ExpandableContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/ExpandableContextWrapper.md
@@ -17,7 +17,7 @@ ExpandableContextWrapper: (props: {
 | required | **id**       | string                                                   |
 
 ## Returns
-ReactElement.
+`ReactElement`
 
 ## Usage example
 

--- a/docs/docs/tracking/react/api-reference/locationWrappers/ExpandableContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/ExpandableContextWrapper.md
@@ -1,6 +1,7 @@
 # ExpandableContextWrapper
 
-Wraps its children in a [ExpandableContext](/taxonomy/reference/location-contexts/ExpandableContext.md). Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).
+Wraps its children in a [ExpandableContext](/taxonomy/reference/location-contexts/ExpandableContext.md).  
+Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).
 
 ```tsx
 ExpandableContextWrapper: (props: {
@@ -10,10 +11,10 @@ ExpandableContextWrapper: (props: {
 ```
 
 ## Parameters
-|          |              | type                                                     | default value |
-|:--------:|:-------------|:---------------------------------------------------------|:--------------|
-| required | **children** | ReactNode &vert; ((parameters: TrackingContext) => void) |               |
-| required | **id**       | string                                                   |               |
+|          |              | type                                                     |
+|:--------:|:-------------|:---------------------------------------------------------|
+| required | **children** | ReactNode &vert; ((parameters: TrackingContext) => void) |
+| required | **id**       | string                                                   |
 
 ## Returns
 ReactElement.
@@ -34,10 +35,14 @@ import { ExpandableContextWrapper } from '@objectiv/tracker-react';
 </ExpandableContextWrapper>
 ```
 
-### Render Props inline tracking
+### Tracking via Render Props
 
 ```jsx
-import { ExpandableContextWrapper, trackPressEvent, trackVisibility } from '@objectiv/tracker-react';
+import { 
+  ExpandableContextWrapper, 
+  trackPressEvent, 
+  trackVisibility
+} from '@objectiv/tracker-react';
 ```
 
 ```jsx
@@ -45,7 +50,10 @@ import { ExpandableContextWrapper, trackPressEvent, trackVisibility } from '@obj
   {(trackingContext) => (
     <Accordion
       onClick={() => trackPressEvent(trackingContext)}  
-      onToggle={(isOpen) => trackVisibility({ ...trackingContext, isVisible: isOpen })}
+      onToggle={(isOpen) => trackVisibility({ 
+        ...trackingContext, 
+        isVisible: isOpen
+      })}
     >
     ...
     </Accordion>

--- a/docs/docs/tracking/react/api-reference/locationWrappers/ExpandableContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/ExpandableContextWrapper.md
@@ -20,6 +20,8 @@ ReactElement.
 
 ## Usage example
 
+### Enrich Locations
+
 ```jsx
 import { ExpandableContextWrapper } from '@objectiv/tracker-react';
 ```
@@ -31,6 +33,26 @@ import { ExpandableContextWrapper } from '@objectiv/tracker-react';
   </Tooltip>
 </ExpandableContextWrapper>
 ```
+
+### Render Props inline tracking
+
+```jsx
+import { ExpandableContextWrapper, trackPressEvent, trackVisibility } from '@objectiv/tracker-react';
+```
+
+```jsx
+<ExpandableContextWrapper id={'accordion'}>
+  {(trackingContext) => (
+    <Accordion
+      onClick={() => trackPressEvent(trackingContext)}  
+      onToggle={(isOpen) => trackVisibility({ ...trackingContext, isVisible: isOpen })}
+    >
+    ...
+    </Accordion>
+  )}
+</ExpandableContextWrapper>
+```
+
 
 <br />
 

--- a/docs/docs/tracking/react/api-reference/locationWrappers/ExpandableContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/ExpandableContextWrapper.md
@@ -53,7 +53,6 @@ import { ExpandableContextWrapper, trackPressEvent, trackVisibility } from '@obj
 </ExpandableContextWrapper>
 ```
 
-
 <br />
 
 :::tip Did you know ?

--- a/docs/docs/tracking/react/api-reference/locationWrappers/InputContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/InputContextWrapper.md
@@ -1,6 +1,7 @@
 # InputContextWrapper
 
-Wraps its children in a [InputContext](/taxonomy/reference/location-contexts/InputContext.md). Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).
+Wraps its children in a [InputContext](/taxonomy/reference/location-contexts/InputContext.md).  
+Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).
 
 ```tsx
 InputContextWrapper: (props: {
@@ -10,10 +11,10 @@ InputContextWrapper: (props: {
 ```
 
 ## Parameters
-|          |              | type                                                     | default value |
-|:--------:|:-------------|:---------------------------------------------------------|:--------------|
-| required | **children** | ReactNode &vert; ((parameters: TrackingContext) => void) |               |
-| required | **id**       | string                                                   |               |
+|          |              | type                                                     |
+|:--------:|:-------------|:---------------------------------------------------------|
+| required | **children** | ReactNode &vert; ((parameters: TrackingContext) => void) |
+| required | **id**       | string                                                   |
 
 ## Returns
 ReactElement.
@@ -32,16 +33,22 @@ import { InputContextWrapper } from '@objectiv/tracker-react';
 </InputContextWrapper>
 ```
 
-### Render Props inline tracking
+### Tracking via Render Props
 
 ```jsx
-import { InputContextWrapper, trackInputChangeEvent } from '@objectiv/tracker-react';
+import { 
+  InputContextWrapper, 
+  trackInputChangeEvent
+} from '@objectiv/tracker-react';
 ```
 
 ```jsx
 <InputContextWrapper id={'search'}>
   {(trackingContext) => (
-    <input type={'text'} onBlur={() => trackInputChangeEvent(trackingContext)} />
+    <input 
+      type={'text'} 
+      onBlur={() => trackInputChangeEvent(trackingContext)} 
+    />
   )}
 </InputContextWrapper>
 ```

--- a/docs/docs/tracking/react/api-reference/locationWrappers/InputContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/InputContextWrapper.md
@@ -1,30 +1,30 @@
 # InputContextWrapper
 
-Wraps its children in a [InputContext](/taxonomy/reference/location-contexts/InputContext.md).
+Wraps its children in a [InputContext](/taxonomy/reference/location-contexts/InputContext.md). Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).
 
 ```tsx
-InputContextWrapper: (props: { 
-  children: ReactNode, 
+InputContextWrapper: (props: {
+  children: ReactNode | ((parameters: TrackingContext) => void),
   id: string
 }) => ReactElement
 ```
 
 ## Parameters
-|          |              | type      | default value |
-|:--------:|:-------------|:----------|:--------------|
-| required | **children** | ReactNode |               |
-| required | **id**       | string    |               |
+|          |              | type                                                     | default value |
+|:--------:|:-------------|:---------------------------------------------------------|:--------------|
+| required | **children** | ReactNode &vert; ((parameters: TrackingContext) => void) |               |
+| required | **id**       | string                                                   |               |
 
 ## Returns
 ReactElement.
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { InputContextWrapper } from '@objectiv/tracker-react';
 ```
 
-```typescript jsx
+```jsx
 <InputContextWrapper id={'email'}>
   <input type={'email'} />
 </InputContextWrapper>

--- a/docs/docs/tracking/react/api-reference/locationWrappers/InputContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/InputContextWrapper.md
@@ -17,7 +17,7 @@ InputContextWrapper: (props: {
 | required | **id**       | string                                                   |
 
 ## Returns
-ReactElement.
+`ReactElement`
 
 ## Usage example
 

--- a/docs/docs/tracking/react/api-reference/locationWrappers/InputContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/InputContextWrapper.md
@@ -20,6 +20,8 @@ ReactElement.
 
 ## Usage example
 
+### Enrich Locations
+
 ```jsx
 import { InputContextWrapper } from '@objectiv/tracker-react';
 ```
@@ -29,6 +31,24 @@ import { InputContextWrapper } from '@objectiv/tracker-react';
   <input type={'email'} />
 </InputContextWrapper>
 ```
+
+### Render Props inline tracking
+
+```jsx
+import { InputContextWrapper, trackInputChangeEvent } from '@objectiv/tracker-react';
+```
+
+```jsx
+<InputContextWrapper id={'search'}>
+  {(trackingContext) => (
+    <input 
+      type={'text'} 
+      onBlur={ () => trackInputChangeEvent(trackingContext) }
+    />
+  )}
+</InputContextWrapper>
+```
+
 
 <br />
 

--- a/docs/docs/tracking/react/api-reference/locationWrappers/InputContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/InputContextWrapper.md
@@ -41,14 +41,10 @@ import { InputContextWrapper, trackInputChangeEvent } from '@objectiv/tracker-re
 ```jsx
 <InputContextWrapper id={'search'}>
   {(trackingContext) => (
-    <input 
-      type={'text'} 
-      onBlur={ () => trackInputChangeEvent(trackingContext) }
-    />
+    <input type={'text'} onBlur={() => trackInputChangeEvent(trackingContext)} />
   )}
 </InputContextWrapper>
 ```
-
 
 <br />
 

--- a/docs/docs/tracking/react/api-reference/locationWrappers/InputContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/InputContextWrapper.md
@@ -55,6 +55,13 @@ import {
 
 <br />
 
+:::info
+The above is just an example to illustrate the Render Props functionality.   
+Check out our [Tracked Elements](/tracking/react/api-reference/trackedElements/overview.md) for a ready-to-use [TrackedInput](/tracking/react/api-reference/trackedElements/TrackedInput.md) component.
+:::
+
+<br />
+
 :::tip Did you know ?
 `InputContextWrapper` internally uses [LocationContextWrapper](/tracking/react/api-reference/locationWrappers/LocationContextWrapper.md).
 :::

--- a/docs/docs/tracking/react/api-reference/locationWrappers/LinkContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/LinkContextWrapper.md
@@ -1,30 +1,30 @@
 # LinkContextWrapper
 
-Wraps its children in a [LinkContext](/taxonomy/reference/location-contexts/LinkContext.md).
+Wraps its children in a [LinkContext](/taxonomy/reference/location-contexts/LinkContext.md). Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).
 
 ```tsx
-LinkContextWrapper: (props: { 
-  children: ReactNode, 
+LinkContextWrapper: (props: {
+  children: ReactNode | ((parameters: TrackingContext) => void), 
   id: string
 }) => ReactElement
 ```
 
 ## Parameters
-|          |              | type      | default value |
-|:--------:|:-------------|:----------|:--------------|
-| required | **children** | ReactNode |               |
-| required | **id**       | string    |               |
+|          |              | type                                                     | default value |
+|:--------:|:-------------|:---------------------------------------------------------|:--------------|
+| required | **children** | ReactNode &vert; ((parameters: TrackingContext) => void) |               |
+| required | **id**       | string                                                   |               |
 
 ## Returns
 ReactElement.
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { LinkContextWrapper } from '@objectiv/tracker-react';
 ```
 
-```typescript jsx
+```jsx
 <LinkContextWrapper id={'privacy'}>
   <a href={'/privacy'}>Privacy</a>
 </LinkContextWrapper>

--- a/docs/docs/tracking/react/api-reference/locationWrappers/LinkContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/LinkContextWrapper.md
@@ -57,6 +57,13 @@ import {
 
 <br />
 
+:::info
+The above is just an example to illustrate the Render Props functionality.   
+Check out our [Tracked Elements](/tracking/react/api-reference/trackedElements/overview.md) for a ready-to-use [TrackedAnchor](/tracking/react/api-reference/trackedElements/TrackedAnchor.md) component.
+:::
+
+<br />
+
 :::tip Did you know ?
 `LinkContextWrapper` internally uses [LocationContextWrapper](/tracking/react/api-reference/locationWrappers/LocationContextWrapper.md).
 :::

--- a/docs/docs/tracking/react/api-reference/locationWrappers/LinkContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/LinkContextWrapper.md
@@ -17,7 +17,7 @@ LinkContextWrapper: (props: {
 | required | **id**       | string                                                   |
 
 ## Returns
-ReactElement.
+`ReactElement`
 
 ## Usage example
 

--- a/docs/docs/tracking/react/api-reference/locationWrappers/LinkContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/LinkContextWrapper.md
@@ -20,6 +20,8 @@ ReactElement.
 
 ## Usage example
 
+### Enrich Locations
+
 ```jsx
 import { LinkContextWrapper } from '@objectiv/tracker-react';
 ```
@@ -27,6 +29,22 @@ import { LinkContextWrapper } from '@objectiv/tracker-react';
 ```jsx
 <LinkContextWrapper id={'privacy'}>
   <a href={'/privacy'}>Privacy</a>
+</LinkContextWrapper>
+```
+
+### Render Props inline tracking
+
+```jsx
+import { LinkContextWrapper, trackPressEvent } from '@objectiv/tracker-react';
+```
+
+```jsx
+<LinkContextWrapper id={'privacy'}>
+  {(trackingContext) => (
+    <a href={'/privacy'} onClick={() => trackPressEvent(trackingContext)}>
+      Privacy
+    </a>
+  )}
 </LinkContextWrapper>
 ```
 

--- a/docs/docs/tracking/react/api-reference/locationWrappers/LinkContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/LinkContextWrapper.md
@@ -1,6 +1,7 @@
 # LinkContextWrapper
 
-Wraps its children in a [LinkContext](/taxonomy/reference/location-contexts/LinkContext.md). Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).
+Wraps its children in a [LinkContext](/taxonomy/reference/location-contexts/LinkContext.md).  
+Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).
 
 ```tsx
 LinkContextWrapper: (props: {
@@ -10,10 +11,10 @@ LinkContextWrapper: (props: {
 ```
 
 ## Parameters
-|          |              | type                                                     | default value |
-|:--------:|:-------------|:---------------------------------------------------------|:--------------|
-| required | **children** | ReactNode &vert; ((parameters: TrackingContext) => void) |               |
-| required | **id**       | string                                                   |               |
+|          |              | type                                                     |
+|:--------:|:-------------|:---------------------------------------------------------|
+| required | **children** | ReactNode &vert; ((parameters: TrackingContext) => void) |
+| required | **id**       | string                                                   |
 
 ## Returns
 ReactElement.
@@ -32,16 +33,22 @@ import { LinkContextWrapper } from '@objectiv/tracker-react';
 </LinkContextWrapper>
 ```
 
-### Render Props inline tracking
+### Tracking via Render Props
 
 ```jsx
-import { LinkContextWrapper, trackPressEvent } from '@objectiv/tracker-react';
+import { 
+  LinkContextWrapper, 
+  trackPressEvent 
+} from '@objectiv/tracker-react';
 ```
 
 ```jsx
 <LinkContextWrapper id={'privacy'}>
   {(trackingContext) => (
-    <a href={'/privacy'} onClick={() => trackPressEvent(trackingContext)}>
+    <a 
+      href={'/privacy'} 
+      onClick={() => trackPressEvent(trackingContext)}
+    >
       Privacy
     </a>
   )}

--- a/docs/docs/tracking/react/api-reference/locationWrappers/LocationContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/LocationContextWrapper.md
@@ -21,7 +21,7 @@ LocationContextWrapper: (props: {
 | required | **locationContext** | LocationContext                                          |
 
 ## Returns
-ReactElement.
+`ReactElement`
 
 ## Usage example
 

--- a/docs/docs/tracking/react/api-reference/locationWrappers/LocationContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/LocationContextWrapper.md
@@ -1,6 +1,7 @@
 # LocationContextWrapper
 
-Wraps its children in the given [LocationContext](/taxonomy/reference/location-contexts/overview.md) instance. Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).
+Wraps its children in the given [LocationContext](/taxonomy/reference/location-contexts/overview.md) instance.  
+Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).
 
 ```tsx
 LocationContextWrapper: (props: {
@@ -14,28 +15,60 @@ LocationContextWrapper: (props: {
 :::
 
 ## Parameters
-|          |                     | type                                                     | default value |
-|:--------:|:--------------------|:---------------------------------------------------------|:--------------|
-| required | **children**        | ReactNode &vert; ((parameters: TrackingContext) => void) |               |
-| required | **locationContext** | LocationContext                                          |               |
+|          |                     | type                                                     |
+|:--------:|:--------------------|:---------------------------------------------------------|
+| required | **children**        | ReactNode &vert; ((parameters: TrackingContext) => void) |
+| required | **locationContext** | LocationContext                                          |
 
 ## Returns
 ReactElement.
 
 ## Usage example
 
+### Enrich Locations
+
 ```jsx
-import { LocationContextWrapper, makeContentContext } from '@objectiv/tracker-react';
+import { 
+  LocationContextWrapper, 
+  makeContentContext
+} from '@objectiv/tracker-react';
 ```
 
 ```jsx
-<LocationContextWrapper locationContext={ makeContentContext({ id: 'content' }) }>
+<LocationContextWrapper 
+  locationContext={ makeContentContext({ id: 'content' }) 
+}>
   <div>
     ...
   </div>
   <span>
     ...
   </span>
+</LocationContextWrapper>
+```
+
+### Tracking via Render Props
+```jsx
+import {
+  LocationContextWrapper, 
+  trackPressEvent
+} from '@objectiv/tracker-react';
+```
+
+```jsx
+<LocationContextWrapper 
+  locationContext={ makeContentContext({ id: 'content' })
+}>
+  {(trackingContext) => (
+    <>
+      <div onClick={() => trackPressEvent(trackingContext)}>
+        Hi!
+      </div>
+      <span>
+        ...
+      </span>
+    </>
+  )}
 </LocationContextWrapper>
 ```
 

--- a/docs/docs/tracking/react/api-reference/locationWrappers/LocationContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/LocationContextWrapper.md
@@ -1,10 +1,10 @@
 # LocationContextWrapper
 
-Wraps its children in the given [LocationContext](/taxonomy/reference/location-contexts/overview.md) instance.
+Wraps its children in the given [LocationContext](/taxonomy/reference/location-contexts/overview.md) instance. Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).
 
 ```tsx
-LocationContextWrapper: (props: { 
-  children: ReactNode, 
+LocationContextWrapper: (props: {
+  children: ReactNode | ((parameters: TrackingContext) => void),
   locationContext: LocationContext
 }) => ReactElement
 ```
@@ -14,21 +14,21 @@ LocationContextWrapper: (props: {
 :::
 
 ## Parameters
-|          |                     | type            | default value |
-|:--------:|:--------------------|:----------------|:--------------|
-| required | **children**        | ReactNode       |               |
-| required | **locationContext** | LocationContext |               |
+|          |                     | type                                                     | default value |
+|:--------:|:--------------------|:---------------------------------------------------------|:--------------|
+| required | **children**        | ReactNode &vert; ((parameters: TrackingContext) => void) |               |
+| required | **locationContext** | LocationContext                                          |               |
 
 ## Returns
 ReactElement.
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { LocationContextWrapper, makeContentContext } from '@objectiv/tracker-react';
 ```
 
-```typescript jsx
+```jsx
 <LocationContextWrapper locationContext={ makeContentContext({ id: 'content' }) }>
   <div>
     ...

--- a/docs/docs/tracking/react/api-reference/locationWrappers/MediaPlayerContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/MediaPlayerContextWrapper.md
@@ -20,6 +20,8 @@ ReactElement.
 
 ## Usage example
 
+### Enrich Locations
+
 ```jsx
 import { MediaPlayerContextWrapper } from '@objectiv/tracker-react';
 ```
@@ -27,6 +29,32 @@ import { MediaPlayerContextWrapper } from '@objectiv/tracker-react';
 ```jsx
 <MediaPlayerContextWrapper id={'video'}>
   <video src={'https://www.youtube.com/watch?v=dQw4w9WgXcQ'} />
+</MediaPlayerContextWrapper>
+```
+
+### Render Props inline tracking
+
+```jsx
+import { 
+  MediaPlayerContextWrapper, 
+  trackMediaLoadEvent, 
+  trackMediaPauseEvent,
+  trackMediaStartEvent,
+  trackMediaStopEvent
+} from '@objectiv/tracker-react';
+```
+
+```jsx
+<MediaPlayerContextWrapper id={'video'}>
+  {(trackingContext) => (
+    <video 
+      src={'https://www.youtube.com/watch?v=dQw4w9WgXcQ'} 
+      onLoad={() => trackMediaLoadEvent(trackingContext)}
+      onPlay={() => trackMediaStartEvent(trackingContext)}
+      onPause={() => trackMediaPauseEvent(trackingContext)}
+      onEnded={() => trackMediaStopEvent(trackingContext)}
+    />
+  )}
 </MediaPlayerContextWrapper>
 ```
 

--- a/docs/docs/tracking/react/api-reference/locationWrappers/MediaPlayerContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/MediaPlayerContextWrapper.md
@@ -17,7 +17,7 @@ MediaPlayerContextWrapper: (props: {
 | required | **id**       | string                                                   |
 
 ## Returns
-ReactElement.
+`ReactElement`
 
 ## Usage example
 

--- a/docs/docs/tracking/react/api-reference/locationWrappers/MediaPlayerContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/MediaPlayerContextWrapper.md
@@ -1,30 +1,30 @@
 # MediaPlayerContextWrapper
 
-Wraps its children in a [MediaPlayerContext](/taxonomy/reference/location-contexts/MediaPlayerContext.md).
+Wraps its children in a [MediaPlayerContext](/taxonomy/reference/location-contexts/MediaPlayerContext.md). Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).
 
 ```tsx
-MediaPlayerContextWrapper: (props: { 
-  children: ReactNode, 
+MediaPlayerContextWrapper: (props: {
+  children: ReactNode | ((parameters: TrackingContext) => void),
   id: string
 }) => ReactElement
 ```
 
 ## Parameters
-|          |              | type      | default value |
-|:--------:|:-------------|:----------|:--------------|
-| required | **children** | ReactNode |               |
-| required | **id**       | string    |               |
+|          |              | type                                                     | default value |
+|:--------:|:-------------|:---------------------------------------------------------|:--------------|
+| required | **children** | ReactNode &vert; ((parameters: TrackingContext) => void) |               |
+| required | **id**       | string                                                   |               |
 
 ## Returns
 ReactElement.
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { MediaPlayerContextWrapper } from '@objectiv/tracker-react';
 ```
 
-```typescript jsx
+```jsx
 <MediaPlayerContextWrapper id={'video'}>
   <video src={'https://www.youtube.com/watch?v=dQw4w9WgXcQ'} />
 </MediaPlayerContextWrapper>

--- a/docs/docs/tracking/react/api-reference/locationWrappers/MediaPlayerContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/MediaPlayerContextWrapper.md
@@ -1,6 +1,7 @@
 # MediaPlayerContextWrapper
 
-Wraps its children in a [MediaPlayerContext](/taxonomy/reference/location-contexts/MediaPlayerContext.md). Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).
+Wraps its children in a [MediaPlayerContext](/taxonomy/reference/location-contexts/MediaPlayerContext.md).  
+Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).
 
 ```tsx
 MediaPlayerContextWrapper: (props: {
@@ -10,10 +11,10 @@ MediaPlayerContextWrapper: (props: {
 ```
 
 ## Parameters
-|          |              | type                                                     | default value |
-|:--------:|:-------------|:---------------------------------------------------------|:--------------|
-| required | **children** | ReactNode &vert; ((parameters: TrackingContext) => void) |               |
-| required | **id**       | string                                                   |               |
+|          |              | type                                                     |
+|:--------:|:-------------|:---------------------------------------------------------|
+| required | **children** | ReactNode &vert; ((parameters: TrackingContext) => void) |
+| required | **id**       | string                                                   |
 
 ## Returns
 ReactElement.
@@ -32,7 +33,7 @@ import { MediaPlayerContextWrapper } from '@objectiv/tracker-react';
 </MediaPlayerContextWrapper>
 ```
 
-### Render Props inline tracking
+### Tracking via Render Props
 
 ```jsx
 import { 

--- a/docs/docs/tracking/react/api-reference/locationWrappers/NavigationContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/NavigationContextWrapper.md
@@ -1,30 +1,30 @@
 # NavigationContextWrapper
 
-Wraps its children in a [NavigationContext](/taxonomy/reference/location-contexts/NavigationContext.md).
+Wraps its children in a [NavigationContext](/taxonomy/reference/location-contexts/NavigationContext.md). Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).
 
 ```tsx
-NavigationContextWrapper: (props: { 
-  children: ReactNode, 
+NavigationContextWrapper: (props: {
+  children: ReactNode | ((parameters: TrackingContext) => void),
   id: string
 }) => ReactElement
 ```
 
 ## Parameters
-|          |              | type      | default value |
-|:--------:|:-------------|:----------|:--------------|
-| required | **children** | ReactNode |               |
-| required | **id**       | string    |               |
+|          |              | type                                                     | default value |
+|:--------:|:-------------|:---------------------------------------------------------|:--------------|
+| required | **children** | ReactNode &vert; ((parameters: TrackingContext) => void) |               |
+| required | **id**       | string                                                   |               |
 
 ## Returns
 ReactElement.
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { NavigationContextWrapper } from '@objectiv/tracker-react';
 ```
 
-```typescript jsx
+```jsx
 <NavigationContextWrapper id={'content'}>
   <nav>
     <a href={'/'}>Homepage</a>

--- a/docs/docs/tracking/react/api-reference/locationWrappers/NavigationContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/NavigationContextWrapper.md
@@ -42,8 +42,8 @@ import { NavigationContextWrapper } from '@objectiv/tracker-react';
 ```jsx
 import { 
   NavigationContextWrapper, 
-  trackVisibleEvent, 
-  trackHiddenEvent
+  trackHiddenEvent,
+  trackVisibleEvent 
 } from '@objectiv/tracker-react';
 ```
 

--- a/docs/docs/tracking/react/api-reference/locationWrappers/NavigationContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/NavigationContextWrapper.md
@@ -17,7 +17,7 @@ NavigationContextWrapper: (props: {
 | required | **id**       | string                                                   |
 
 ## Returns
-ReactElement.
+`ReactElement`
 
 ## Usage example
 

--- a/docs/docs/tracking/react/api-reference/locationWrappers/NavigationContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/NavigationContextWrapper.md
@@ -20,17 +20,44 @@ ReactElement.
 
 ## Usage example
 
+### Enrich Locations
+
 ```jsx
 import { NavigationContextWrapper } from '@objectiv/tracker-react';
 ```
 
 ```jsx
-<NavigationContextWrapper id={'content'}>
+<NavigationContextWrapper id={'footer'}>
   <nav>
     <a href={'/'}>Homepage</a>
     <a href={'/privacy'}>Privacy</a>
     <a href={'/contact'}>Contact</a>
   </nav>
+</NavigationContextWrapper>
+```
+
+### Render Props inline tracking
+
+```jsx
+import { 
+  NavigationContextWrapper, 
+  trackVisibleEvent, 
+  trackHiddenEvent
+} from '@objectiv/tracker-react';
+```
+
+```jsx
+<NavigationContextWrapper id={'drawer'}>
+  {(trackingContext) => (
+    <Drawer
+      onShow={() => trackVisibleEvent(trackingContext)}
+      onHide={() => trackHiddenEvent(trackingContext)}
+    >
+      <a href={'/'}>Homepage</a>
+      <a href={'/privacy'}>Privacy</a>
+      <a href={'/contact'}>Contact</a>
+    </Drawer>
+  )}
 </NavigationContextWrapper>
 ```
 

--- a/docs/docs/tracking/react/api-reference/locationWrappers/NavigationContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/NavigationContextWrapper.md
@@ -1,6 +1,7 @@
 # NavigationContextWrapper
 
-Wraps its children in a [NavigationContext](/taxonomy/reference/location-contexts/NavigationContext.md). Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).
+Wraps its children in a [NavigationContext](/taxonomy/reference/location-contexts/NavigationContext.md).  
+Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).
 
 ```tsx
 NavigationContextWrapper: (props: {
@@ -10,10 +11,10 @@ NavigationContextWrapper: (props: {
 ```
 
 ## Parameters
-|          |              | type                                                     | default value |
-|:--------:|:-------------|:---------------------------------------------------------|:--------------|
-| required | **children** | ReactNode &vert; ((parameters: TrackingContext) => void) |               |
-| required | **id**       | string                                                   |               |
+|          |              | type                                                     |
+|:--------:|:-------------|:---------------------------------------------------------|
+| required | **children** | ReactNode &vert; ((parameters: TrackingContext) => void) |
+| required | **id**       | string                                                   |
 
 ## Returns
 ReactElement.
@@ -36,7 +37,7 @@ import { NavigationContextWrapper } from '@objectiv/tracker-react';
 </NavigationContextWrapper>
 ```
 
-### Render Props inline tracking
+### Tracking via Render Props
 
 ```jsx
 import { 

--- a/docs/docs/tracking/react/api-reference/locationWrappers/OverlayContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/OverlayContextWrapper.md
@@ -1,30 +1,30 @@
 # OverlayContextWrapper
 
-Wraps its children in a [OverlayContext](/taxonomy/reference/location-contexts/OverlayContext.md).
+Wraps its children in a [OverlayContext](/taxonomy/reference/location-contexts/OverlayContext.md). Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).
 
 ```tsx
-OverlayContextWrapper: (props: { 
-  children: ReactNode, 
+OverlayContextWrapper: (props: {
+  children: ReactNode | ((parameters: TrackingContext) => void),
   id: string
 }) => ReactElement
 ```
 
 ## Parameters
-|          |              | type      | default value |
-|:--------:|:-------------|:----------|:--------------|
-| required | **children** | ReactNode |               |
-| required | **id**       | string    |               |
+|          |              | type                                                     | default value |
+|:--------:|:-------------|:---------------------------------------------------------|:--------------|
+| required | **children** | ReactNode &vert; ((parameters: TrackingContext) => void) |               |
+| required | **id**       | string                                                   |               |
 
 ## Returns
 ReactElement.
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { OverlayContextWrapper } from '@objectiv/tracker-react';
 ```
 
-```typescript jsx
+```jsx
 <OverlayContextWrapper id={'modal'}>
   <Modal>
     ...

--- a/docs/docs/tracking/react/api-reference/locationWrappers/OverlayContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/OverlayContextWrapper.md
@@ -17,7 +17,7 @@ OverlayContextWrapper: (props: {
 | required | **id**       | string                                                   |
 
 ## Returns
-ReactElement.
+`ReactElement`
 
 ## Usage example
 

--- a/docs/docs/tracking/react/api-reference/locationWrappers/OverlayContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/OverlayContextWrapper.md
@@ -1,6 +1,7 @@
 # OverlayContextWrapper
 
-Wraps its children in a [OverlayContext](/taxonomy/reference/location-contexts/OverlayContext.md). Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).
+Wraps its children in a [OverlayContext](/taxonomy/reference/location-contexts/OverlayContext.md).  
+Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).
 
 ```tsx
 OverlayContextWrapper: (props: {
@@ -10,15 +11,17 @@ OverlayContextWrapper: (props: {
 ```
 
 ## Parameters
-|          |              | type                                                     | default value |
-|:--------:|:-------------|:---------------------------------------------------------|:--------------|
-| required | **children** | ReactNode &vert; ((parameters: TrackingContext) => void) |               |
-| required | **id**       | string                                                   |               |
+|          |              | type                                                     |
+|:--------:|:-------------|:---------------------------------------------------------|
+| required | **children** | ReactNode &vert; ((parameters: TrackingContext) => void) |
+| required | **id**       | string                                                   |
 
 ## Returns
 ReactElement.
 
 ## Usage example
+
+### Enrich Locations
 
 ```jsx
 import { OverlayContextWrapper } from '@objectiv/tracker-react';
@@ -29,6 +32,33 @@ import { OverlayContextWrapper } from '@objectiv/tracker-react';
   <Modal>
     ...
   </Modal>
+</OverlayContextWrapper>
+```
+
+### Tracking via Render Props
+
+```jsx
+import { 
+  OverlayContextWrapper, 
+  trackVisibility, 
+  trackPressEvent
+} from '@objectiv/tracker-react';
+```
+
+```jsx
+<OverlayContextWrapper id={'modal'}>
+  {(trackingContext) => (
+    <Modal 
+      onToggle={() => trackVisibility(trackingContext)}
+      closeButton={
+        <button onClick={() => trackPressEvent(trackingContext)}>
+          close
+        </button>
+      }
+    >
+      ...
+    </Modal>
+  )}
 </OverlayContextWrapper>
 ```
 

--- a/docs/docs/tracking/react/api-reference/locationWrappers/PressableContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/PressableContextWrapper.md
@@ -1,6 +1,7 @@
 # PressableContextWrapper
 
-Wraps its children in a [PressableContext](/taxonomy/reference/location-contexts/PressableContext.md). Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).
+Wraps its children in a [PressableContext](/taxonomy/reference/location-contexts/PressableContext.md).  
+Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).
 
 ```tsx
 PressableContextWrapper: (props: {
@@ -10,15 +11,17 @@ PressableContextWrapper: (props: {
 ```
 
 ## Parameters
-|          |              | type                                                     | default value |
-|:--------:|:-------------|:---------------------------------------------------------|:--------------|
-| required | **children** | ReactNode &vert; ((parameters: TrackingContext) => void) |               |
-| required | **id**       | string                                                   |               |
+|          |              | type                                                     |
+|:--------:|:-------------|:---------------------------------------------------------|
+| required | **children** | ReactNode &vert; ((parameters: TrackingContext) => void) |
+| required | **id**       | string                                                   |
 
 ## Returns
 ReactElement.
 
 ## Usage example
+
+### Enrich Locations
 
 ```jsx
 import { PressableContextWrapper } from '@objectiv/tracker-react';
@@ -26,11 +29,40 @@ import { PressableContextWrapper } from '@objectiv/tracker-react';
 
 ```jsx
 <PressableContextWrapper id={'do-it'}>
-  <button onClick={ () => doIt() }>
+  <button onClick={() => doIt()}>
     Do it
   </button>
 </PressableContextWrapper>
 ```
+
+### Tracking via Render Props
+
+```jsx
+import { 
+  PressableContextWrapper, 
+  trackPressEvent
+} from '@objectiv/tracker-react';
+```
+
+```jsx
+<PressableContextWrapper id={'do-it'}>
+  {(trackingContext) => (
+    <button onClick={() => {
+      trackPressEvent(trackingContext);
+      doIt();
+    }}>
+      Do it
+    </button>
+  )}
+</PressableContextWrapper>
+```
+
+<br />
+
+:::info
+The above is just an example to illustrate the Render Props functionality.   
+Check out our [Tracked Elements](/tracking/react/api-reference/trackedElements/overview.md) for a ready-to-use [TrackedButton](/tracking/react/api-reference/trackedElements/TrackedButton.md) component. 
+:::
 
 <br />
 

--- a/docs/docs/tracking/react/api-reference/locationWrappers/PressableContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/PressableContextWrapper.md
@@ -17,7 +17,7 @@ PressableContextWrapper: (props: {
 | required | **id**       | string                                                   |
 
 ## Returns
-ReactElement.
+`ReactElement`
 
 ## Usage example
 
@@ -39,17 +39,26 @@ import { PressableContextWrapper } from '@objectiv/tracker-react';
 
 ```jsx
 import { 
-  PressableContextWrapper, 
-  trackPressEvent
+  PressableContextWrapper,
+  trackFailureEvent,
+  trackPressEvent,
+  trackSuccessEvent
 } from '@objectiv/tracker-react';
 ```
 
 ```jsx
 <PressableContextWrapper id={'do-it'}>
   {(trackingContext) => (
-    <button onClick={() => {
+    <button onClick={async () => {
       trackPressEvent(trackingContext);
-      doIt();
+
+      const response = await doIt();
+
+      if (response.ok) {
+        trackSuccessEvent(trackingContext);
+      } else {
+        trackFailureEvent(trackingContext);
+      }
     }}>
       Do it
     </button>

--- a/docs/docs/tracking/react/api-reference/locationWrappers/PressableContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/PressableContextWrapper.md
@@ -1,30 +1,30 @@
 # PressableContextWrapper
 
-Wraps its children in a [PressableContext](/taxonomy/reference/location-contexts/PressableContext.md).
+Wraps its children in a [PressableContext](/taxonomy/reference/location-contexts/PressableContext.md). Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).
 
 ```tsx
-PressableContextWrapper: (props: { 
-  children: ReactNode, 
+PressableContextWrapper: (props: {
+  children: ReactNode | ((parameters: TrackingContext) => void),
   id: string
 }) => ReactElement
 ```
 
 ## Parameters
-|          |              | type      | default value |
-|:--------:|:-------------|:----------|:--------------|
-| required | **children** | ReactNode |               |
-| required | **id**       | string    |               |
+|          |              | type                                                     | default value |
+|:--------:|:-------------|:---------------------------------------------------------|:--------------|
+| required | **children** | ReactNode &vert; ((parameters: TrackingContext) => void) |               |
+| required | **id**       | string                                                   |               |
 
 ## Returns
 ReactElement.
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { PressableContextWrapper } from '@objectiv/tracker-react';
 ```
 
-```typescript jsx
+```jsx
 <PressableContextWrapper id={'do-it'}>
   <button onClick={ () => doIt() }>
     Do it

--- a/docs/docs/tracking/react/api-reference/locationWrappers/RootLocationContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/RootLocationContextWrapper.md
@@ -22,7 +22,7 @@ This is enabled by default in [ReactTracker](/tracking/react/api-reference/React
 | required | **id**       | string                                                   |
 
 ## Returns
-ReactElement.
+`ReactElement`
 
 ## Usage example
 

--- a/docs/docs/tracking/react/api-reference/locationWrappers/RootLocationContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/RootLocationContextWrapper.md
@@ -1,6 +1,7 @@
 # RootLocationContextWrapper
 
-Wraps its children in a [RootLocationContext](/taxonomy/reference/location-contexts/RootLocationContext.md). Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).
+Wraps its children in a [RootLocationContext](/taxonomy/reference/location-contexts/RootLocationContext.md).  
+Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).
 
 ```tsx
 RootLocationContextWrapper: (props: {
@@ -15,15 +16,17 @@ This is enabled by default in [ReactTracker](/tracking/react/api-reference/React
 :::
 
 ## Parameters
-|          |              | type                                                     | default value |
-|:--------:|:-------------|:---------------------------------------------------------|:--------------|
-| required | **children** | ReactNode &vert; ((parameters: TrackingContext) => void) |               |
-| required | **id**       | string                                                   |               |
+|          |              | type                                                     |
+|:--------:|:-------------|:---------------------------------------------------------|
+| required | **children** | ReactNode &vert; ((parameters: TrackingContext) => void) |
+| required | **id**       | string                                                   |
 
 ## Returns
 ReactElement.
 
 ## Usage example
+
+### Enrich Locations
 
 ```jsx
 import { RootLocationContextWrapper } from '@objectiv/tracker-react';
@@ -36,6 +39,35 @@ import { RootLocationContextWrapper } from '@objectiv/tracker-react';
   </Layout>
 </RootLocationContextWrapper>
 ```
+
+### Tracking via Render Props
+
+```jsx
+import { 
+  RootLocationContextWrapper, 
+  trackHiddenEvent,
+  trackVisibleEvent
+} from '@objectiv/tracker-react';
+```
+
+```jsx
+<RootLocationContextWrapper id={'page'}>
+  {(trackingContext) => (
+    <>
+      <Layout>
+        ...
+      </Layout>
+      <SupportChatOverlay
+        onShow={() => trackVisibleEvent(trackingContext)}
+        onHide={() => trackHiddenEvent(trackingContext)}
+      >
+        ...
+      </SupportChatOverlay>
+    </>
+  )}
+</RootLocationContextWrapper>
+```
+
 
 <br />
 

--- a/docs/docs/tracking/react/api-reference/locationWrappers/RootLocationContextWrapper.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/RootLocationContextWrapper.md
@@ -1,10 +1,10 @@
 # RootLocationContextWrapper
 
-Wraps its children in a [RootLocationContext](/taxonomy/reference/location-contexts/RootLocationContext.md).
+Wraps its children in a [RootLocationContext](/taxonomy/reference/location-contexts/RootLocationContext.md). Children can be a ReactNode or a [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) function receiving [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md).
 
 ```tsx
-RootLocationContextWrapper: (props: { 
-  children: ReactNode, 
+RootLocationContextWrapper: (props: {
+  children: ReactNode | ((parameters: TrackingContext) => void),
   id: string
 }) => ReactElement
 ```
@@ -15,21 +15,21 @@ This is enabled by default in [ReactTracker](/tracking/react/api-reference/React
 :::
 
 ## Parameters
-|          |              | type      | default value |
-|:--------:|:-------------|:----------|:--------------|
-| required | **children** | ReactNode |               |
-| required | **id**       | string    |               |
+|          |              | type                                                     | default value |
+|:--------:|:-------------|:---------------------------------------------------------|:--------------|
+| required | **children** | ReactNode &vert; ((parameters: TrackingContext) => void) |               |
+| required | **id**       | string                                                   |               |
 
 ## Returns
 ReactElement.
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { RootLocationContextWrapper } from '@objectiv/tracker-react';
 ```
 
-```typescript jsx
+```jsx
 <RootLocationContextWrapper id={'page'}>
   <Layout>
     ...

--- a/docs/docs/tracking/react/api-reference/locationWrappers/overview.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/overview.md
@@ -8,7 +8,8 @@ These Components wrap their children in a [Context.Provider](https://reactjs.org
 
 :::tip
 The combination of Location Wrappers and [Low-level Event Trackers](/tracking/react/api-reference/overview.md#low-level-event-trackers) is how we build Tracked Contexts and Elements.  
-Check the Render Props Usage sections for example of how to combine the two.  
+
+Take a loot at this [how to build your own Custom Tracked Components](/tracking/react/how-to-guides/custom-components.md) guide for more info.
 :::
 
 #### Higher-level

--- a/docs/docs/tracking/react/api-reference/locationWrappers/overview.md
+++ b/docs/docs/tracking/react/api-reference/locationWrappers/overview.md
@@ -6,6 +6,11 @@ sidebar_position: 1
 
 These Components wrap their children in a [Context.Provider](https://reactjs.org/docs/context.html#contextprovider). This allows the ReactTracker to reconstruct their Location in the UI.
 
+:::tip
+The combination of Location Wrappers and [Low-level Event Trackers](/tracking/react/api-reference/overview.md#low-level-event-trackers) is how we build Tracked Contexts and Elements.  
+Check the Render Props Usage sections for example of how to combine the two.  
+:::
+
 #### Higher-level
 - [ContentContextWrapper](/tracking/react/api-reference/locationWrappers/ContentContextWrapper.md)
 - [ExpandableContextWrapper](/tracking/react/api-reference/locationWrappers/ExpandableContextWrapper.md)

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedContentContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedContentContext.md
@@ -21,7 +21,7 @@ TrackedContentContext: (props: {
 | optional | forwardId     | boolean                              | `false`       |
 
 ## Returns
-ReactElement.
+`ReactElement`
 
 ## Automatic Events
 None.

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedContentContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedContentContext.md
@@ -28,11 +28,11 @@ None.
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { TrackedContentContext } from '@objectiv/tracker-react';
 ```
 
-```typescript jsx
+```jsx
 <TrackedContentContext Component={'div'} id={'content'}>
   ...
   <TrackedContentContext Component={'p'} id={'intro'}>

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedExpandableContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedExpandableContext.md
@@ -35,11 +35,11 @@ The `isVisible` state of a TrackedExpandableContext at mount is ignored. Only ac
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { TrackedExpandableContext } from '@objectiv/tracker-react';
 ```
 
-```typescript jsx
+```jsx
 <TrackedExpandableContext Component={Tooltip} id={'tooltip'}>
   ...
 </TrackedExpandableContext>

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedExpandableContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedExpandableContext.md
@@ -23,7 +23,7 @@ TrackedExpandableContext: (props: {
 | optional | isVisible     | boolean                              | `undefined`   |
 
 ## Returns
-ReactElement.
+`ReactElement`
 
 ## Automatic Events
 - [HiddenEvent](/taxonomy/reference/events/HiddenEvent.md) when `isVisible` switches from `true` to `false`. 

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedInputContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedInputContext.md
@@ -20,7 +20,7 @@ TrackedInputContext: (props: {
 | optional | forwardId     | boolean                              | `false`       |
 
 ## Returns
-ReactElement.
+`ReactElement`
 
 ## Automatic Events
 - [InputChangeEvent](/taxonomy/reference/events/InputChangeEvent.md) when `onBlur` triggers and the  value changed.

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedInputContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedInputContext.md
@@ -27,11 +27,11 @@ ReactElement.
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { TrackedInputContext } from '@objectiv/tracker-react';
 ```
 
-```typescript jsx
+```jsx
 <TrackedInputContext Component={'input'} type={'email'} id={'email'} />
 ```
 

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedLinkContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedLinkContext.md
@@ -30,7 +30,7 @@ TrackedLinkContext: (props: {
 | optional | waitUntilTracked | boolean                              | `false`                             |
 
 ## Returns
-ReactElement.
+`ReactElement`
 
 ## Automatic Events
 - [PressEvent](/taxonomy/reference/events/PressEvent.md) when `onClick` triggers.

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedLinkContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedLinkContext.md
@@ -37,11 +37,11 @@ ReactElement.
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { TrackedLinkContext } from '@objectiv/tracker-react';
 ```
 
-```typescript jsx
+```jsx
 <TrackedLinkContext Component={'a'} href={'/privacy'}>
   Privacy
 </TrackedLinkContext>

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedMediaPlayerContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedMediaPlayerContext.md
@@ -20,7 +20,7 @@ TrackedMediaPlayerContext: (props: {
 | optional | forwardId     | boolean                              | `false`       |
 
 ## Returns
-ReactElement.
+`ReactElement`
 
 ## Automatic Events
 None.

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedMediaPlayerContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedMediaPlayerContext.md
@@ -27,11 +27,11 @@ None.
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { TrackedMediaPlayerContext } from '@objectiv/tracker-react';
 ```
 
-```typescript jsx
+```jsx
 <TrackedMediaPlayerContext Component={'video'} id={'content'} />
 ```
 

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedNavigationContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedNavigationContext.md
@@ -20,7 +20,7 @@ TrackedNavigationContext: (props: {
 | optional | forwardId     | boolean                              | `false`       |
 
 ## Returns
-ReactElement.
+`ReactElement`
 
 ## Automatic Events
 None.

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedNavigationContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedNavigationContext.md
@@ -27,11 +27,11 @@ None.
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { TrackedNavigationContext } from '@objectiv/tracker-react';
 ```
 
-```typescript jsx
+```jsx
 <TrackedNavigationContext Component={'nav'} id={'top-nav'}>
   <a href={'/'}>Homepage</a>
   <a href={'/privacy'}>Privacy</a>

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedOverlayContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedOverlayContext.md
@@ -21,7 +21,7 @@ TrackedOverlayContext: (props: {
 | optional | forwardId     | boolean                              | `false`       |
 
 ## Returns
-ReactElement.
+`ReactElement`
 
 ## Automatic Events
 - [HiddenEvent](/taxonomy/reference/events/HiddenEvent.md) when `isVisible` switches from `true` to `false`.

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedOverlayContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedOverlayContext.md
@@ -34,11 +34,11 @@ The `isVisible` state of a TrackedOverlayContext at mount is ignored. Only actua
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { TrackedOverlayContext } from '@objectiv/tracker-react';
 ```
 
-```typescript jsx
+```jsx
 <TrackedOverlayContext Component={'div'} id={'modal'}>
   ...
 </TrackedOverlayContext>

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedPressableContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedPressableContext.md
@@ -33,11 +33,11 @@ ReactElement.
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { TrackedPressableContext } from '@objectiv/tracker-react';
 ```
 
-```typescript jsx
+```jsx
 <TrackedPressableContext Component={'button'} onClick={ () => doIt() }>
   Do it
 </TrackedPressableContext>

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedPressableContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedPressableContext.md
@@ -26,7 +26,7 @@ TrackedPressableContext: (props: {
 | optional | waitUntilTracked  | boolean                              | `false`                             |
 
 ## Returns
-ReactElement.
+`ReactElement`
 
 ## Automatic Events
 - [PressEvent](/taxonomy/reference/events/PressEvent.md) when `onClick` triggers.

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedRootLocationContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedRootLocationContext.md
@@ -20,7 +20,7 @@ TrackedRootLocationContext: (props: {
 | optional | forwardId     | boolean                              | `false`       |
 
 ## Returns
-ReactElement.
+`ReactElement`
 
 ## Automatic Events
 None.

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedRootLocationContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedRootLocationContext.md
@@ -27,11 +27,11 @@ None.
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { TrackedRootLocationContext } from '@objectiv/tracker-react';
 ```
 
-```typescript jsx
+```jsx
 <TrackedRootLocationContext id={'page'}>
   <Layout>
     ...

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedAnchor.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedAnchor.md
@@ -35,11 +35,11 @@ ReactElement.
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { TrackedAnchor } from '@objectiv/tracker-react';
 ```
 
-```typescript jsx
+```jsx
 <div>
   <header>
     <TrackedAnchor href={'/'}>Homepage</TrackedAnchor>

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedAnchor.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedAnchor.md
@@ -28,7 +28,7 @@ TrackedAnchor: (props: {
 | optional | waitUntilTracked | boolean   | `false`                             |
 
 ## Returns
-ReactElement.
+`ReactElement`
 
 ## Automatic Events
 - [PressEvent](/taxonomy/reference/events/PressEvent.md) when `onClick` triggers.

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedButton.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedButton.md
@@ -31,11 +31,11 @@ ReactElement.
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { TrackedButton } from '@objectiv/tracker-react';
 ```
 
-```typescript jsx
+```jsx
 <div>
   <header>
     ...

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedButton.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedButton.md
@@ -24,7 +24,7 @@ TrackedButton: (props: {
 | optional | waitUntilTracked | boolean   | `false`                             |
 
 ## Returns
-ReactElement.
+`ReactElement`
 
 ## Automatic Events
 - [PressEvent](/taxonomy/reference/events/PressEvent.md) when `onClick` triggers.

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedDiv.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedDiv.md
@@ -25,11 +25,11 @@ None.
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { TrackedDiv } from '@objectiv/tracker-react';
 ```
 
-```typescript jsx
+```jsx
 <TrackedDiv id={'content'}>
   ...
   <TrackedDiv id={'details'}>

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedDiv.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedDiv.md
@@ -18,7 +18,7 @@ TrackedDiv: (props: {
 | optional | forwardId     | boolean   | `false`       |
 
 ## Returns
-ReactElement.
+`ReactElement`
 
 ## Automatic Events
 None.

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedFooter.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedFooter.md
@@ -25,11 +25,11 @@ None.
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { TrackedFooter } from '@objectiv/tracker-react';
 ```
 
-```typescript jsx
+```jsx
 <div>
   <header>
     ...

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedFooter.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedFooter.md
@@ -18,7 +18,7 @@ TrackedFooter: (props: {
 | optional | forwardId    | boolean                              | `false`       |
 
 ## Returns
-ReactElement.
+`ReactElement`
 
 ## Automatic Events
 None.

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedHeader.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedHeader.md
@@ -18,7 +18,7 @@ TrackedHeader: (props: {
 | optional | forwardId    | boolean                              | `false`       |
 
 ## Returns
-ReactElement.
+`ReactElement`
 
 ## Automatic Events
 None.

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedHeader.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedHeader.md
@@ -25,11 +25,11 @@ None.
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { TrackedHeader } from '@objectiv/tracker-react';
 ```
 
-```typescript jsx
+```jsx
 <div>
   <TrackedHeader>
     ...

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedInput.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedInput.md
@@ -22,7 +22,7 @@ TrackedInput: (props: {
 | optional | forwardTitle | boolean   | `false`       |
 
 ## Returns
-ReactElement.
+`ReactElement`
 
 ## Automatic Events
 - [InputChangeEvent](/taxonomy/reference/events/InputChangeEvent.md) when `onBlur` triggers and the  value changed.

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedInput.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedInput.md
@@ -29,11 +29,11 @@ ReactElement.
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { TrackedInput } from '@objectiv/tracker-react';
 ```
 
-```typescript jsx
+```jsx
 <div>
   <header>
     ...

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedMain.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedMain.md
@@ -18,7 +18,7 @@ TrackedMain: (props: {
 | optional | forwardId    | boolean   | `false`       |
 
 ## Returns
-ReactElement.
+`ReactElement`
 
 ## Automatic Events
 None.

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedMain.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedMain.md
@@ -25,11 +25,11 @@ None.
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { TrackedMain } from '@objectiv/tracker-react';
 ```
 
-```typescript jsx
+```jsx
 <div>
   <header>
     ...

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedNav.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedNav.md
@@ -25,11 +25,11 @@ None.
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { TrackedNav } from '@objectiv/tracker-react';
 ```
 
-```typescript jsx
+```jsx
 <div>
   <header>
     ...

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedNav.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedNav.md
@@ -18,7 +18,7 @@ TrackedNav: (props: {
 | optional | forwardId    | boolean   | `false`       |
 
 ## Returns
-ReactElement.
+`ReactElement`
 
 ## Automatic Events
 None.

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedSection.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedSection.md
@@ -18,7 +18,7 @@ TrackedSection: (props: {
 | optional | forwardId     | boolean                              | `false`       |
 
 ## Returns
-ReactElement.
+`ReactElement`
 
 ## Automatic Events
 None.

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedSection.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedSection.md
@@ -25,11 +25,11 @@ None.
 
 ## Usage example
 
-```typescript jsx
+```jsx
 import { TrackedSection } from '@objectiv/tracker-react';
 ```
 
-```typescript jsx
+```jsx
 <TrackedSection id={'content'}>
   ...
   <TrackedSection id={'sub-section'}>

--- a/docs/docs/tracking/react/how-to-guides/custom-components.md
+++ b/docs/docs/tracking/react/how-to-guides/custom-components.md
@@ -1,0 +1,174 @@
+---
+sidebar_position: 5
+---
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+# Custom Components
+
+Our [previous how-to-guide](/tracking/react/how-to-guides/tracking-locations.md) explained how to enrich Locations by using [Tracked Contexts](/tracking/react/api-reference/trackedContexts/overview.md) and [Tracked Elements](/tracking/react/api-reference/trackedElements/overview.md).
+
+In this guide we are going to explore how to correctly use Location Wrappers and low-level Event Trackers to produce a fully functional Tracked Component.
+
+## Making TrackedVideo
+Suppose we have several HTML `<video>` tags on our website, and we would like to track when users saw a video, when they played or paused it and when the video reached its end.
+
+Since we want to track all videos, ideally we want to make this into a new Tracked Component to be reused where needed.
+
+## Picking a LocationContext 
+The most appropriate candidate to wrap around our videos is a [MediaPlayerContext](/taxonomy/reference/location-contexts/MediaPlayerContext.md).
+
+The equivalent Location Wrapper is [MediaPlayerContextWrapper](/tracking/react/api-reference/locationWrappers/MediaPlayerContextWrapper.md).
+
+Here is how our component could look like:
+
+```tsx
+import { MediaPlayerContextWrapper } from "@objectiv/tracker-react";
+
+type TrackedVideoProps = { videoUrl: string, id: string };
+
+const TrackedVideo = ({ videoUrl, id = "video" }: TrackedVideoProps) => (
+  <MediaPlayerContextWrapper id={id}>
+    <video
+      src={videoUrl}
+    />
+  </MediaPlayerContextWrapper>
+);
+```
+
+## Handling Media Events
+Next we are going to hook up the `<video>` event handlers to Event Trackers. React Tracker SDK offers both [Hook based Event Trackers](/tracking/react/api-reference/hooks/eventTrackers/overview.md) and [Low-level Event Trackers](/tracking/react/api-reference/eventTrackers/overview.md).
+
+
+### Hooks vs Low-level
+Both of them can work, but the implementation will differ quite a bit. As a rule of thumb: 
+
+- Hook Event Trackers should not be used in Components enriching Locations in their JSX.
+
+
+#### A broken example 
+Let's take a look at why is that so important. First let's `hook` our Component to the hook-based Event Trackers. 
+
+```tsx
+import {
+  useMediaLoadEventTracker,
+  useMediaPauseEventTracker,
+  useMediaStartEventTracker, 
+  useMediaStopEventTracker
+} from "@objectiv/tracker-react";
+
+type TrackedVideoProps = { videoUrl: string, id: string };
+
+const TrackedVideo = ({ videoUrl, id = "video" }: TrackedVideoProps) => {
+  const trackMediaLoadEvent = useMediaLoadEventTracker();
+  const trackMediaStartEvent = useMediaStartEventTracker();
+  const trackMediaPauseEvent = useMediaPauseEventTracker();
+  const trackMediaStopEvent = useMediaStopEventTracker();
+
+  return (
+    <MediaPlayerContextWrapper id={id}>
+      <video
+        src={videoUrl}
+        onReady={() => trackMediaLoadEvent()}
+        onStart={() => trackMediaStartEvent()}
+        onPause={() => trackMediaPauseEvent()}
+        onEnded={() => trackMediaStopEvent()}
+      />
+    </MediaPlayerContextWrapper>
+  );
+}
+```
+
+#### It doesn't work 
+If we test this component you will quickly notice that the LocationStack of all Events will not contain the MediaPlayerContext entry.
+
+Why aren't the Event Trackers detecting the MediaPlayerContextWrapper that is clearly there?
+
+Simply because hooks generated those callbacks before the JSX has been executed. JSX looks like HTML, but is in fact compiled to JavaScript.
+
+So what actually happens in the example above is that `trackMediaLoadEvent`, `trackMediaStartEvent`, `trackMediaStartEvent` and `trackMediaStopEvent` will never know about `MediaPlayerContextWrapper` as it doesn't even exist when they have been generated.  
+
+#### Two possible solutions
+There are two ways of solving this issue:
+
+1. Split the `<video>` component and the hooks calls in a separate component.
+2. Use LocationWrapper RenderProps to gain access to the correct TrackingContext.
+
+### Split-component approach
+While this works fine, we don't really recommend it as it makes for a very fragmented codebase. Nonetheless, here is how it would look like:
+
+```tsx
+import {
+  useMediaLoadEventTracker,
+  useMediaPauseEventTracker,
+  useMediaStartEventTracker, 
+  useMediaStopEventTracker
+} from "@objectiv/tracker-react";
+
+type TrackedVideoProps = VideoPlayerProps & { id: string };
+
+const TrackedVideo = ({ videoUrl, id = "video" }: TrackedVideoProps) => (
+  <MediaPlayerContextWrapper id={id}>
+    <VideoPlayer src={videoUrl} />
+  </MediaPlayerContextWrapper>
+);
+
+type VideoPlayerProps = { videoUrl: string };
+
+const VideoPlayer = ({ videoUrl }: VideoPlayerProps) => {
+  const trackMediaLoadEvent = useMediaLoadEventTracker();
+  const trackMediaStartEvent = useMediaStartEventTracker();
+  const trackMediaPauseEvent = useMediaPauseEventTracker();
+  const trackMediaStopEvent = useMediaStopEventTracker();
+
+  return (
+    <video
+      src={videoUrl}
+      onReady={() => trackMediaLoadEvent()}
+      onStart={() => trackMediaStartEvent()}
+      onPause={() => trackMediaPauseEvent()}
+      onEnded={() => trackMediaStopEvent()}
+    />
+  );
+}
+```
+
+This works because now `VideoPlayer`, being a separate component, will be able to correctly fetch the Context Provider that `TrackedVideo` provides via `MediaPlayerContextWrapper`.
+
+### Render Props approach
+There's a less verbose solution using [Render Props](https://reactjs.org/docs/render-props.html).  
+
+All LocationWrappers can render either regular ReactNode children or a function that receives an up-to-date [TrackingContext](/tracking/react/api-reference/common/providers/TrackingContext.md) as parameter.
+
+TrackingContext will contain the closest instance of ReactTracker and the LocationStack.
+
+This is how that looks like:
+
+```tsx
+import {
+  trackMediaLoadEvent,
+  trackMediaPauseEvent,
+  trackMediaStartEvent,
+  trackMediaStopEvent
+} from "@objectiv/tracker-react";
+
+type TrackedVideoProps = { videoUrl: string, id: string };
+
+const TrackedVideo = ({ videoUrl, id = "video" }: TrackedVideoProps) => (
+  <MediaPlayerContextWrapper id={id}>
+    {(trackingContext) => {
+      <video
+        src={videoUrl}
+        onReady={() => trackMediaLoadEvent(trackingContext)}
+        onStart={() => trackMediaStartEvent(trackingContext)}
+        onPause={() => trackMediaPauseEvent(trackingContext)}
+        onEnded={() => trackMediaStopEvent(trackingContext)}
+      />
+    }}
+  </MediaPlayerContextWrapper>
+);
+```
+
+All we did here is switching our hook-based Event Trackers with low-level ones.  
+These require a `trackingContext` which we can obtain, via Render Props, from `MediaPlayerContextWrapper`.
+

--- a/docs/docs/tracking/react/how-to-guides/custom-components.md
+++ b/docs/docs/tracking/react/how-to-guides/custom-components.md
@@ -156,7 +156,7 @@ type TrackedVideoProps = { videoUrl: string, id: string };
 
 const TrackedVideo = ({ videoUrl, id = "video" }: TrackedVideoProps) => (
   <MediaPlayerContextWrapper id={id}>
-    {(trackingContext) => {
+    {(trackingContext) => (
       <video
         src={videoUrl}
         onReady={() => trackMediaLoadEvent(trackingContext)}
@@ -164,7 +164,7 @@ const TrackedVideo = ({ videoUrl, id = "video" }: TrackedVideoProps) => (
         onPause={() => trackMediaPauseEvent(trackingContext)}
         onEnded={() => trackMediaStopEvent(trackingContext)}
       />
-    }}
+    )}
   </MediaPlayerContextWrapper>
 );
 ```

--- a/docs/docs/tracking/react/how-to-guides/custom-components.md
+++ b/docs/docs/tracking/react/how-to-guides/custom-components.md
@@ -84,9 +84,9 @@ If we test this component you will quickly notice that the LocationStack of all 
 
 Why aren't the Event Trackers detecting the MediaPlayerContextWrapper that is clearly there?
 
-Simply because hooks generated those callbacks before the JSX has been executed. JSX looks like HTML, but is in fact compiled to JavaScript.
+Simply because hooks have generated those callbacks before the JSX has been executed. JSX looks like HTML, but is in fact compiled to JavaScript.
 
-So what actually happens in the example above is that `trackMediaLoadEvent`, `trackMediaStartEvent`, `trackMediaStartEvent` and `trackMediaStopEvent` will never know about `MediaPlayerContextWrapper` as it doesn't even exist when they have been generated.  
+What actually happens here is that the `trackMediaLoadEvent`, `trackMediaStartEvent`, `trackMediaStartEvent` and `trackMediaStopEvent` callbacks cannot know about `MediaPlayerContextWrapper`, as that Element didn't even exist when they got factored.  
 
 #### Two possible solutions
 There are two ways of solving this issue:
@@ -170,5 +170,5 @@ const TrackedVideo = ({ videoUrl, id = "video" }: TrackedVideoProps) => (
 ```
 
 All we did here is switching our hook-based Event Trackers with low-level ones.  
-These require a `trackingContext` which we can obtain, via Render Props, from `MediaPlayerContextWrapper`.
+These require a `trackingContext` which we can obtained, via Render Props, from `MediaPlayerContextWrapper`.
 

--- a/docs/docs/tracking/react/how-to-guides/tracking-interactions.md
+++ b/docs/docs/tracking/react/how-to-guides/tracking-interactions.md
@@ -54,7 +54,7 @@ import { TrackedButton, TrackedPressableContext } from '@objectiv/tracker-react'
 ### Link
 Links are interactive elements that cause a change in the current URL. Thus, we'd like to track the destination href.
 
-```typescript jsx
+```jsx
 // A link tag 
 <a href="/somewhere">Go!</a>
 

--- a/docs/docs/tracking/react/introduction.md
+++ b/docs/docs/tracking/react/introduction.md
@@ -18,6 +18,7 @@ To immediately jump into instrumenting your application, follow the step-by-step
 - [Getting Started](/tracking/react/how-to-guides/getting-started.md)
 - [Tracking Interactions](/tracking/react/how-to-guides/tracking-interactions.md)
 - [Tracking Locations](/tracking/react/how-to-guides/tracking-locations.md)
+- [Custom Components](/tracking/react/how-to-guides/custom-components.md)
 
 ## API Reference 
 - [React SDK API Reference](/tracking/react/api-reference/overview.md)


### PR DESCRIPTION
In this PR I'm updating ReactTracker Components documentation (as in definitions, parameters and examples) to show how to use Render Props and when to do so. 

Added Render Props examples to:
- ContentContextWrapper
- ExpandableContextWrapper
- InputContextWrapper
- LinkContextWrapper
- LocationContextWrapper
- MediaPlayerContextWrapper
- NavigationContextWrapper
- OverlayContextWrapper
- PressableContextWrapper
- RootLocationContextWrapper


Added links to usage examples to:

- trackApplicationLoadedEvent.md
- trackFailureEvent.md
- trackHiddenEvent.md
- trackInputChangeEvent.md
- trackMediaLoadEvent.md
- trackMediaPauseEvent.md
- trackMediaStartEvent.md
- trackMediaStopEvent.md
- trackPressEvent.md
- trackSuccessEvent.md
- trackVisibility.md
- trackVisibleEvent.md

Added how-to:
- Custom Components