### PR TITLE
Update License year to 2022

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 Objectiv B.V.
+   Copyright 2022 Objectiv B.V.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Sets the year for the copyright notice in the License file to 2022.