### PR TITLE
'Join Slack' page

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -7,7 +7,7 @@ const objectivEnvironment = process.env.OBJECTIV_ENVIRONMENT ?? 'development';
 const getEnvConfig = require('../env_config.js');
 const envConfig = getEnvConfig(objectivEnvironment);
 
-const slackJoinLink = 'https://join.slack.com/t/objectiv-io/shared_invite/zt-u6xma89w-DLDvOB7pQer5QUs5B_~5pg';
+const slackJoinLink = envConfig.websiteUrl + '/join-slack';
 
 const lightCodeTheme = require('prism-react-renderer/themes/github');
 const darkCodeTheme = require('prism-react-renderer/themes/dracula');

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -133,7 +133,7 @@ const config = {
         },
         {
           href: slackJoinLink,
-          label: ' ',
+          label: 'Slack',
           position: 'right',
           className: 'navItem navSlack',
           target: '_self',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,7 +7,7 @@ const objectivEnvironment = process.env.OBJECTIV_ENVIRONMENT ?? 'development';
 const getEnvConfig = require('./env_config.js');
 const envConfig = getEnvConfig(objectivEnvironment);
 
-const slackJoinLink = 'https://join.slack.com/t/objectiv-io/shared_invite/zt-u6xma89w-DLDvOB7pQer5QUs5B_~5pg';
+const slackJoinLink = '/join-slack';
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -133,7 +133,7 @@ const config = {
         },
         {
           href: slackJoinLink,
-          label: 'Slack',
+          label: ' ',
           position: 'right',
           className: 'navItem navSlack',
           target: '_self',

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -109,6 +109,7 @@ body {
   }
   .navbar .navSlack {
     background: url('/img/icons/icon-nav-slack.svg') no-repeat;
+    color: transparent; 
   }
   .navbar .navSlack:hover {
     background: url('/img/icons/icon-nav-slack-hover.svg') no-repeat;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,7 +11,7 @@ import styles from './styles.module.css';
 
 export default function Home() {
   const context = useDocusaurusContext();
-  const {tagline, customFields} = context.siteConfig;
+  const {tagline} = context.siteConfig;
 
   return (
     <div>
@@ -397,13 +397,12 @@ export default function Home() {
               <h2>Objectiv is open-source and we're building it in public.</h2>
               <p>Have opinions on where we should take this or want to stay in the loop?</p>
               <TrackedLink
-                to={customFields.slackJoinLink as string}
-                waitUntilTracked={true}
+                to="/join-slack"
                 className={clsx("button", styles.ctaButton)}
               >
-                  <span><img src={useBaseUrl("img/icons/icon-slack.svg")}  alt={'Join us on Slack'}/></span>
-                  Join us on Slack
-                </TrackedLink>
+                <span><img src={useBaseUrl("img/icons/icon-slack.svg")}  alt={'Join us on Slack'}/></span>
+                Join us on Slack
+              </TrackedLink>
             </TrackedDiv>
           </footer>
 

--- a/src/pages/join-slack/index.tsx
+++ b/src/pages/join-slack/index.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect } from "react";
+import Layout from "@theme/Layout";
+import clsx from "clsx";
+import styles from './styles.module.css';
+import { TrackedLink } from "../../trackedComponents/TrackedLink";
+import { useSuccessEventTracker } from "@objectiv/tracker-react";
+
+export default function JoinSlack() {
+  const slackJoinLink = 
+    'https://join.slack.com/t/objectiv-io/shared_invite/zt-u6xma89w-DLDvOB7pQer5QUs5B_~5pg';
+  const trackSuccessEvent = useSuccessEventTracker({message: 'Redirect to Slack'});
+
+  useEffect(() => {
+    trackSuccessEvent();
+    window.location.href = slackJoinLink;
+  }, []);
+
+  return (
+    <Layout title='Join Slack'>
+      <header className={clsx('hero hero--primary', styles.joinSlackHeader)}>
+        <div className={clsx('container')}>
+          <h1>Join Slack</h1>
+          <p>
+            Redirecting you to our Slack channel...&nbsp;
+            <TrackedLink href={slackJoinLink}>(click here if you don't get redirected)</TrackedLink>
+          </p>
+        </div>
+      </header>
+    </Layout>
+  );
+};

--- a/src/pages/join-slack/styles.module.css
+++ b/src/pages/join-slack/styles.module.css
@@ -1,0 +1,20 @@
+/**************
+ JOIN SLACK PAGE 
+***************/
+.joinSlackHeader {
+  background-color: #FEF284;
+  padding: 100px 0;
+  text-align: center;
+  color: #000;
+}
+
+.joinSlackHeader a {
+  color: #333;
+  text-decoration: underline;
+}
+
+.joinSlackHeader a:hover {
+  color: rgb(100, 100, 100);
+  text-decoration: none;
+}
+


### PR DESCRIPTION
We link in several places to join our Slack channel, via an invite link that is currently https://join.slack.com/t/objectiv-io/shared_invite/zt-u6xma89w-DLDvOB7pQer5QUs5B_~5pg.

Issues with this:
- Though we’ve set this link to never expire, there are [reports](https://www.reddit.com/r/Slack/comments/cmj56t/invite_link_set_to_never_expire_expired/) of that happening anyway.
- The link is used in at least 6 READMEs in our objectiv-analytics repo, which would all have to be updated if the invite expires.
- When it’s linked from anywhere else (e.g. our repo or on a forum) we cannot track that.
- The link doesn’t look very friendly.

This PR contains a PoC for a 'Join Slack' page (which will look like https://objectiv.io/join-slack), which redirects to the Slack invite link. If that link has to change, it only has to change in one place. Added benefits:

- The link looks a lot friendlier.
- We track this, so if it’s linked from somewhere other than our own site (e.g. a repo README or somewhere on a forum), we will also know.
- We can show a nice looking page while Slack is loading. In the future this could also be a different page where we tell more about our community first.

If we like this, we should make a bit of a design for the page (though it's only shown for a second before redirecting), which currently looks like this:
![image](https://user-images.githubusercontent.com/920184/156733593-9b9e8584-a79b-4efd-b711-81e2e60833e9.png)
