### PR TITLE
PoC: search metadata

### DIFF
--- a/docs/docs/tracking/react/introduction.md
+++ b/docs/docs/tracking/react/introduction.md
@@ -5,6 +5,11 @@ title: Introduction
 ---
 # React SDK
 
+import SearchMetadata from '@theme/SearchMetadata';
+
+<SearchMetadata platform="React" />
+<SearchMetadata type="React" />
+
 The React SDK leverages React Context Providers for mapping JSX Elements and Components to the [Open Taxonomy](/taxonomy/introduction.md).
 
 It provides a number of Higher Order [Elements](/tracking/react/api-reference/trackedElements/overview.md), [Components](/tracking/react/api-reference/trackedContexts/overview.md) and [Wrappers](/tracking/react/api-reference/locationWrappers/overview.md) to easily make a regular UI Element into a Tracked one. 

--- a/docs/src/theme/SearchMetadata/index.tsx
+++ b/docs/src/theme/SearchMetadata/index.tsx
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+
+import Head from '@docusaurus/Head';
+import type {Props} from '@theme/SearchMetadata';
+// OBJECTIV
+interface PropsWithType extends Props {
+  type: string;
+  platform: string;
+}
+// END OBJECTIV
+
+// Note: we bias toward using Algolia metadata on purpose
+// Not doing so leads to confusion in the community,
+// as it requires to first crawl the site with the Algolia plugin enabled first
+// - https://github.com/facebook/docusaurus/issues/6693
+// - https://github.com/facebook/docusaurus/issues/4555
+export default function SearchMetadata({
+  locale,
+  version,
+  tag,
+  // OBJECTIV
+  type, // can be used for grouping search results in the future
+  platform // can be used for filtering on the platform type (e.g. 'React') in the future
+  // END OBJECTIV
+}: PropsWithType): JSX.Element {
+  // Seems safe to consider here the locale is the language, as the existing
+  // docsearch:language filter is afaik a regular string-based filter
+  const language = locale;
+
+  return (
+    <Head>
+      {/*
+      Docusaurus metadata, used by third-party search plugin
+      See https://github.com/cmfcmf/docusaurus-search-local/issues/99
+      */}
+      {locale && <meta name="docusaurus_locale" content={locale} />}
+      {version && <meta name="docusaurus_version" content={version} />}
+      {tag && <meta name="docusaurus_tag" content={tag} />}
+
+      {/* Algolia DocSearch metadata */}
+      {language && <meta name="docsearch:language" content={language} />}
+      {version && <meta name="docsearch:version" content={version} />}
+      {tag && <meta name="docsearch:docusaurus_tag" content={tag} />}
+      {/* OBJECTIV */}
+      {type && <meta name="docsearch:type" content={type} />}
+      {platform && <meta name="docsearch:platform" content={platform} />}
+      {/* END OBJECTIV */}
+    </Head>
+  );
+}


### PR DESCRIPTION
PoC to add metadata to certain docs to index with Algolia, and use in search results. Two parameters added:
- `platform`: for example 'React' or 'Angular'. Can be used to group search results, or in the future to filter on.
- `type`: for example 'Guide' or 'Core Concepts'. Can also be used to group search results, e.g. if not related to a specific platform.

Purely for discussion, let's not merge this yet.