### PR TITLE
Fix Mermaid graphs not rendering without cookie consent

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -62,7 +62,7 @@ const config = {
     {
       src: 'https://consent.cookiebot.com/uc.js?cbid=7498452c-872b-431a-9859-21045f83f0a0',
       'data-cbid': '7498452c-872b-431a-9859-21045f83f0a0',
-      'data-blockingmode': 'auto',
+      'data-blockingmode': 'manual',
       id: 'Cookiebot'
     },
   ],

--- a/docs/src/theme/Mermaid/index.tsx
+++ b/docs/src/theme/Mermaid/index.tsx
@@ -13,6 +13,7 @@ mermaid.initialize({
     curve:'cardinal',
     useMaxWidth: true,
   },
+  dataCookieConsent: 'ignore',
   theme: 'base', 
   themeCSS: `
     .node rect { 
@@ -62,7 +63,7 @@ const Mermaid = ({ chart, caption, baseColor, links}) => {
 
 	return (
     <div className={"diagram-"+baseColor}>
-      <div className="mermaid">{chart}</div>
+      <div className="mermaid" data-cookieconsent="ignore">{chart}</div>
       <p className="diagram-caption">{caption}</p>
     </div>
   );


### PR DESCRIPTION
Reported in https://github.com/objectiv/objectiv.io/issues/277. Cookiebot is blocking Mermaid graphs from loading, even though it doesn't set cookies. 

Issue can be reproduced on production, but not in dev mode, nor on staging.

This potential (since we can't reproduce locally) fix:
- Sets Cookiebot's blocking mode to manual. We don't use anything that sets cookies other than our own tracking, so this should be fine.
- Adds `data-cookieconsent="ignore"` to the element containing the graph, although most likely that doesn't do anything.