### PR TITLE
Tracker docs updates

### DIFF
--- a/docs/docs/tracking/angular/how-to-guides/getting-started.md
+++ b/docs/docs/tracking/angular/how-to-guides/getting-started.md
@@ -37,7 +37,7 @@ import { ObjectivTrackerModule } from '@objectiv/tracker-angular';
     ...
     ObjectivTrackerModule.forRoot({
       applicationId: 'app-id',
-      endpoint: 'https://collector.application.dev'
+      endpoint: 'https://collector.app.dev'
     })
   ],
   ...

--- a/docs/docs/tracking/angular/how-to-guides/tagging-locations.md
+++ b/docs/docs/tracking/angular/how-to-guides/tagging-locations.md
@@ -24,11 +24,6 @@ Anything that the user can interact with, but does not cause a URL change, can b
 <img [tagPressable]="{ id: 'button-3' }" src="/img/ok.png" alt="OK!" />
 ```
 
-:::info WIP
-Currently it's necessary to specify `text` manually. We are working on improvements to make this easier.
-:::
-
-
 ### Links
 Links are interactive elements that cause, directly or indirectly, a change in the current URL.
 
@@ -38,7 +33,7 @@ Links are interactive elements that cause, directly or indirectly, a change in t
 ```
 
 :::info WIP
-Currently it's necessary to specify `text` and `href` manually. We are working on improvements to make this easier.
+Currently it's necessary to specify `href` manually. We are working on improvements to make this easier.
 :::
 
 

--- a/docs/docs/tracking/browser/api-reference/core/CoreFactories.md
+++ b/docs/docs/tracking/browser/api-reference/core/CoreFactories.md
@@ -44,7 +44,6 @@ makeItemContext = (props: {
 ```typescript
 makeLinkContext = (props: { 
   id: string, 
-  text: string, 
   href: string 
 }) => LinkContext
 ```
@@ -69,8 +68,7 @@ makeOverlayContext = (props: {
 
 ```typescript
 makePressableContext = (props: { 
-  id: string, 
-  text: string 
+  id: string 
 }) => PressableEvent
 ```
 

--- a/docs/docs/tracking/browser/api-reference/general/BrowserTracker.md
+++ b/docs/docs/tracking/browser/api-reference/general/BrowserTracker.md
@@ -49,7 +49,11 @@ Browser Tracker comes preconfigured with the following plugins:
 To get an idea of how much Browser Tracker automates under the hood, this statement:
 
 ```typescript
- const tracker = new BrowserTracker({ applicationId: 'app-id', endpoint: '/endpoint', console: console });
+ const tracker = new BrowserTracker({ 
+  applicationId: 'app-id', 
+  endpoint: 'https://collector.app.dev', 
+  console: console
+});
 ``` 
 
 is equivalent to:
@@ -58,8 +62,8 @@ is equivalent to:
  
  const trackerId = trackerConfig.trackerId ?? trackerConfig.applicationId;
  const console = trackerConfig.console;
- const fetch = new FetchAPITransport({ endpoint: '/endpoint', console });
- const xmlHttpRequest = new XMLHttpRequestTransport({ endpoint: '/endpoint', console });
+ const fetch = new FetchAPITransport({ endpoint: 'https://collector.app.dev', console });
+ const xmlHttpRequest = new XMLHttpRequestTransport({ endpoint: 'https://collector.app.dev', console });
  const transportSwitch = new TransportSwitch({ transports: [fetch, xmlHttpRequest], console });
  const transport = new RetryTransport({ transport: transportSwitch, console });
  const queueStorage = new TrackerQueueLocalStorageStore({ trackerId, console })

--- a/docs/docs/tracking/browser/api-reference/general/makeTracker.md
+++ b/docs/docs/tracking/browser/api-reference/general/makeTracker.md
@@ -50,7 +50,7 @@ import { makeTracker } from '@objectiv/tracker-browser';
 ```jsx
 makeTracker({
   applicationId: 'awesome-app',
-  endpoint: 'https://collector.awesome-app.dev' 
+  endpoint: 'https://collector.app.dev' 
 })
 ```
 

--- a/docs/docs/tracking/browser/api-reference/transports/FetchAPITransport.md
+++ b/docs/docs/tracking/browser/api-reference/transports/FetchAPITransport.md
@@ -14,7 +14,7 @@ import {
   FetchAPITransport 
 } from '@objectiv/tracker-browser';
 
-const COLLECTOR_ENDPOINT = 'https://collector.application.dev';
+const COLLECTOR_ENDPOINT = 'https://collector.app.dev';
 
 // Create a simple factory to make a custom FetchAPITransport with our customFetchParameters.  
 const makeCustomFetchAPITransport = ({ endpoint: string }) => new FetchAPITransport({

--- a/docs/docs/tracking/browser/api-reference/transports/XMLHttpRequestTransport.md
+++ b/docs/docs/tracking/browser/api-reference/transports/XMLHttpRequestTransport.md
@@ -10,7 +10,7 @@ In the following example we swap the default XMLHttpRequest implementation with 
 ```typescript
 import { XMLHttpRequestTransport } from '@objectiv/tracker-browser';
 
-const COLLECTOR_ENDPOINT = 'https://collector.application.dev';
+const COLLECTOR_ENDPOINT = 'https://collector.app.dev';
 
 // Create a simple factory to make a custom XMLHttpRequestTransport with our custom xmlHttpRequestFunction
 const makeCustomXMLHttpRequestTransport = ({ endpoint: string }) => new XMLHttpRequestTransport({

--- a/docs/docs/tracking/browser/how-to-guides/getting-started.md
+++ b/docs/docs/tracking/browser/how-to-guides/getting-started.md
@@ -32,7 +32,7 @@ import { makeTracker } from "@objectiv/tracker-browser";
 
 makeTracker({
   applicationId: 'app-id',
-  endpoint: 'https://collector.application.dev'
+  endpoint: 'https://collector.app.dev'
 });
 
 ReactDOM.render(
@@ -54,7 +54,7 @@ const App = () => {
     () => {
       makeTracker({
         applicationId: 'app-id',
-        endpoint: 'https://collector.application.dev'
+        endpoint: 'https://collector.app.dev'
       });
     },
     [] // no dependencies => no side effects on re-render

--- a/docs/docs/tracking/browser/how-to-guides/tagging-locations.md
+++ b/docs/docs/tracking/browser/how-to-guides/tagging-locations.md
@@ -30,11 +30,6 @@ Anything that the user can interact with, but does not cause a URL change, can b
 <img {...tagPressable({ id: 'button-3' })} src="/img/ok.png" alt="OK!" />
 ```
 
-:::info WIP
-Currently it's necessary to specify `text` manually. We are working on improvements to make this easier.
-:::
-
-
 ### Links
 Links are interactive elements that cause, directly or indirectly, a change in the current URL.
 
@@ -47,7 +42,7 @@ Links are interactive elements that cause, directly or indirectly, a change in t
 ```
 
 :::info WIP
-Currently it's necessary to specify `text` and `href` manually. We are working on improvements to make this 
+Currently it's necessary to specify `href` manually. We are working on improvements to make this 
 easier.
 :::
 

--- a/docs/docs/tracking/core-concepts/angular/validation.md
+++ b/docs/docs/tracking/core-concepts/angular/validation.md
@@ -44,7 +44,7 @@ Logging can be enabled in two ways:
 ```js
 ObjectivTrackerModule.forRoot({
   applicationId: 'app-id',
-  endpoint: 'https://collector.application.dev',
+  endpoint: 'https://collector.app.dev',
   console: console
 })
 ```

--- a/docs/docs/tracking/core-concepts/browser/validation.md
+++ b/docs/docs/tracking/core-concepts/browser/validation.md
@@ -44,7 +44,7 @@ Logging can be enabled in two ways:
 ```js
 makeTracker({
   applicationId: 'app-id',
-  endpoint: 'https://collector.application.dev',
+  endpoint: 'https://collector.app.dev',
   console: console
 })
 ```

--- a/docs/docs/tracking/react/api-reference/ReactTracker.md
+++ b/docs/docs/tracking/react/api-reference/ReactTracker.md
@@ -17,7 +17,7 @@ import { ObjectivProvider, ReactTracker } from '@objectiv/tracker-react';
 const App = ({children}) => {
 
   const tracker = new ReactTracker({
-    endpoint: '/collector',
+    endpoint: 'https://collector.app.dev',
     applicationId: 'app-id'
   })
 
@@ -78,7 +78,7 @@ To get an idea of how much React Tracker automates under the hood, compared to t
 ```typescript
 const tracker = new ReactTracker({ 
   applicationId: 'app-id', 
-  endpoint: '/endpoint', 
+  endpoint: 'https://collector.app.dev', 
   console: console
 });
 ``` 
@@ -89,8 +89,8 @@ is equivalent to:
  
 const trackerId = trackerConfig.trackerId ?? trackerConfig.applicationId;
 const console = trackerConfig.console;
-const fetch = new FetchAPITransport({ endpoint: '/endpoint', console });
-const xmlHttpRequest = new XMLHttpRequestTransport({ endpoint: '/endpoint', console });
+const fetch = new FetchAPITransport({ endpoint: 'https://collector.app.dev', console });
+const xmlHttpRequest = new XMLHttpRequestTransport({ endpoint: 'https://collector.app.dev', console });
 const transportSwitch = new TransportSwitch({ transports: [fetch, xmlHttpRequest], console });
 const transport = new RetryTransport({ transport: transportSwitch, console });
 const queueStorage = new TrackerQueueLocalStorageStore({ trackerId, console })

--- a/docs/docs/tracking/react/api-reference/common/providers/ObjectivProvider.md
+++ b/docs/docs/tracking/react/api-reference/common/providers/ObjectivProvider.md
@@ -35,7 +35,7 @@ import { ObjectivProvider, ReactTracker } from "@objectiv/tracker-react";
 const App = ({children}) => {
 
   const tracker = new ReactTracker({
-    endpoint: '/collector',
+    endpoint: 'https://collector.app.dev',
     applicationId: 'app-id'
   })
 

--- a/docs/docs/tracking/react/api-reference/eventTrackers/trackApplicationLoadedEvent.md
+++ b/docs/docs/tracking/react/api-reference/eventTrackers/trackApplicationLoadedEvent.md
@@ -47,7 +47,7 @@ import { useOnMount } from "@objectiv/tracker-react";
 
 const App = ({ children }) => {
   const tracker = new ReactTracker({
-    endpoint: '/collector',
+    endpoint: 'https://collector.app.dev',
     applicationId: 'app-id'
   })
 

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedContentContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedContentContext.md
@@ -44,6 +44,15 @@ import { TrackedContentContext } from '@objectiv/tracker-react';
 </TrackedContentContext>
 ```
 
+:::caution Props forwarding
+All `TrackedContext` components support props forwarding, 
+
+Whenever a `TrackedContext` requires one or more props that may overlap with the given `Component`, props forwarding allows the
+developer to specify which ones are needed by `Component` as well.
+
+For an actual example, check [TrackedLinkContext](/tracking/react/api-reference/trackedContexts/TrackedLinkContext.md#components) usage.
+:::
+
 <br />
 
 :::tip Did you know ?

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedExpandableContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedExpandableContext.md
@@ -30,7 +30,7 @@ TrackedExpandableContext: (props: {
 - [VisibleEvent](/taxonomy/reference/events/VisibleEvent.md) when `isVisible` switches from `false` to `true`.
 
 :::caution
-The `isVisible` state of a TrackedExpandableContext at mount is ignored. Only actual changes and tracked.
+The `isVisible` state of a TrackedExpandableContext is ignored on mount. Only actual changes and tracked.
 :::
 
 ## Usage example
@@ -44,6 +44,15 @@ import { TrackedExpandableContext } from '@objectiv/tracker-react';
   ...
 </TrackedExpandableContext>
 ```
+
+:::caution Props forwarding
+All `TrackedContext` components support props forwarding,
+
+Whenever a `TrackedContext` requires one or more props that may overlap with the given `Component`, props forwarding allows the
+developer to specify which ones are needed by `Component` as well.
+
+For an actual example, check [TrackedLinkContext](/tracking/react/api-reference/trackedContexts/TrackedLinkContext.md#components) usage.
+:::
 
 <br />
 

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedInputContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedInputContext.md
@@ -35,6 +35,15 @@ import { TrackedInputContext } from '@objectiv/tracker-react';
 <TrackedInputContext Component={'input'} type={'email'} id={'email'} />
 ```
 
+:::caution Props forwarding
+All `TrackedContext` components support props forwarding,
+
+Whenever a `TrackedContext` requires one or more props that may overlap with the given `Component`, props forwarding allows the
+developer to specify which ones are needed by `Component` as well.
+
+For an actual example, check [TrackedLinkContext](/tracking/react/api-reference/trackedContexts/TrackedLinkContext.md#components) usage.
+:::
+
 <br />
 
 :::tip Did you know ?

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedLinkContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedLinkContext.md
@@ -37,6 +37,8 @@ TrackedLinkContext: (props: {
 
 ## Usage example
 
+### Elements
+
 ```jsx
 import { TrackedLinkContext } from '@objectiv/tracker-react';
 ```
@@ -46,7 +48,7 @@ import { TrackedLinkContext } from '@objectiv/tracker-react';
   Privacy
 </TrackedLinkContext>
 
-// Whenever inferring 'id' is not possible, due to children not having any text, a `title` can be specified
+// Whenever inferring 'id' is not possible, eg: children without text, a `title` can be specified
 <TrackedLinkContext Component={'a'} href={'/privacy'} title={'privacy'}>
   <img src="/lock.jpg"/>
 </TrackedLinkContext>
@@ -56,6 +58,42 @@ import { TrackedLinkContext } from '@objectiv/tracker-react';
   <img src="/lock.jpg"/>
 </TrackedLinkContext>
 ```
+
+### Components
+
+Here is an example of an actual [TrackedLink component](https://github.com/objectiv/objectiv.io/blob/main/src/trackedComponents/TrackedLink.tsx) we use on our Docusaurus based website.
+
+```jsx
+import { TrackedLinkContext } from '@objectiv/tracker-react';
+```
+
+```tsx
+type TrackedLinkProps = Omit<TrackedLinkContextProps, 'Component' | 'href'> & LinkProps;
+ 
+const TrackedLink = React.forwardRef<HTMLAnchorElement, TrackedLinkProps>(
+  (props, ref) => (
+    <TrackedLinkContext
+      Component={Link} 
+      {...props}
+      href={props.href ?? props.to}
+      forwardHref={!!props.href}
+      ref={ref}
+    />
+  )
+)
+```
+
+:::caution Props forwarding
+Interesting to note in the example above is the `forwardHref` prop. 
+Without it, the resulting wrapped component would not receive the `href` prop, most likely resulting in a TypeScript error or crash.
+
+**Overlapping props**  
+`TrackedLinkContext` requires a set of props that may overlap with the given `Component` but it cannot know which one automatically.  
+
+Props forwarding allows the developer to tell `TrackedLinkContext` which of the overlapping props must be forwarded to `Component` as well. These forwarders exist for most properties that are likely to collide like `id`, `href` and `title`.
+
+By setting `forwardHref` to `true` we are telling `TrackedLinkContext` to forward the `href` value to the given Link component as well.
+:::
 
 <br />
 

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedMediaPlayerContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedMediaPlayerContext.md
@@ -35,6 +35,15 @@ import { TrackedMediaPlayerContext } from '@objectiv/tracker-react';
 <TrackedMediaPlayerContext Component={'video'} id={'content'} />
 ```
 
+:::caution Props forwarding
+All `TrackedContext` components support props forwarding,
+
+Whenever a `TrackedContext` requires one or more props that may overlap with the given `Component`, props forwarding allows the
+developer to specify which ones are needed by `Component` as well.
+
+For an actual example, check [TrackedLinkContext](/tracking/react/api-reference/trackedContexts/TrackedLinkContext.md#components) usage.
+:::
+
 <br />
 
 :::tip Did you know ?

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedNavigationContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedNavigationContext.md
@@ -39,6 +39,15 @@ import { TrackedNavigationContext } from '@objectiv/tracker-react';
 </TrackedNavigationContext>
 ```
 
+:::caution Props forwarding
+All `TrackedContext` components support props forwarding,
+
+Whenever a `TrackedContext` requires one or more props that may overlap with the given `Component`, props forwarding allows the
+developer to specify which ones are needed by `Component` as well.
+
+For an actual example, check [TrackedLinkContext](/tracking/react/api-reference/trackedContexts/TrackedLinkContext.md#components) usage.
+:::
+
 <br />
 
 :::tip Did you know ?

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedOverlayContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedOverlayContext.md
@@ -28,7 +28,7 @@ TrackedOverlayContext: (props: {
 - [VisibleEvent](/taxonomy/reference/events/VisibleEvent.md) when `isVisible` switches from `false` to `true`.
 
 :::caution
-The `isVisible` state of a TrackedOverlayContext at mount is ignored. Only actual changes and tracked.
+The `isVisible` state of a TrackedOverlayContext is ignored on mount. Only actual changes and tracked.
 :::
 
 
@@ -46,6 +46,15 @@ import { TrackedOverlayContext } from '@objectiv/tracker-react';
   ...
 </TrackedOverlayContext>
 ```
+
+:::caution Props forwarding
+All `TrackedContext` components support props forwarding,
+
+Whenever a `TrackedContext` requires one or more props that may overlap with the given `Component`, props forwarding allows the
+developer to specify which ones are needed by `Component` as well.
+
+For an actual example, check [TrackedLinkContext](/tracking/react/api-reference/trackedContexts/TrackedLinkContext.md#components) usage.
+:::
 
 <br />
 

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedPressableContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedPressableContext.md
@@ -53,6 +53,15 @@ import { TrackedPressableContext } from '@objectiv/tracker-react';
 </TrackedPressableContext>
 ```
 
+:::caution Props forwarding
+All `TrackedContext` components support props forwarding,
+
+Whenever a `TrackedContext` requires one or more props that may overlap with the given `Component`, props forwarding allows the
+developer to specify which ones are needed by `Component` as well.
+
+For an actual example, check [TrackedLinkContext](/tracking/react/api-reference/trackedContexts/TrackedLinkContext.md#components) usage.
+:::
+
 <br />
 
 :::tip Did you know ?

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedRootLocationContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedRootLocationContext.md
@@ -39,6 +39,15 @@ import { TrackedRootLocationContext } from '@objectiv/tracker-react';
 </TrackedRootLocationContext>
 ```
 
+:::caution Props forwarding
+All `TrackedContext` components support props forwarding,
+
+Whenever a `TrackedContext` requires one or more props that may overlap with the given `Component`, props forwarding allows the
+developer to specify which ones are needed by `Component` as well.
+
+For an actual example, check [TrackedLinkContext](/tracking/react/api-reference/trackedContexts/TrackedLinkContext.md#components) usage.
+:::
+
 <br />
 
 :::tip Did you know ?

--- a/docs/docs/tracking/react/how-to-guides/getting-started.md
+++ b/docs/docs/tracking/react/how-to-guides/getting-started.md
@@ -28,7 +28,7 @@ import { ObjectivProvider, ReactTracker } from '@objectiv/tracker-react';
 const App = ({children}) => {
 
   const tracker = new ReactTracker({
-    endpoint: 'collector-url',
+    endpoint: 'https://collector.app.dev',
     applicationId: 'app-id'
   })
 
@@ -86,7 +86,7 @@ import { ObjectivProvider, ReactTracker } from '@objectiv/tracker-react';
 ```tsx
 makeTracker({
   applicationId: 'app-id',
-  endpoint: 'https://collector.application.dev'
+  endpoint: 'https://collector.app.dev'
 });
 
 ReactDOM.render(

--- a/docs/docs/tracking/react/how-to-guides/tracking-interactions.md
+++ b/docs/docs/tracking/react/how-to-guides/tracking-interactions.md
@@ -62,59 +62,37 @@ Links are interactive elements that cause a change in the current URL. Thus, we'
 <Link to="/cart">Back</Link>
 ```
 
-This is how they can be tracked using React Tracker tracked components.
+Regular anchors can be tracked using [TrackedAnchor](/tracking/react/api-reference/trackedElements/TrackedAnchor.md) tracked components.
 
 ```ts
-import { TrackedAnchor, TrackedLinkContext } from '@objectiv/tracker-react';
+import { TrackedAnchor} from '@objectiv/tracker-react';
 ```
-
 ```tsx
-// A anchor tag can be tracked by simply swapping the anchor Element tag with TrackedAnchor 
 <TrackedAnchor href="/somewhere">Go!</TrackedAnchor>
-
-// Link can be swapped with a TrackedLinkContext with the addition of an extra `href` property   
-<TrackedLinkContext Component={Link} href="/cart" to="/cart">Do It!</TrackedLinkContext>
 ```
 
-:::tip
-We highly recommend moving TrackedContext based Components to their own modules for re-usability.   
+Similarly, Components can be wrapped in a LinkContext using [TrackedLinkContext](/tracking/react/api-reference/trackedContexts/TrackedLinkContext.md)
 
-Here is a real example we made for Docusaurus Links:
+```ts
+import { TrackedLinkContext } from '@objectiv/tracker-react';
+```
 
 ```tsx
-import Link, { LinkProps } from "@docusaurus/Link";
-import { TrackedLinkContext, TrackedLinkContextProps } from "@objectiv/tracker-react";
-import React from 'react';
-
-export type TrackedLinkProps = Omit<TrackedLinkContextProps, 'Component' | 'href'> & LinkProps;
-
-export const TrackedLink = React.forwardRef<HTMLAnchorElement, TrackedLinkProps>(
-  (props, ref) => (
-    <TrackedLinkContext 
-      Component={Link} {...props} 
-      href={props.href ?? props.to} 
-      forwardHref={!!props.href} 
-      ref={ref}
-    />
-  )
-)
+<TrackedLinkContext 
+  Component={Link} 
+  href="/cart" 
+  forwardHref={true} 
+  to="/cart"
+>
+  Do It!
+</TrackedLinkContext>
 ```
 
-Now instead of:
-```tsx
-<TrackedLinkContext Component={Link} href="/cart" to="/cart">Do It!</TrackedLinkContext>
-```
-
-We can simply use:
-```tsx
-<TrackedLink to="/cart">Do It!</TrackedLink>
-
-// or
-
-<TrackedLink href="/cart">Do It!</TrackedLink>
-
-```
+:::tip see also
+Wrapping Components in TrackedContexts requires a little more care that regular Elements.   
+Check out the [API Reference of TrackedLinkContext](/tracking/react/api-reference/trackedContexts/TrackedLinkContext.md#components) for a more detailed usage example, where we explain also what props forwarding does. 
 :::
+
 
 ### External Links
 All Pressable may lead users to an external website and the Tracker may not have had the time to track those PressEvents.


### PR DESCRIPTION
- Updated taggers documentation to not mention deprecated `text` attribute.
- Updated tracker examples to use actual URLs for `endpoint` prop.
- Added documentation and examples around props forwarding for TrackedContexts.