### PR TITLE
Use absolute URL for og:image

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -86,7 +86,7 @@ const config = {
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
     metadata: [{
-      property: 'og:image', content: 'img/open-graph/objectiv-og-large.png'
+      property: 'og:image', content: 'https://objectiv.io/img/open-graph/objectiv-og-large.png'
     }],
     colorMode: {
       disableSwitch: true,


### PR DESCRIPTION
Should fix Twitter cards having an empty image for the main website:
![image](https://user-images.githubusercontent.com/920184/152157812-6652085e-695b-4c04-bfee-be4a3e65e038.png)
