### PR TITLE
Upgrade blog components to Docusaurus beta15

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "@docusaurus/core": "^2.0.0-beta.15",
     "@docusaurus/preset-classic": "^2.0.0-beta.15",
-    "@docusaurus/theme-classic": "^2.0.0-beta.15",
     "@mdx-js/react": "^1.6.22",
     "@objectiv/tracker-react": "^0.0.7",
     "@u-wave/react-vimeo": "^0.9.5",

--- a/src/theme/BlogListPaginator/index.tsx
+++ b/src/theme/BlogListPaginator/index.tsx
@@ -7,10 +7,10 @@
 
 import React from 'react';
 import Translate, {translate} from '@docusaurus/Translate';
+import PaginatorNavLink from '@theme/PaginatorNavLink';
 import type {Props} from '@theme/BlogListPaginator';
 
 import { TrackedNav } from "@objectiv/tracker-react";
-import { TrackedLink } from "../../trackedComponents/TrackedLink";
 
 function BlogListPaginator(props: Props): JSX.Element {
   const {metadata} = props;
@@ -26,34 +26,30 @@ function BlogListPaginator(props: Props): JSX.Element {
       })}>
       <div className="pagination-nav__item">
         {previousPage && (
-          <TrackedLink 
-            to={previousPage}
-            className="pagination-nav__link">
-            <div className="pagination-nav__label">
-              &laquo;{' '}
+          <PaginatorNavLink
+            permalink={previousPage}
+            title={
               <Translate
                 id="theme.blog.paginator.newerEntries"
                 description="The label used to navigate to the newer blog posts page (previous page)">
                 Newer Entries
               </Translate>
-            </div>
-          </TrackedLink>
+            }
+          />
         )}
       </div>
       <div className="pagination-nav__item pagination-nav__item--next">
         {nextPage && (
-          <TrackedLink 
-            to={nextPage}
-            className="pagination-nav__link">
-            <div className="pagination-nav__label">
+          <PaginatorNavLink
+            permalink={nextPage}
+            title={
               <Translate
                 id="theme.blog.paginator.olderEntries"
                 description="The label used to navigate to the older blog posts page (next page)">
                 Older Entries
-              </Translate>{' '}
-              &raquo;
-            </div>
-          </TrackedLink>
+              </Translate>
+            }
+          />
         )}
       </div>
     </TrackedNav>

--- a/src/theme/BlogPostAuthor/index.tsx
+++ b/src/theme/BlogPostAuthor/index.tsx
@@ -32,7 +32,7 @@ function BlogPostAuthor({author}: Props): JSX.Element {
             itemScope
             itemType="https://schema.org/Person">
             <TrackedDiv id={'avatar-name'} className="avatar__name">
-              <TrackedLink href={url} itemProp="url">
+              <TrackedLink href={url} itemProp="url" id={title} waitUntilTracked={true}>
                 <span itemProp="name">{name}</span>
               </TrackedLink>
             </TrackedDiv>

--- a/src/theme/BlogPostAuthor/index.tsx
+++ b/src/theme/BlogPostAuthor/index.tsx
@@ -18,13 +18,13 @@ function BlogPostAuthor({author}: Props): JSX.Element {
   return (
     <TrackedDiv id={'avatar'} className="avatar margin-bottom--sm">
       {imageURL && (
-        <TrackedLink className="avatar__photo-link avatar__photo" href={url} id={title} waitUntilTracked={true}>
+        <TrackedLink id={name} className="avatar__photo-link avatar__photo" href={url}>
           <img className={styles.image} src={imageURL} alt={name} />
         </TrackedLink>
       )}
 
       {
-        // Note: only legacy author frontmatter allow empty name (not frontMatter.authors)
+        // Note: only legacy author front matter allow empty name (not frontMatter.authors)
         name && (
           <div
             className="avatar__intro"
@@ -32,7 +32,7 @@ function BlogPostAuthor({author}: Props): JSX.Element {
             itemScope
             itemType="https://schema.org/Person">
             <TrackedDiv id={'avatar-name'} className="avatar__name">
-              <TrackedLink href={url} itemProp="url" id={title} waitUntilTracked={true}>
+              <TrackedLink href={url} itemProp="url">
                 <span itemProp="name">{name}</span>
               </TrackedLink>
             </TrackedDiv>

--- a/src/theme/BlogPostItem/index.tsx
+++ b/src/theme/BlogPostItem/index.tsx
@@ -12,6 +12,7 @@ import {MDXProvider} from '@mdx-js/react';
 import Translate, {translate} from '@docusaurus/Translate';
 import {useBaseUrlUtils} from '@docusaurus/useBaseUrl';
 import {usePluralForm} from '@docusaurus/theme-common';
+import {blogPostContainerID} from '@docusaurus/utils-common';
 import MDXComponents from '@theme/MDXComponents';
 import EditThisPage from '@theme/EditThisPage';
 import type {Props} from '@theme/BlogPostItem';
@@ -77,17 +78,25 @@ function BlogPostItem(props: Props): JSX.Element {
   const image = assets.image ?? frontMatter.image;
   const truncatedPost = !isBlogPostPage && truncated;
   const tagsExists = tags.length > 0;
+  const TitleHeading = isBlogPostPage ? 'h1' : 'h2';
 
-  const renderPostHeader = () => {
-    const TitleHeading = isBlogPostPage ? 'h1' : 'h2';
-
-    return (
+  return (
+    <TrackedContentContext 
+      Component={'article'} 
+      id={`post-${makeIdFromString(title)}`}
+      className={!isBlogPostPage ? 'margin-bottom--xl' : undefined}
+      itemProp="blogPost"
+      itemScope
+      itemType="http://schema.org/BlogPosting">
       <TrackedHeader>
         <TitleHeading className={styles.blogPostTitle} itemProp="headline">
           {isBlogPostPage ? (
             title
           ) : (
-            <TrackedLink itemProp="url" to={permalink}>
+            <TrackedLink 
+              id={`post-${makeIdFromString(title)}`}  
+              itemProp="url" 
+              to={permalink}>
               {title}
             </TrackedLink>
           )}
@@ -106,25 +115,16 @@ function BlogPostItem(props: Props): JSX.Element {
         </div>
         <BlogPostAuthors authors={authors} assets={assets} />
       </TrackedHeader>
-    );
-  };
-
-  return (
-    <TrackedContentContext 
-      Component={'article'} 
-      id={`post-${makeIdFromString(title)}`}
-      className={!isBlogPostPage ? 'margin-bottom--xl' : undefined}
-      itemProp="blogPost"
-      itemScope
-      itemType="http://schema.org/BlogPosting">
-
-      {renderPostHeader()}
 
       {image && (
         <meta itemProp="image" content={withBaseUrl(image, {absolute: true})} />
       )}
 
-      <div className="markdown" itemProp="articleBody">
+      <div
+        // This ID is used for the feed generation to locate the main content
+        id={isBlogPostPage ? blogPostContainerID : undefined}
+        className="markdown"
+        itemProp="articleBody">
         <MDXProvider components={MDXComponents}>{children}</MDXProvider>
       </div>
 

--- a/src/theme/BlogPostItem/index.tsx
+++ b/src/theme/BlogPostItem/index.tsx
@@ -94,7 +94,6 @@ function BlogPostItem(props: Props): JSX.Element {
             title
           ) : (
             <TrackedLink 
-              id={`post-${makeIdFromString(title)}`}  
               itemProp="url" 
               to={permalink}>
               {title}

--- a/src/theme/BlogPostItem/styles.module.css
+++ b/src/theme/BlogPostItem/styles.module.css
@@ -11,7 +11,6 @@
 
 .blogPostData {
   font-size: 0.9rem;
-  margin-bottom: -0.5rem !important;
 }
 
 .blogPostDetailsFull {

--- a/src/theme/BlogPostPaginator/index.tsx
+++ b/src/theme/BlogPostPaginator/index.tsx
@@ -7,16 +7,16 @@
 
 import React from 'react';
 import Translate, {translate} from '@docusaurus/Translate';
+import PaginatorNavLink from '@theme/PaginatorNavLink';
 import type {Props} from '@theme/BlogPostPaginator';
 
 import { TrackedNav } from "@objectiv/tracker-react";
-import { TrackedLink } from "../../trackedComponents/TrackedLink";
 
 function BlogPostPaginator(props: Props): JSX.Element {
   const {nextItem, prevItem} = props;
 
   return (
-    <TrackedNav 
+    <TrackedNav
       id={'blog-post-paginator'}
       className="pagination-nav docusaurus-mt-lg"
       aria-label={translate({
@@ -26,34 +26,30 @@ function BlogPostPaginator(props: Props): JSX.Element {
       })}>
       <div className="pagination-nav__item">
         {prevItem && (
-          <TrackedLink className="pagination-nav__link" to={prevItem.permalink}>
-            <div className="pagination-nav__sublabel">
+          <PaginatorNavLink
+            {...prevItem}
+            subLabel={
               <Translate
                 id="theme.blog.post.paginator.newerPost"
                 description="The blog post button label to navigate to the newer/previous post">
                 Newer Post
               </Translate>
-            </div>
-            <div className="pagination-nav__label">
-              &laquo; {prevItem.title}
-            </div>
-          </TrackedLink>
+            }
+          />
         )}
       </div>
       <div className="pagination-nav__item pagination-nav__item--next">
         {nextItem && (
-          <TrackedLink className="pagination-nav__link" to={nextItem.permalink}>
-            <div className="pagination-nav__sublabel">
+          <PaginatorNavLink
+            {...nextItem}
+            subLabel={
               <Translate
                 id="theme.blog.post.paginator.olderPost"
                 description="The blog post button label to navigate to the older/next post">
                 Older Post
               </Translate>
-            </div>
-            <div className="pagination-nav__label">
-              {nextItem.title} &raquo;
-            </div>
-          </TrackedLink>
+            }
+          />
         )}
       </div>
     </TrackedNav>

--- a/src/theme/PaginatorNavLink/index.tsx
+++ b/src/theme/PaginatorNavLink/index.tsx
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import type {Props} from '@theme/PaginatorNavLink';
+
+import { TrackedLink } from "../../trackedComponents/TrackedLink";
+
+function PaginatorNavLink(props: Props): JSX.Element {
+  const {permalink, title, subLabel} = props;
+  return (
+    <TrackedLink className="pagination-nav__link" to={permalink}>
+      {subLabel && <div className="pagination-nav__sublabel">{subLabel}</div>}
+      <div className="pagination-nav__label">{title}</div>
+    </TrackedLink>
+  );
+}
+
+export default PaginatorNavLink;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2162,7 +2162,7 @@
     "@types/react" "*"
     prop-types "^15.6.2"
 
-"@docusaurus/theme-classic@2.0.0-beta.15", "@docusaurus/theme-classic@^2.0.0-beta.15":
+"@docusaurus/theme-classic@2.0.0-beta.15":
   version "2.0.0-beta.15"
   resolved "https://registry.yarnpkg.com/@docusaurus/theme-classic/-/theme-classic-2.0.0-beta.15.tgz#35d04232f2d5fcb2007675339b0e6d0e8681be95"
   integrity sha512-WwNRcQvMtQ7KDhOEHFKFHxXCdoZwLg66hT3vhqNIFMfGQuPzOP91MX5LUSo1QWHhlrD3H3Og+r7Ik/fy2bf5lQ==


### PR DESCRIPTION
- Upgrade blog components to Docusaurus beta15. Only some internal refactoring by Docusaurus, nothing that was broken.
- Remove `theme-classic` dependency, as it's already imported by the `preset-classic` dependency.