### PR TITLE
WIP: fix issues with Vimeo video player & cookiebot

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -59,7 +59,7 @@ const config = {
     {
       src: 'https://consent.cookiebot.com/uc.js?cbid=7498452c-872b-431a-9859-21045f83f0a0',
       'data-cbid': '7498452c-872b-431a-9859-21045f83f0a0',
-      'data-blockingmode': 'auto',
+      'data-blockingmode': 'manual',
       id: 'Cookiebot'
     },
   ],

--- a/src/components/video-player/index.js
+++ b/src/components/video-player/index.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import ReactPlayer from "react-player";
+import ReactPlayer from "react-player/vimeo";
 import {
   MediaPlayerContextWrapper,
   trackMediaLoadEvent,
@@ -16,25 +16,27 @@ function VideoPlayer({
   id,
   enableControls = true
 }) {
-  const [isPlaying, setPlaying] = useState(false);
-
-  function handlePlayPause() {
-    setPlaying(!isPlaying);
-  }
-
   return (
     <MediaPlayerContextWrapper id={id}>
       {(trackingContext) => (
         <>
           <ReactPlayer
             url={url}
-            playing={isPlaying}
+            config={{
+              vimeo: {
+                dnt: false,
+                playerOptions: {
+                  dnt: false
+                }
+              }
+            }}
             controls={enableControls}
             onReady={() => trackMediaLoadEvent(trackingContext)}
             onStart={() => trackMediaStartEvent(trackingContext)}
             onPause={() => trackMediaPauseEvent(trackingContext)}
             onEnded={() => trackMediaStopEvent(trackingContext)}
             className={clsx(styles.videoWrapper)} 
+            data-cookieconsent="ignore" 
           />
         </>
       )}


### PR DESCRIPTION
Attempt to fix the issues with the Vimeo player being blocked by cookiebot:
- [ReactPlayer components docs](https://www.npmjs.com/package/react-player).
- [Vimeo Player options](https://vimeo.zendesk.com/hc/en-us/articles/360001494447-Using-Player-Parameters).
- [User with the same issue](https://support.cookiebot.com/hc/en-us/community/posts/360006739100-Issue-Vimeo-playback-blocked-but-no-Cookies-detected).
- [And why, explained by cookiebot](https://support.cookiebot.com/hc/en-us/articles/360009063100-Automatic-Cookie-Blocking-How-does-it-work-).
- [How to disable autoblocking for a specific script](https://support.cookiebot.com/hc/en-us/articles/360009063660-Disable-automatic-cookie-blocking-for-a-specific-script).

Unfortunately I cannot reproduce the issue on production locally.