### PR TITLE
Update absolute links to our Slack in docs

### DIFF
--- a/docs/docs/home/quickstart-guide.md
+++ b/docs/docs/home/quickstart-guide.md
@@ -5,6 +5,7 @@ title: Quickstart Guide
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import JoinSlackLink from '@site/src/components/join-slack-link';
 
 This quickstart guide will show you how to spin up a fully functional Objectiv demo pipeline. It includes everything you need to test drive Objectiv locally.
 
@@ -72,4 +73,4 @@ To learn more about tracking & modeling with Objectiv, or about the open taxonom
 * [Modeling with Objectiv Bach](/modeling/intro.mdx)
 * [The open analytics taxonomy](/taxonomy/introduction.md)
 
-If you have any questions or feedback, please [join us on Slack](https://join.slack.com/t/objectiv-io/shared_invite/zt-u6xma89w-DLDvOB7pQer5QUs5B_~5pg).
+If you have any questions or feedback, please <JoinSlackLink linkText='join us on Slack' />.

--- a/docs/docs/home/the-project/FAQ.md
+++ b/docs/docs/home/the-project/FAQ.md
@@ -1,10 +1,12 @@
 ---
-title: FAQ
+title: Frequently Asked Questions
 slug: /home/the-project/faq
 sidebar_label: FAQ
 sidebar_position: 1
 ---
 # Frequently Asked Questions
+
+import JoinSlackLink from '@site/src/components/join-slack-link';
 
 ### How is Objectiv different from product analytics tools?
 There is a big gap between what data scientists want their data to look like and what data actually looks like when it comes from the current generation of trackers. 
@@ -110,4 +112,4 @@ Objectiv ultimately wants to monetize with paid offerings to users of the ecosys
 We want to make sure the taxonomy enables collection of data that meets the requirements of the data science community for effective modeling. As such, we will be looking to create a continuous feedback loop with said community to ensure it meets their needs. As widespread adoption is a goal, we will put effort in seeing that it can be used for a wide range of DS use cases.
 
 ### Do you plan to develop a taxonomy for other areas?
-The current version of our taxonomy is built for product analytics. With it, we’ve built a solid foundation that can be used to create taxonomies for other fields, e.g. Payments and CRM. If you’ve got a lot of experience in a particular field and would like to contribute, please [join us on Slack](https://join.slack.com/t/objectiv-io/shared_invite/zt-u6xma89w-DLDvOB7pQer5QUs5B_~5pg).
+The current version of our taxonomy is built for product analytics. With it, we’ve built a solid foundation that can be used to create taxonomies for other fields, e.g. Payments and CRM. If you’ve got a lot of experience in a particular field and would like to contribute, please  <JoinSlackLink linkText='join us on Slack' />.

--- a/docs/docs/home/the-project/contributing.md
+++ b/docs/docs/home/the-project/contributing.md
@@ -6,6 +6,7 @@ sidebar_position: 3
 ---
 
 import Mermaid from '@theme/Mermaid';
+import JoinSlackLink from '@site/src/components/join-slack-link';
 
 First off, thank you for considering to contribute to Objectiv! Please feel welcome - we need volunteer developers like yourself. Community adoption and contribution are critical to Objectiv's success. We're here to help you find things to work on that you're excited about.
 
@@ -27,7 +28,6 @@ To jump straight to what you're looking for, see Objectiv's contribution map bel
     Contribution ----> PR["Create a Pull Request"];
     LabelUpdate["GitHub Label update"] ----> PR["Create a Pull Request"];
     StayUpToDate["Receive Updates"] ----> GitHubReleases["Follow Releases on GitHub"];
-    click PostSlack "https://join.slack.com/t/objectiv-io/shared_invite/zt-u6xma89w-DLDvOB7pQer5QUs5B_~5pg" "Join Objectiv on Slack" _blank;
 `} 
   caption="Figure: How To Contribute" 
   baseColor="basic" 
@@ -38,7 +38,7 @@ To jump straight to what you're looking for, see Objectiv's contribution map bel
     { name: 'GitHubIssue', to: 'https://github.com/objectiv/objectiv-analytics/issues', tooltip: 'Go to GitHub Issues', target: '_blank' },
     { name: 'PR', to: 'https://github.com/objectiv/objectiv-analytics/pulls', tooltip: 'Go to GitHub Pull Requests', target: '_blank' },
     { name: 'GitHubReleases', to: 'https://github.com/objectiv/objectiv-analytics', tooltip: 'Follow Releases on GitHub', target: '_blank' },
-    { name: 'PostSlack', to: 'https://join.slack.com/t/objectiv-io/shared_invite/zt-u6xma89w-DLDvOB7pQer5QUs5B_~5pg', tooltip: 'Join Objectiv on Slack', target: '_blank' }
+    { name: 'PostSlack', to: 'https://objectiv.io/join-slack', tooltip: 'Join Objectiv on Slack', target: '_blank' }
   ]}
 />
 
@@ -58,7 +58,7 @@ We take security issues very seriously. Please do not open up a GitHub issue if 
 
 :::note
 
-Please don't file an issue to ask a question. You'll get faster results by posting it in [Objectiv's Slack channels](https://join.slack.com/t/objectiv-io/shared_invite/zt-u6xma89w-DLDvOB7pQer5QUs5B_~5pg).
+Please don't file an issue to ask a question. You'll get faster results by posting it in <JoinSlackLink linkText="Objectiv's Slack channels" />
 
 :::
 

--- a/docs/docs/home/the-project/get-help.md
+++ b/docs/docs/home/the-project/get-help.md
@@ -5,18 +5,19 @@ sidebar_label: Get Help
 sidebar_position: 2
 ---
 
+import JoinSlackLink from '@site/src/components/join-slack-link';
+
 Looking to get help, found a bug or just have a question? Reporting it at the right place will ensure a quick response from our team:
 
 * If your question is roughly "I've hit this error and am stuck", please ask it in the **Troubleshooting** 
-  channel of our 
-  [Slack community](https://join.slack.com/t/objectiv-io/shared_invite/zt-u6xma89w-DLDvOB7pQer5QUs5B_~5pg).
+  channel of our <JoinSlackLink linkText='Slack community' trackingId='join-slack-troubleshooting' />.
 * If you think you've found a bug, please report it on our 
   [GitHub repo](https://github.com/objectiv/objectiv-analytics/issues). 
 * For security issues, please email [security@objectiv.io](mailto:security@objectiv.io) to avoid publicizing 
   means of exploitation.
 * If you are looking for an opinionated answer (e.g. "What's the best approach to X?", "Why is Y done this 
   way?"), just ask our devs in the **Lobby** channel of our 
-  [Slack community](https://join.slack.com/t/objectiv-io/shared_invite/zt-u6xma89w-DLDvOB7pQer5QUs5B_~5pg).
+  <JoinSlackLink linkText='Slack community' trackingId='join-slack-lobby' />.
 * Got a feature request? Please create an issue on our 
   [GitHub repo](https://github.com/objectiv/objectiv-analytics/issues).
   

--- a/docs/docs/taxonomy/introduction.md
+++ b/docs/docs/taxonomy/introduction.md
@@ -7,6 +7,7 @@ title: Introduction
 # The open analytics taxonomy 
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import JoinSlackLink from '@site/src/components/join-slack-link';
 
 The open analytics taxonomy is [Objectiv's](https://objectiv.io/about/) proposal for a common way to collect, structure, and 
 validate analytics data. Adoption of the open analytics taxonomy enables data & models to be reused and allows data scientists to build on knowledge and practises of others.
@@ -33,5 +34,5 @@ Find out everything about the taxonomy: all Contexts and Events are open and doc
 [Check out the Reference](./reference/overview.md)
 
 :::info join the discussion
-Objectiv and the open analytics taxonomy are open-source and we're building them in public. Have opinions on where we should take this next? [Join us on Slack](https://join.slack.com/t/objectiv-io/shared_invite/zt-u6xma89w-DLDvOB7pQer5QUs5B_~5pg)
+Objectiv and the open analytics taxonomy are open-source and we're building them in public. Have opinions on where we should take this next? <JoinSlackLink linkText='Join us on Slack' />.
 :::

--- a/docs/src/components/join-slack-link/index.tsx
+++ b/docs/src/components/join-slack-link/index.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import Link from '@docusaurus/Link';
+import { tagLink } from '@objectiv/tracker-browser';
+
+export default function JoinSlackLink({linkText='join us on Slack', trackingId='join-slack'}) {
+  const {siteConfig} = useDocusaurusContext();
+  const {slackJoinLink} = siteConfig.customFields;
+
+  return <Link 
+    {...tagLink({id: trackingId, href: slackJoinLink as string}) }
+    to={slackJoinLink as string}>
+      {linkText}
+  </Link>;
+};
+


### PR DESCRIPTION
Changes the links to our Slack page in the docs. 

Introduces a small component, as .md files cannot read site variables in Docusaurus. Side-benefit is that the links are tracked in this component.