### PR TITLE
Open external top nav links in same tab

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -128,6 +128,7 @@ const config = {
           label: 'GitHub',
           position: 'right',
           className: 'navItem navGitHub',
+          target: '_self',
           waitUntilTracked: true
         },
         {
@@ -135,6 +136,7 @@ const config = {
           label: 'Slack',
           position: 'right',
           className: 'navItem navSlack',
+          target: '_self',
           waitUntilTracked: true
         },
         {
@@ -142,6 +144,7 @@ const config = {
           label: 'Twitter',
           position: 'right',
           className: 'navItem navTwitter',
+          target: '_self',
           waitUntilTracked: true
         },
         {
@@ -149,6 +152,7 @@ const config = {
           label: 'Contact Us',
           position: 'right',
           className: 'navItem navEmail',
+          target: '_self',
           waitUntilTracked: true
         },
       ],


### PR DESCRIPTION
Opens the external links in the top nav in the same tab.

Should fix an issue with these links not opening on iOS Safari browsers.