### PR TITLE
Taxonomy Docs : Update HttpContext documentation

### DIFF
--- a/docs/docs/taxonomy/reference/global-contexts/HttpContext.md
+++ b/docs/docs/taxonomy/reference/global-contexts/HttpContext.md
@@ -27,5 +27,5 @@ import Mermaid from '@theme/Mermaid';
 | remote_address | string | (public) IP address of the agent that sent the event.                                              |
 
 :::info setting of properties
-The tracker will set the referrer and user_agent properties, while the collector will set the remote_address.
+The tracker will automatically set the referrer and user_agent properties, while the collector will automatically set the remote_address.
 :::

--- a/docs/docs/taxonomy/reference/global-contexts/HttpContext.md
+++ b/docs/docs/taxonomy/reference/global-contexts/HttpContext.md
@@ -7,7 +7,7 @@ import Mermaid from '@theme/Mermaid';
 <Mermaid chart={`
 	graph LR
         AbstractContext["AbstractContext<br><span class='properties'>id: string<br />_type: string</span>"] --> AbstractGlobalContext;
-        AbstractGlobalContext --> HttpContext["HttpContext<br><span class='properties'>referrer: string<br>user_agent: string<br>remote_address: string</span>"];
+        AbstractGlobalContext --> HttpContext["HttpContext<br><span class='properties'>referrer: string<br>user_agent: string<br>remote_address?: string</span>"];
     class HttpContext diagramActive;
 `} 
   caption="Diagram: HttpContext inheritance" 
@@ -18,14 +18,14 @@ import Mermaid from '@theme/Mermaid';
 />
 
 ### Properties
-|           | type        | description
-| :--       | :--         | :--           
-| **id**    | string      | Unique string to be combined with the Context Type (`_type`) for Context instance uniqueness.
-| **_type** | string      | String literal used during serialization. Should always match the Context interface name.          
-| **referrer**         | string          | The URL that the browser sets in the referrer header, in the request that loaded the current page.
-| **user_agent**      | string          | User-agent of the agent that sent the event.
-| **remote_address**  | string          | (public) IP address of the agent that sent the event.
+|                | type   | description                                                                                        |
+|:---------------|:-------|:---------------------------------------------------------------------------------------------------|
+| **id**         | string | Unique string to be combined with the Context Type (`_type`) for Context instance uniqueness.      |
+| **_type**      | string | String literal used during serialization. Should always match the Context interface name.          |
+| **referrer**   | string | The URL that the browser sets in the referrer header, in the request that loaded the current page. |
+| **user_agent** | string | User-agent of the agent that sent the event.                                                       |
+| remote_address | string | (public) IP address of the agent that sent the event.                                              |
 
 :::info setting of properties
-The tracker will automatically set all the properties and assign a cookie_id.
+The tracker will set the referrer and user_agent properties, while the collector will set the remote_address.
 :::

--- a/docs/docs/taxonomy/reference/global-contexts/overview.md
+++ b/docs/docs/taxonomy/reference/global-contexts/overview.md
@@ -15,7 +15,7 @@ Global Contexts add general information to an [Event](/taxonomy/reference/events
         AbstractContext["AbstractContext<br><span class='properties'>id: string<br />_type: string</span>"] --> AbstractGlobalContext;
         AbstractGlobalContext --> ApplicationContext;
         AbstractGlobalContext --> CookieIdContext["CookieIdContext<br><span class='properties'>cookie_id: string</span>"];
-        AbstractGlobalContext --> HttpContext["HttpContext<br><span class='properties'>referer: string<br>user_agent: string<br>remote_address: string</span>"];
+        AbstractGlobalContext --> HttpContext["HttpContext<br><span class='properties'>referer: string<br>user_agent: string<br>remote_address?: string</span>"];
         AbstractGlobalContext --> MarketingContext["MarketingContext<br><span class='properties'>source: string<br>medium: string<br>campaign: string<br>term?: string<br>content?: string</span>"];
         AbstractGlobalContext --> PathContext;
         AbstractGlobalContext --> SessionContext["SessionContext<br><span class='properties'>hit_number: integer</span>"];

--- a/docs/docs/tracking/browser/plugins/http-context.md
+++ b/docs/docs/tracking/browser/plugins/http-context.md
@@ -1,6 +1,6 @@
 # HttpContext
 
-[HttpContext](/taxonomy/reference/global-contexts/HttpContext.md) carries information about Referrer and User Agent.
+[HttpContext](/taxonomy/reference/global-contexts/HttpContext.md) carries information about Referrer, User Agent and remote address.
 
 This Plugin automatically retrieves the former from the [Document](https://developer.mozilla.org/en-US/docs/Web/API/Document/referrer) and the latter from the [Navigator](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/userAgent).
 


### PR DESCRIPTION
Since we have the ability of specifying optional attributes now, we made the remote_address of HttpContext optional, as opposed to setting it to an hardcoded value (127.0.0.1). 

This PR updates the documentation diagrams and pages so remote_address is correctly indicated as optional, plus some minor copy fixes.

Corresponding PR with the changes: https://github.com/objectiv/objectiv-analytics/pull/577