### PR TITLE
Tracking Docs: Make exempli gratia consistent everywhere

### DIFF
--- a/docs/docs/tracking/angular/how-to-guides/portals.md
+++ b/docs/docs/tracking/angular/how-to-guides/portals.md
@@ -3,7 +3,7 @@ sidebar_position: 3
 ---
 
 # Portals and options.parent 
-If the LocationStack is missing some elements, although they have been correctly tagged, the most likely cause is the use of [Portal-like](https://material.angular.io/cdk/portal/overview) methods to render their contents. Eg: they render part of their templates in an arbitrary location of the DOM.
+If the LocationStack is missing some elements, although they have been correctly tagged, the most likely cause is the use of [Portal-like](https://material.angular.io/cdk/portal/overview) methods to render their contents, e.g. they render part of their templates in an arbitrary location of the DOM.
 
 Because the Tracker follows the DOM upwards, to reconstruct where an Interaction occurred, this will lead to incorrect Locations.
 

--- a/docs/docs/tracking/angular/how-to-guides/troubleshooting.md
+++ b/docs/docs/tracking/angular/how-to-guides/troubleshooting.md
@@ -14,7 +14,7 @@ Sometimes the browser console will show a warning about  colliding elements, e.g
 The [Core Concepts section explains Collisions and how to solve them](/tracking/core-concepts/locations.md#solving-collisions).
 
 ## Problem: Incorrect Location Stack
-If the LocationStack is missing some elements, although they have been correctly tagged, the most likely cause is the use of [Portal-like](https://material.angular.io/cdk/portal/overview) methods to render their contents. Eg: they render part of their templates in an arbitrary location of the DOM.
+If the LocationStack is missing some elements, although they have been correctly tagged, the most likely cause is the use of [Portal-like](https://material.angular.io/cdk/portal/overview) methods to render their contents, e.g. they render part of their templates in an arbitrary location of the DOM.
 
 Because the Tracker follows the DOM upwards, to reconstruct where an Interaction occurred, this will lead to incorrect Locations.
 

--- a/docs/docs/tracking/browser/api-reference/core/TrackerPlugin.md
+++ b/docs/docs/tracking/browser/api-reference/core/TrackerPlugin.md
@@ -18,7 +18,7 @@ Used for logging messages and, in general, to uniquely identify this plugin.
 ```typescript
 isUsable(): boolean
 ```
-Should return if the TrackerPlugin can be used. Eg: a browser based plugin may want to return `false` during SSR.
+Should return if the TrackerPlugin can be used, e.g. a browser based plugin may want to return `false` during SSR.
 
 ## Lifecycle
 Plugins may implement lifecycle methods. These receive as parameter the Tracker's contexts.

--- a/docs/docs/tracking/browser/api-reference/core/TrackerTransport.md
+++ b/docs/docs/tracking/browser/api-reference/core/TrackerTransport.md
@@ -59,7 +59,7 @@ new TrackerTransportGroup({
 ### TrackerTransportSwitch
 Forwards received TransportableEvents to the first of its usable Transports.
 
-This allows to implement preference logic between similar Transports. Eg. Fetch and XMLHttpRequest.
+This allows to implement preference logic between similar Transports, e.g. Fetch and XMLHttpRequest.
 
 ```typescript
 new TrackerTransportSwitch({

--- a/docs/docs/tracking/browser/api-reference/definitions/TagLocationOptions.md
+++ b/docs/docs/tracking/browser/api-reference/definitions/TagLocationOptions.md
@@ -124,6 +124,6 @@ Used to configure client-side validation.
 
 
 ### options.validate.locationUniqueness
-Sometimes the same piece of UI can have mutually exclusive variants. Eg: a menu switching to its mobile version via CSS.
+Sometimes the same piece of UI can have mutually exclusive variants, e.g. a menu switching to its mobile version via CSS.
 
 In those cases uniqueness checking can be disabled setting `validate.locationUniqueness` to false.

--- a/docs/docs/tracking/browser/api-reference/definitions/TaggingAttribute.md
+++ b/docs/docs/tracking/browser/api-reference/definitions/TaggingAttribute.md
@@ -21,7 +21,7 @@ A unique identifier used internally to pinpoint a specific [Tagged Element](/tra
 A serialized [Location Context](/taxonomy/reference/location-contexts/overview.md) instance.
 
 ### TaggingAttribute.parentElementId
-Rebuilding [Locations](/tracking/core-concepts/locations.md) via the DOM is not always accurate (eg: [React Portals](https://reactjs.org/docs/portals.html)). This allows specifying a parent [Tagged Element](/tracking/core-concepts/browser/tagging.md#tagged-elements).
+Rebuilding [Locations](/tracking/core-concepts/locations.md) via the DOM is not always accurate (e.g. [React Portals](https://reactjs.org/docs/portals.html)). This allows specifying a parent [Tagged Element](/tracking/core-concepts/browser/tagging.md#tagged-elements).
 
 ### TaggingAttribute.trackClicks
 Whether to attach [Event Listeners](https://developer.mozilla.org/en-US/docs/Web/API/EventListener) to the [Tagged Element](/tracking/core-concepts/browser/tagging.md#tagged-elements) to automatically trigger [trackPressEvent](/tracking/browser/api-reference/eventTrackers/trackPressEvent.md) on [click](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).

--- a/docs/docs/tracking/browser/how-to-guides/configuring-root-locations.md
+++ b/docs/docs/tracking/browser/how-to-guides/configuring-root-locations.md
@@ -140,7 +140,7 @@ RootLocationContext is obligatory in all LocationStacks.
 
 There are several ways to track them without RootLocationContextFromURLPlugin:
 - Wrap logical pages in [RootLocationContextWrapper](/tracking/react/api-reference/locationWrappers/RootLocationContextWrapper.md).
-- Enrich root Elements or Components with [TrackedRootLocation](/tracking/react/api-reference/trackedContexts/TrackedRootLocationContext.md). Eg: a Layout Component.
+- Enrich root Elements or Components with [TrackedRootLocation](/tracking/react/api-reference/trackedContexts/TrackedRootLocationContext.md), e.g. a Layout Component.
 - Write your own Plugin and leverage your internal state or non-url based routing system.
 
 And if you are unsure which to pick or how to begin, please let us know. We love a challenge.

--- a/docs/docs/tracking/react/api-reference/common/providers/TrackingContextProvider.md
+++ b/docs/docs/tracking/react/api-reference/common/providers/TrackingContextProvider.md
@@ -15,7 +15,7 @@ Under normal circumstances there's no need to use this context, since [ObjectivP
 
 The main use case for adding another TrackingContextProvider is to reconfigure or swap the ReactTracker instance with a new one and/or to initialize the LocationStack for a branch of Components. 
 
-This may be necessary for utilizing different configurations, eg: for privacy reasons. 
+This may be necessary for utilizing different configurations, e.g. for privacy reasons. 
 :::
 
 ## Parameters

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedLinkContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedLinkContext.md
@@ -48,7 +48,7 @@ import { TrackedLinkContext } from '@objectiv/tracker-react';
   Privacy
 </TrackedLinkContext>
 
-// Whenever inferring 'id' is not possible, eg: children without text, a `title` can be specified
+// Whenever inferring 'id' is not possible, e.g. children without text, a `title` can be specified
 <TrackedLinkContext Component={'a'} href={'/privacy'} title={'privacy'}>
   <img src="/lock.jpg"/>
 </TrackedLinkContext>

--- a/docs/docs/tracking/react/how-to-guides/configuring-root-locations.md
+++ b/docs/docs/tracking/react/how-to-guides/configuring-root-locations.md
@@ -140,7 +140,7 @@ RootLocationContext is obligatory in all LocationStacks.
 
 There are several ways to track them without RootLocationContextFromURLPlugin:
 - Wrap logical pages in [RootLocationContextWrapper](/tracking/react/api-reference/locationWrappers/RootLocationContextWrapper.md).
-- Enrich root Elements or Components with [TrackedRootLocation](/tracking/react/api-reference/trackedContexts/TrackedRootLocationContext.md). Eg: a Layout Component.
+- Enrich root Elements or Components with [TrackedRootLocation](/tracking/react/api-reference/trackedContexts/TrackedRootLocationContext.md), e.g. a Layout Component.
 - Write your own Plugin and leverage your internal state or non-url based routing system.
 
 And if you are unsure which to pick or how to begin, please let us know. We love a challenge.


### PR DESCRIPTION
In several places we used `.Eg:` or `, eg:`. This PR makes all of them `, e.g.`.