### PR TITLE
Category first link selection in sidebar

### DIFF
--- a/docs/src/theme/DocSidebarItem/index.tsx
+++ b/docs/src/theme/DocSidebarItem/index.tsx
@@ -158,7 +158,7 @@ function DocSidebarItemCategory({
                 onItemClick?.(item);
               }
           }
-          href={collapsible ? firstCategoryLink : undefined}
+          href={item.type !== 'category' && collapsible ? firstCategoryLink : undefined}
           {...props}>
           {label}
         </Link>

--- a/docs/src/theme/DocSidebarItem/index.tsx
+++ b/docs/src/theme/DocSidebarItem/index.tsx
@@ -35,6 +35,7 @@ import {
 } from "@objectiv/tracker-browser";
 
 import styles from './styles.module.css';
+import { useHistory } from "react-router-dom";
 
 export default function DocSidebarItem({
   item,
@@ -118,6 +119,8 @@ function DocSidebarItemCategory({
     setCollapsed,
     autoCollapseSidebarCategories,
   ]);
+  let history = useHistory();
+
 
   return (
     <li
@@ -152,6 +155,10 @@ function DocSidebarItemCategory({
                 onItemClick?.(item);
                 if(!collapsed && isActive) {
                   e.preventDefault();
+                }
+                // OBJECTIV: auto-select the first item in the category if it's a link
+                if (items && items.length > 0 && items[0].type == 'link') {
+                  history.push(items[0].href)
                 }
                 updateCollapsed();
               } : () => {

--- a/docs/src/theme/DocSidebarItem/index.tsx
+++ b/docs/src/theme/DocSidebarItem/index.tsx
@@ -154,8 +154,7 @@ function DocSidebarItemCategory({
                   e.preventDefault();
                 }
                 updateCollapsed();
-              }
-              : () => {
+              } : () => {
                 onItemClick?.(item);
               }
           }


### PR DESCRIPTION
This is a draft to restore automatically selecting the first child item when a sidebar category is opened. 

This behavior is native to Docusaurus but only in SSR, we actually want this to happen all the time, especially for the modeling section, where the TOC resides in the sidebar itself.

Currently there are duplicated HREFs in the sidebar and this throws off the whole algorithm and, I believe, also Algolia.

For example the DataFrame Reference and DataFrame Reference Overview are identical:
![Screen Shot 2022-02-03 at 15 15 19](https://user-images.githubusercontent.com/567826/152360060-b06e6008-ae02-4ed5-bfe1-07fb9562473d.png)

In a normal Docusaurus sidebar DataFrame Reference would be a category (eg /reference, instead of #reference).

This prevents Docusaurus from understanding which section is selected and thus break the highlighting and selection of those items.

Seems also that, in general, hashtags are not supported for selection in the sidebar, so /DataFrame#reference is the same item as /DataFrame 


Perhaps a trick we could use is to avoid using hashes for these "fake" sub-categories

Eg: 
/DataFrame.reference instead of /DataFrame#reference

