### PR TITLE
Fix issue building on Windows

### DIFF
--- a/docs/docs/tracking/react/how-to-guides/custom-components.md
+++ b/docs/docs/tracking/react/how-to-guides/custom-components.md
@@ -2,9 +2,9 @@
 sidebar_position: 5
 ---
 
-import useBaseUrl from '@docusaurus/useBaseUrl';
-
 # Custom Components
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
 
 Our [previous how-to-guide](/tracking/react/how-to-guides/tracking-locations.md) explained how to enrich Locations by using [Tracked Contexts](/tracking/react/api-reference/trackedContexts/overview.md) and [Tracked Elements](/tracking/react/api-reference/trackedElements/overview.md).
 

--- a/docs/docs/tracking/react/how-to-guides/tracking-locations.md
+++ b/docs/docs/tracking/react/how-to-guides/tracking-locations.md
@@ -2,9 +2,9 @@
 sidebar_position: 4
 ---
 
-import useBaseUrl from '@docusaurus/useBaseUrl';
-
 # Tracking Locations
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
 
 ## Collisions
 If you started [instrumenting your Interactions](/tracking/react/how-to-guides/tracking-interactions.md), chances are you already ran into some Collisions.


### PR DESCRIPTION
If an `import` in an `md` file is done before the title, the sidebar menu doesn't render the correct title, when making a build on Windows. This works fine on a Linux system.