### PR TITLE
Use base URL for all docs links

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -137,7 +137,7 @@ export default function Home() {
               <div className={clsx(styles.outro)}>
                 <p>To learn more about the open analytics taxonomy, check out the Docs.</p>
                 <TrackedLink
-                  to={url + "/docs/taxonomy/"}
+                  to={useBaseUrl("/docs/taxonomy/", {absolute: true})}
                   autoAddBaseUrl={true}
                   waitUntilTracked={true}
                   target="_self"
@@ -248,7 +248,7 @@ export default function Home() {
               <div className={clsx(styles.outro)}>
                 <p>For an overview of all available pre-built models, check out the Docs.</p>
                 <TrackedLink
-                  to={url + "/docs/modeling/Objectiv/bach_open_taxonomy.ModelHub"}
+                  to={useBaseUrl("/docs/modeling/Objectiv/bach_open_taxonomy.ModelHub", {absolute: true})}
                   autoAddBaseUrl={true}
                   waitUntilTracked={true}
                   target="_self"
@@ -275,7 +275,7 @@ export default function Home() {
               <p className={clsx(styles.quickStartOutro)}>Follow the <strong>Quickstart Guide</strong> to 
               locally run the full Objectiv pipeline dockerized.</p>
               <TrackedLink
-                to={url + "/docs/home/quickstart-guide/"}
+                to={useBaseUrl("/docs/home/quickstart-guide/", {absolute: true})}
                 autoAddBaseUrl={true}
                 waitUntilTracked={true}
                 target="_self"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -139,7 +139,6 @@ export default function Home() {
                 <p>To learn more about the open analytics taxonomy, check out the Docs.</p>
                 <TrackedLink
                   to={useBaseUrl("/docs/taxonomy/", {absolute: true})}
-                  autoAddBaseUrl={true}
                   waitUntilTracked={true}
                   target="_self"
                   className={clsx("button", styles.ctaButton)}
@@ -250,7 +249,6 @@ export default function Home() {
                 <p>For an overview of all available pre-built models, check out the Docs.</p>
                 <TrackedLink
                   to={useBaseUrl("/docs/modeling/Objectiv/bach_open_taxonomy.ModelHub", {absolute: true})}
-                  autoAddBaseUrl={true}
                   waitUntilTracked={true}
                   target="_self"
                   className={clsx("button", styles.ctaButton)}
@@ -277,7 +275,6 @@ export default function Home() {
               locally run the full Objectiv pipeline dockerized.</p>
               <TrackedLink
                 to={useBaseUrl("/docs/home/quickstart-guide/", {absolute: true})}
-                autoAddBaseUrl={true}
                 waitUntilTracked={true}
                 target="_self"
                 className={clsx("button", styles.ctaButton)}

--- a/src/pages/jobs.tsx
+++ b/src/pages/jobs.tsx
@@ -50,7 +50,6 @@ export default function Jobs() {
                 </TrackedLink>,&nbsp;
                 <TrackedLink
                   to={useBaseUrl("/docs/", {absolute: true})}
-                  autoAddBaseUrl={true}
                   waitUntilTracked={true}
                   target="_self"
                 >
@@ -72,7 +71,6 @@ export default function Jobs() {
             <p>The key part of the project that is directly used by data scientists, is the&nbsp;
               <TrackedLink
                 to={useBaseUrl("/docs/modeling/", {absolute: true})}
-                autoAddBaseUrl={true}
                 waitUntilTracked={true}
                 target="_self"
               >
@@ -81,7 +79,6 @@ export default function Jobs() {
               This is a collection of pre-built models that can run out of the box on data collected using the&nbsp;
               <TrackedLink
                 to={useBaseUrl("/docs/taxonomy/", {absolute: true})}
-                autoAddBaseUrl={true}
                 waitUntilTracked={true}
                 target="_self"
               >

--- a/src/pages/jobs.tsx
+++ b/src/pages/jobs.tsx
@@ -70,11 +70,21 @@ export default function Jobs() {
 
             <h2><img width="32px" src='/img/icons/icon-cap.svg' alt='The team' /> The role</h2>
             <p>The key part of the project that is directly used by data scientists, is the&nbsp;
-              <TrackedLink to={useBaseUrl("/docs/modeling/", {absolute: true})}>
+              <TrackedLink
+                to={useBaseUrl("/docs/modeling/", {absolute: true})}
+                autoAddBaseUrl={true}
+                waitUntilTracked={true}
+                target="_self"
+              >
                 open model hub
               </TrackedLink>.
               This is a collection of pre-built models that can run out of the box on data collected using the&nbsp;
-              <TrackedLink to={useBaseUrl("/docs/taxonomy/", {absolute: true})}>
+              <TrackedLink
+                to={useBaseUrl("/docs/taxonomy/", {absolute: true})}
+                autoAddBaseUrl={true}
+                waitUntilTracked={true}
+                target="_self"
+              >
                 open analytics taxonomy
               </TrackedLink>.
               </p>

--- a/src/pages/jobs.tsx
+++ b/src/pages/jobs.tsx
@@ -1,3 +1,4 @@
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import { TrackedDiv } from "@objectiv/tracker-react";
 import React from 'react';
 import clsx from 'clsx';
@@ -48,7 +49,7 @@ export default function Jobs() {
                   site
                 </TrackedLink>,&nbsp;
                 <TrackedLink
-                  to={url + "/docs/"}
+                  to={useBaseUrl("/docs/", {absolute: true})}
                   autoAddBaseUrl={true}
                   waitUntilTracked={true}
                   target="_self"
@@ -69,11 +70,11 @@ export default function Jobs() {
 
             <h2><img width="32px" src='/img/icons/icon-cap.svg' alt='The team' /> The role</h2>
             <p>The key part of the project that is directly used by data scientists, is the&nbsp;
-              <TrackedLink to={'https://objectiv.io/docs/modeling/'}>
+              <TrackedLink to={useBaseUrl("/docs/modeling/", {absolute: true})}>
                 open model hub
               </TrackedLink>.
               This is a collection of pre-built models that can run out of the box on data collected using the&nbsp;
-              <TrackedLink to={'https://objectiv.io/docs/taxonomy/'}>
+              <TrackedLink to={useBaseUrl("/docs/taxonomy/", {absolute: true})}>
                 open analytics taxonomy
               </TrackedLink>.
               </p>

--- a/src/theme/BlogPostItem/index.tsx
+++ b/src/theme/BlogPostItem/index.tsx
@@ -136,12 +136,21 @@ function BlogPostItem(props: Props): JSX.Element {
             more data stores and make it easier to integrate with your existing stack. We also want to expand 
             the selection of models that's included.</p>
           <p>
-            <TrackedLink to={withBaseUrl("/docs/home/quickstart-guide/", {absolute: true})}>Quickstart Guide</TrackedLink> - Try 
-              Objectiv on your local machine (takes 5 minutes)<br />
-            <TrackedLink to="https://github.com/objectiv/objectiv-analytics">Objectiv on Github</TrackedLink> 
-              &nbsp;- Check out the project and star us for future reference<br />
-            <TrackedLink to={slackJoinLink as string}>Objectiv on Slack</TrackedLink> - Join the discussion 
-              or get help
+            <TrackedLink 
+              to={withBaseUrl("/docs/home/quickstart-guide/", {absolute: true})}
+              target="_self">
+                Quickstart Guide
+            </TrackedLink> - Try Objectiv on your local machine (takes 5 minutes)<br />
+            <TrackedLink 
+              to="https://github.com/objectiv/objectiv-analytics"
+              target="_self">
+                Objectiv on Github
+              </TrackedLink> - Check out the project and star us for future reference<br />
+            <TrackedLink 
+              to={slackJoinLink as string}
+              target="_self">
+                Objectiv on Slack
+            </TrackedLink> - Join the discussion or get help
           </p>
         </TrackedDiv>
       )}

--- a/src/theme/BlogPostItem/index.tsx
+++ b/src/theme/BlogPostItem/index.tsx
@@ -136,7 +136,7 @@ function BlogPostItem(props: Props): JSX.Element {
             more data stores and make it easier to integrate with your existing stack. We also want to expand 
             the selection of models that's included.</p>
           <p>
-            <TrackedLink to="https://objectiv.io/docs/home/quickstart-guide/">Quickstart Guide</TrackedLink> - Try 
+            <TrackedLink to={withBaseUrl("/docs/home/quickstart-guide/", {absolute: true})}>Quickstart Guide</TrackedLink> - Try 
               Objectiv on your local machine (takes 5 minutes)<br />
             <TrackedLink to="https://github.com/objectiv/objectiv-analytics">Objectiv on Github</TrackedLink> 
               &nbsp;- Check out the project and star us for future reference<br />


### PR DESCRIPTION
Use absolute URLs for all /docs links on the site, so they can also be automatically checked with the `broken-link-checker`. Also changes a few to open in the same tab, to prevent any potentials issues with iOS Safari.

Testing done:
- On staging, all links still work on both desktop and mobile (tested on Chrome only).
- Tracking events are still sent.
- Deliberately breaking all 7 adjusted links are now all actually detected by the `broken-link-checker`.
![image](https://user-images.githubusercontent.com/920184/154657851-42644856-63e3-43ff-b108-1e17e666cdb3.png)
(8 instead of 7 because one is repeated in two blog posts)
![image](https://user-images.githubusercontent.com/920184/154658266-8d80e46e-ce77-48e3-9f6d-e03a28cbb4f4.png)
![image](https://user-images.githubusercontent.com/920184/154658283-c55d0e58-1794-4083-bf16-3cb69f44cacf.png)
![image](https://user-images.githubusercontent.com/920184/154658314-a8c557df-41be-4870-ad2e-4fd946bea5e2.png)
![image](https://user-images.githubusercontent.com/920184/154658359-aec50e0f-126e-4ce4-a087-79a9df781d21.png)
