### PR TITLE
Fix docusaurus links from modeling to outside modeling

### DIFF
--- a/docs/docs/modeling/intro.mdx
+++ b/docs/docs/modeling/intro.mdx
@@ -2,7 +2,7 @@
 id: intro
 title: Introduction — Bach  documentation
 hide_title: true
-slug: /modeling
+slug: /modeling/
 sidebar_label: Introduction
 
 ---

--- a/docs/src/components/sphinx-page/index.tsx
+++ b/docs/src/components/sphinx-page/index.tsx
@@ -124,7 +124,8 @@ const SphinxPage = (props) => {
                 });
 
                 // get base from window.location, should be something like https://objectiv.io, or http://localhost:3000
-                const currentSite = window.location.toString().match(/^(http[s]?:\/\/[a-z0-9.:]+\/).*?$/);
+                const currentLocation = window.location.toString();
+                const currentSite = currentLocation.match(/^(http[s]?:\/\/[a-z0-9.:]+\/).*?$/);
 
                 // fix anchors (remove .html) and fix path
                 Object.values(tempDiv.getElementsByTagName('a')).forEach( a => {
@@ -136,9 +137,14 @@ const SphinxPage = (props) => {
 
                     if ( isInternal ){
                         // fix the hrefs in the overview/index page in case of missing trailing slash
-                        if ( a.href.indexOf('modeling') == -1 && window.location.toString().slice(-1) != '/' ){
+                        // but only if we're toplevel, eg.
+                        // https://$currentSite/.../modeling and there's no modeling in a.href
+                        if ( a.href.indexOf('modeling') == -1
+                            && currentLocation.endsWith('modeling')
+                            && currentLocation.slice(-1) != '/' ){
                             // we add the baseURL to the match, to make sure it works in dev and prod mode
                             const regex = `^(http[s]?://[a-z0-9:.]+${baseUrl.baseUrl})(.*?)$`.replace('\\', '\\\/');
+                            const old = a.href;
                             a.href = a.href.replace(new RegExp(regex), '$1modeling/$2');
                         }
 

--- a/docs/src/components/sphinx-page/index.tsx
+++ b/docs/src/components/sphinx-page/index.tsx
@@ -139,9 +139,7 @@ const SphinxPage = (props) => {
                         // fix the hrefs in the overview/index page in case of missing trailing slash
                         // but only if we're toplevel, eg.
                         // https://$currentSite/.../modeling and there's no modeling in a.href
-                        if ( a.href.indexOf('modeling') == -1
-                            && currentLocation.endsWith('modeling')
-                            && currentLocation.slice(-1) != '/' ){
+                        if ( a.href.indexOf('modeling') == -1 && currentLocation.endsWith('modeling')){
                             // we add the baseURL to the match, to make sure it works in dev and prod mode
                             const regex = `^(http[s]?://[a-z0-9:.]+${baseUrl.baseUrl})(.*?)$`.replace('\\', '\\\/');
                             const old = a.href;

--- a/docs/src/components/sphinx-page/index.tsx
+++ b/docs/src/components/sphinx-page/index.tsx
@@ -123,16 +123,22 @@ const SphinxPage = (props) => {
                     }
                 });
 
+                const extractDomain = (url) => {
+                    return url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?([^.\/]+\.[^.\/]+).*$/, "$1");
+                }
                 // get base from window.location, should be something like https://objectiv.io, or http://localhost:3000
                 const currentLocation = window.location.toString();
                 const currentSite = currentLocation.match(/^(http[s]?:\/\/[a-z0-9.:]+\/).*?$/);
+                const currentDomain = extractDomain(currentLocation);
 
                 // fix anchors (remove .html) and fix path
                 Object.values(tempDiv.getElementsByTagName('a')).forEach( a => {
 
                     // a link is internal if the first part matches the current location,
+                    // or the tld's match (staging vs production
                     // or if it's a relative URL
-                    const isInternal = ((currentSite[1] !== undefined && a.href.startsWith(currentSite[1])) ||
+                    const isInternal = ( (currentSite[1] !== undefined && a.href.startsWith(currentSite[1])) ||
+                        currentDomain == extractDomain(a.href) ||
                         !a.href.startsWith('http'));
 
                     if ( isInternal ){


### PR DESCRIPTION
- add trailing slash to slug for introduction/index
- make sure to only insert "modeling" in a.href if window .location ends with modeling without a trailing slash