### PR TITLE
Add og:image to docs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -79,6 +79,9 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      metadata: [{
+        property: 'og:image', content: 'https://objectiv.io/img/open-graph/objectiv-og-large.png'
+      }],
       navbar: {
         title: '',
         logo: {


### PR DESCRIPTION
Just like on the main website, add the og:image tag to the docs.