### PR TITLE
Docs: Update TrackedHeader and TrackedFooter to match the latest implementation

### DIFF
--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedFooter.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedFooter.md
@@ -1,6 +1,6 @@
 # TrackedFooter
 
-Generates a `<footer>` Element wrapped in a [NavigationContext](/taxonomy/reference/location-contexts/NavigationContext.md) identified as `footer`, unless differently specified. 
+Generates a `<footer>` Element wrapped in a [ContentContext](/taxonomy/reference/location-contexts/ContentContext.md) identified as `footer`, unless differently specified. 
 
 ```tsx
 TrackedFooter: (props: {
@@ -46,7 +46,7 @@ import { TrackedFooter } from '@objectiv/tracker-react';
 <br />
 
 :::tip Did you know ?
-`TrackedFooter` internally uses [TrackedNavigationContext](/tracking/react/api-reference/trackedContexts/TrackedNavigationContext.md).
+`TrackedFooter` internally uses [TrackedContentContext](/tracking/react/api-reference/trackedContexts/TrackedContentContext.md).
 :::
 
 <br />

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedHeader.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedHeader.md
@@ -1,6 +1,6 @@
 # TrackedHeader
 
-Generates a `<header>` Element wrapped in a [NavigationContext](/taxonomy/reference/location-contexts/NavigationContext.md) identified as `header`, unless differently specified. 
+Generates a `<header>` Element wrapped in a [ContentContext](/taxonomy/reference/location-contexts/ContentContext.md) identified as `header`, unless differently specified. 
 
 ```tsx
 TrackedHeader: (props: {
@@ -46,7 +46,7 @@ import { TrackedHeader } from '@objectiv/tracker-react';
 <br />
 
 :::tip Did you know ?
-`TrackedHeader` internally uses [TrackedNavigationContext](/tracking/react/api-reference/trackedContexts/TrackedNavigationContext.md).
+`TrackedHeader` internally uses [TrackedContentContext](/tracking/react/api-reference/trackedContexts/TrackedContentContext.md).
 :::
 
 <br />

--- a/docs/docs/tracking/react/how-to-guides/tracking-locations.md
+++ b/docs/docs/tracking/react/how-to-guides/tracking-locations.md
@@ -32,6 +32,8 @@ Here is a full recap:
 #### ContentContext
 - [TrackedContentContext](/tracking/react/api-reference/trackedContexts/TrackedContentContext.md)
 - [TrackedDiv](/tracking/react/api-reference/trackedElements/TrackedDiv.md)
+- [TrackedFooter](/tracking/react/api-reference/trackedElements/TrackedFooter.md)
+- [TrackedHeader](/tracking/react/api-reference/trackedElements/TrackedHeader.md)
 - [TrackedMain](/tracking/react/api-reference/trackedElements/TrackedMain.md)
 - [TrackedSection](/tracking/react/api-reference/trackedElements/TrackedSection.md)
 
@@ -52,8 +54,6 @@ Here is a full recap:
 #### NavigationContext
 - [TrackedNavigationContext](/tracking/react/api-reference/trackedContexts/TrackedNavigationContext.md)
 - [TrackedNav](/tracking/react/api-reference/trackedElements/TrackedNav.md)
-- [TrackedFooter](/tracking/react/api-reference/trackedElements/TrackedFooter.md)
-- [TrackedHeader](/tracking/react/api-reference/trackedElements/TrackedHeader.md)
 
 #### OverlayContext
 - [TrackedOverlayContext](/tracking/react/api-reference/trackedContexts/TrackedOverlayContext.md)


### PR DESCRIPTION
We switched the wrapping LocationContext of TrackedHeader and TrackedFooter from NavigationContext to ContentContext. We update the documentation pages accordingly.