### PR TITLE
Use categories in model hub restructure

### DIFF
--- a/docs/docs/modeling/DataFrame.mdx
+++ b/docs/docs/modeling/DataFrame.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame
 
 ---
 <head>
-    <meta name="description" content="A mutable DataFrame representing tabular data in a database and enabling operations on that data." />
-    <meta property="og:description" content="A mutable DataFrame representing tabular data in a database and enabling operations on that data." />
+    <meta name="description" content="DataFrame — Bach  documentation" />
+    <meta property="og:description" content="DataFrame — Bach  documentation" />
 </head>
 
 export const toc = [
@@ -37,55 +37,6 @@ export const toc = [
             {
                 "value": "Database access",
                 "id": "database-access",
-                "children": [],
-                "level": 3
-            }
-        ],
-        "level": 2
-    },
-    {
-        "value": "Reference",
-        "id": "reference",
-        "children": [],
-        "level": 2
-    },
-    {
-        "value": "Reference by function",
-        "id": "reference-by-function",
-        "children": [
-            {
-                "value": "Creation",
-                "id": "creation",
-                "children": [],
-                "level": 3
-            },
-            {
-                "value": "Value accessors",
-                "id": "value-accessors",
-                "children": [],
-                "level": 3
-            },
-            {
-                "value": "Attributes and underlying data",
-                "id": "attributes-and-underlying-data",
-                "children": [],
-                "level": 3
-            },
-            {
-                "value": "Reshaping, indexing, sorting & merging",
-                "id": "reshaping-indexing-sorting-merging",
-                "children": [],
-                "level": 3
-            },
-            {
-                "value": "Aggregation & windowing",
-                "id": "aggregation-windowing",
-                "children": [],
-                "level": 3
-            },
-            {
-                "value": "Computations & descriptive stats",
-                "id": "computations-descriptive-stats",
                 "children": [],
                 "level": 3
             }

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.agg.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.agg.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.agg
 
 ---
 <head>
-    <meta name="description" content="Aggregate using one or more operations over the specified axis." />
-    <meta property="og:description" content="Aggregate using one or more operations over the specified axis." />
+    <meta name="description" content="bach.DataFrame.agg — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.agg — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.aggregate.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.aggregate.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.aggregate
 
 ---
 <head>
-    <meta name="description" content="Alias for " />
-    <meta property="og:description" content="Alias for " />
+    <meta name="description" content="bach.DataFrame.aggregate — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.aggregate — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.all_series.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.all_series.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.all_series
 
 ---
 <head>
-    <meta name="description" content="Get all index and data Series in a dictionary " />
-    <meta property="og:description" content="Get all index and data Series in a dictionary " />
+    <meta name="description" content="bach.DataFrame.all_series — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.all_series — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.append.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.append.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.append
 
 ---
 <head>
-    <meta name="description" content="Append rows of other dataframes to the the caller dataframe. Non-shared columns between dataframes are added to the caller." />
-    <meta property="og:description" content="Append rows of other dataframes to the the caller dataframe. Non-shared columns between dataframes are added to the caller." />
+    <meta name="description" content="bach.DataFrame.append — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.append — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.astype.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.astype.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.astype
 
 ---
 <head>
-    <meta name="description" content="Cast all or some of the data columns to a certain dtype." />
-    <meta property="og:description" content="Cast all or some of the data columns to a certain dtype." />
+    <meta name="description" content="bach.DataFrame.astype — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.astype — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.bfill.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.bfill.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.bfill
 
 ---
 <head>
-    <meta name="description" content="Fill missing values by using the next non-nullable value in each series." />
-    <meta property="og:description" content="Fill missing values by using the next non-nullable value in each series." />
+    <meta name="description" content="bach.DataFrame.bfill — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.bfill — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.copy.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.copy.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.copy
 
 ---
 <head>
-    <meta name="description" content="Return a copy of this DataFrame." />
-    <meta property="og:description" content="Return a copy of this DataFrame." />
+    <meta name="description" content="bach.DataFrame.copy — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.copy — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.count.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.count.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.count
 
 ---
 <head>
-    <meta name="description" content="Count all non-NULL values in each column." />
-    <meta property="og:description" content="Count all non-NULL values in each column." />
+    <meta name="description" content="bach.DataFrame.count — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.count — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.create_variable.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.create_variable.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.create_variable
 
 ---
 <head>
-    <meta name="description" content="Create a Series object that can be used as a variable, within the returned DataFrame. The DataFrame will have the variable with the given values set in " />
-    <meta property="og:description" content="Create a Series object that can be used as a variable, within the returned DataFrame. The DataFrame will have the variable with the given values set in " />
+    <meta name="description" content="bach.DataFrame.create_variable — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.create_variable — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.cube.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.cube.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.cube
 
 ---
 <head>
-    <meta name="description" content="Group by and cube over the column(s) " />
-    <meta property="og:description" content="Group by and cube over the column(s) " />
+    <meta name="description" content="bach.DataFrame.cube — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.cube — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.data.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.data.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.data
 
 ---
 <head>
-    <meta name="description" content="Get the data dictionary " />
-    <meta property="og:description" content="Get the data dictionary " />
+    <meta name="description" content="bach.DataFrame.data — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.data — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.data_columns.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.data_columns.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.data_columns
 
 ---
 <head>
-    <meta name="description" content="Get all the data Series’ names in a List" />
-    <meta property="og:description" content="Get all the data Series’ names in a List" />
+    <meta name="description" content="bach.DataFrame.data_columns — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.data_columns — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.describe.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.describe.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.describe
 
 ---
 <head>
-    <meta name="description" content="Returns descriptive statistics. The following statistics are considered: " />
-    <meta property="og:description" content="Returns descriptive statistics. The following statistics are considered: " />
+    <meta name="description" content="bach.DataFrame.describe — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.describe — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.drop.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.drop.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.drop
 
 ---
 <head>
-    <meta name="description" content="Drop columns from the DataFrame" />
-    <meta property="og:description" content="Drop columns from the DataFrame" />
+    <meta name="description" content="bach.DataFrame.drop — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.drop — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.drop_duplicates.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.drop_duplicates.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.drop_duplicates
 
 ---
 <head>
-    <meta name="description" content="Return a dataframe with duplicated rows removed based on all series labels or a subset of labels." />
-    <meta property="og:description" content="Return a dataframe with duplicated rows removed based on all series labels or a subset of labels." />
+    <meta name="description" content="bach.DataFrame.drop_duplicates — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.drop_duplicates — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.dropna.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.dropna.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.dropna
 
 ---
 <head>
-    <meta name="description" content="Removes rows with missing values (NaN, None and SQL NULL)." />
-    <meta property="og:description" content="Removes rows with missing values (NaN, None and SQL NULL)." />
+    <meta name="description" content="bach.DataFrame.dropna — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.dropna — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.dtypes.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.dtypes.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.dtypes
 
 ---
 <head>
-    <meta name="description" content="Get the data Series’ dtypes in a dictionary " />
-    <meta property="og:description" content="Get the data Series’ dtypes in a dictionary " />
+    <meta name="description" content="bach.DataFrame.dtypes — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.dtypes — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.expanding.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.expanding.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.expanding
 
 ---
 <head>
-    <meta name="description" content="Create an expanding window starting with the first row in the group, with at least " />
-    <meta property="og:description" content="Create an expanding window starting with the first row in the group, with at least " />
+    <meta name="description" content="bach.DataFrame.expanding — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.expanding — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.ffill.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.ffill.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.ffill
 
 ---
 <head>
-    <meta name="description" content="Fill missing values by propagating the last non-nullable value in each series." />
-    <meta property="og:description" content="Fill missing values by propagating the last non-nullable value in each series." />
+    <meta name="description" content="bach.DataFrame.ffill — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.ffill — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.fillna.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.fillna.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.fillna
 
 ---
 <head>
-    <meta name="description" content="Fill any NULL value using a method or with a given value." />
-    <meta property="og:description" content="Fill any NULL value using a method or with a given value." />
+    <meta name="description" content="bach.DataFrame.fillna — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.fillna — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.from_model.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.from_model.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.from_model
 
 ---
 <head>
-    <meta name="description" content="Instantiate a new DataFrame based on the result of the query defined in " />
-    <meta property="og:description" content="Instantiate a new DataFrame based on the result of the query defined in " />
+    <meta name="description" content="bach.DataFrame.from_model — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.from_model — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.from_pandas.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.from_pandas.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.from_pandas
 
 ---
 <head>
-    <meta name="description" content="Instantiate a new DataFrame based on the content of a Pandas DataFrame." />
-    <meta property="og:description" content="Instantiate a new DataFrame based on the content of a Pandas DataFrame." />
+    <meta name="description" content="bach.DataFrame.from_pandas — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.from_pandas — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.from_table.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.from_table.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.from_table
 
 ---
 <head>
-    <meta name="description" content="Instantiate a new DataFrame based on the content of an existing table in the database." />
-    <meta property="og:description" content="Instantiate a new DataFrame based on the content of an existing table in the database." />
+    <meta name="description" content="bach.DataFrame.from_table — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.from_table — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.get_all_variable_usage.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.get_all_variable_usage.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.get_all_variable_usage
 
 ---
 <head>
-    <meta name="description" content="Get all variables that influence the values of this DataFrame. This includes both variables that are used in the current " />
-    <meta property="og:description" content="Get all variables that influence the values of this DataFrame. This includes both variables that are used in the current " />
+    <meta name="description" content="bach.DataFrame.get_all_variable_usage — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.get_all_variable_usage — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.get_sample.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.get_sample.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.get_sample
 
 ---
 <head>
-    <meta name="description" content="Returns a DataFrame whose data is a sample of the current DataFrame object." />
-    <meta property="og:description" content="Returns a DataFrame whose data is a sample of the current DataFrame object." />
+    <meta name="description" content="bach.DataFrame.get_sample — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.get_sample — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.get_unsampled.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.get_unsampled.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.get_unsampled
 
 ---
 <head>
-    <meta name="description" content="Return a copy of the current sampled DataFrame, that undoes calling " />
-    <meta property="og:description" content="Return a copy of the current sampled DataFrame, that undoes calling " />
+    <meta name="description" content="bach.DataFrame.get_unsampled — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.get_unsampled — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.group_by.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.group_by.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.group_by
 
 ---
 <head>
-    <meta name="description" content="Get this DataFrame’s grouping, if any." />
-    <meta property="og:description" content="Get this DataFrame’s grouping, if any." />
+    <meta name="description" content="bach.DataFrame.group_by — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.group_by — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.groupby.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.groupby.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.groupby
 
 ---
 <head>
-    <meta name="description" content="Group by any of the series currently in this DataDrame, both from index as well as data." />
-    <meta property="og:description" content="Group by any of the series currently in this DataDrame, both from index as well as data." />
+    <meta name="description" content="bach.DataFrame.groupby — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.groupby — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.head.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.head.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.head
 
 ---
 <head>
-    <meta name="description" content="Similar to " />
-    <meta property="og:description" content="Similar to " />
+    <meta name="description" content="bach.DataFrame.head — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.head — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.index.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.index.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.index
 
 ---
 <head>
-    <meta name="description" content="Get the index dictionary " />
-    <meta property="og:description" content="Get the index dictionary " />
+    <meta name="description" content="bach.DataFrame.index — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.index — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.index_columns.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.index_columns.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.index_columns
 
 ---
 <head>
-    <meta name="description" content="Get all the index columns’ names in a List" />
-    <meta property="og:description" content="Get all the index columns’ names in a List" />
+    <meta name="description" content="bach.DataFrame.index_columns — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.index_columns — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.index_dtypes.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.index_dtypes.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.index_dtypes
 
 ---
 <head>
-    <meta name="description" content="Get the index Series’ dtypes in a dictionary " />
-    <meta property="og:description" content="Get the index Series’ dtypes in a dictionary " />
+    <meta name="description" content="bach.DataFrame.index_dtypes — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.index_dtypes — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.is_materialized.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.is_materialized.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.is_materialized
 
 ---
 <head>
-    <meta name="description" content="Return true if this DataFrame is in a materialized state, i.e. all information about the DataFrame’s values is encoded in self.base_node." />
-    <meta property="og:description" content="Return true if this DataFrame is in a materialized state, i.e. all information about the DataFrame’s values is encoded in self.base_node." />
+    <meta name="description" content="bach.DataFrame.is_materialized — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.is_materialized — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.loc.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.loc.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.loc
 
 ---
 <head>
-    <meta name="description" content="The " />
-    <meta property="og:description" content="The " />
+    <meta name="description" content="bach.DataFrame.loc — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.loc — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.materialize.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.materialize.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.materialize
 
 ---
 <head>
-    <meta name="description" content="Create a copy of this DataFrame with as base_node the current DataFrame’s state." />
-    <meta property="og:description" content="Create a copy of this DataFrame with as base_node the current DataFrame’s state." />
+    <meta name="description" content="bach.DataFrame.materialize — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.materialize — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.max.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.max.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.max
 
 ---
 <head>
-    <meta name="description" content="Returns the maximum of all values in each column." />
-    <meta property="og:description" content="Returns the maximum of all values in each column." />
+    <meta name="description" content="bach.DataFrame.max — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.max — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame
 
 ---
 <head>
-    <meta name="description" content="A mutable DataFrame representing tabular data in a database and enabling operations on that data." />
-    <meta property="og:description" content="A mutable DataFrame representing tabular data in a database and enabling operations on that data." />
+    <meta name="description" content="bach.DataFrame — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.mean.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.mean.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.mean
 
 ---
 <head>
-    <meta name="description" content="Returns the mean of all values in each column." />
-    <meta property="og:description" content="Returns the mean of all values in each column." />
+    <meta name="description" content="bach.DataFrame.mean — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.mean — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.median.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.median.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.median
 
 ---
 <head>
-    <meta name="description" content="Returns the median of all values in each column." />
-    <meta property="og:description" content="Returns the median of all values in each column." />
+    <meta name="description" content="bach.DataFrame.median — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.median — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.merge.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.merge.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.merge
 
 ---
 <head>
-    <meta name="description" content="Join the right Dataframe or Series on self. This will return a new DataFrame that contains the combined columns of both dataframes, and the rows that result from joining on the specified columns. The columns that are joined on can consist (partially or fully) out of index columns." />
-    <meta property="og:description" content="Join the right Dataframe or Series on self. This will return a new DataFrame that contains the combined columns of both dataframes, and the rows that result from joining on the specified columns. The columns that are joined on can consist (partially or fully) out of index columns." />
+    <meta name="description" content="bach.DataFrame.merge — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.merge — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.min.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.min.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.min
 
 ---
 <head>
-    <meta name="description" content="Returns the minimum of all values in each column." />
-    <meta property="og:description" content="Returns the minimum of all values in each column." />
+    <meta name="description" content="bach.DataFrame.min — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.min — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.mode.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.mode.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.mode
 
 ---
 <head>
-    <meta name="description" content="Returns the mode of all values in each column." />
-    <meta property="og:description" content="Returns the mode of all values in each column." />
+    <meta name="description" content="bach.DataFrame.mode — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.mode — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.nunique.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.nunique.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.nunique
 
 ---
 <head>
-    <meta name="description" content="Returns the number of unique values in each column." />
-    <meta property="og:description" content="Returns the number of unique values in each column." />
+    <meta name="description" content="bach.DataFrame.nunique — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.nunique — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.order_by.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.order_by.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.order_by
 
 ---
 <head>
-    <meta name="description" content="Get the current sort order, if any." />
-    <meta property="og:description" content="Get the current sort order, if any." />
+    <meta name="description" content="bach.DataFrame.order_by — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.order_by — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.quantile.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.quantile.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.quantile
 
 ---
 <head>
-    <meta name="description" content="Returns the quantile per numeric/timedelta column." />
-    <meta property="og:description" content="Returns the quantile per numeric/timedelta column." />
+    <meta name="description" content="bach.DataFrame.quantile — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.quantile — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.rename.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.rename.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.rename
 
 ---
 <head>
-    <meta name="description" content="Rename columns." />
-    <meta property="og:description" content="Rename columns." />
+    <meta name="description" content="bach.DataFrame.rename — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.rename — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.reset_index.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.reset_index.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.reset_index
 
 ---
 <head>
-    <meta name="description" content="Drops the current index." />
-    <meta property="og:description" content="Drops the current index." />
+    <meta name="description" content="bach.DataFrame.reset_index — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.reset_index — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.rolling.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.rolling.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.rolling
 
 ---
 <head>
-    <meta name="description" content="A rolling window of size ‘window’, by default right aligned." />
-    <meta property="og:description" content="A rolling window of size ‘window’, by default right aligned." />
+    <meta name="description" content="bach.DataFrame.rolling — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.rolling — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.rollup.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.rollup.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.rollup
 
 ---
 <head>
-    <meta name="description" content="Group by and roll up over the column(s) " />
-    <meta property="og:description" content="Group by and roll up over the column(s) " />
+    <meta name="description" content="bach.DataFrame.rollup — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.rollup — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.round.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.round.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.round
 
 ---
 <head>
-    <meta name="description" content="Returns a DataFrame with rounded numerical values" />
-    <meta property="og:description" content="Returns a DataFrame with rounded numerical values" />
+    <meta name="description" content="bach.DataFrame.round — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.round — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.sem.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.sem.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.sem
 
 ---
 <head>
-    <meta name="description" content="Returns the unbiased standard error of the mean of each column." />
-    <meta property="og:description" content="Returns the unbiased standard error of the mean of each column." />
+    <meta name="description" content="bach.DataFrame.sem — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.sem — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.set_index.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.set_index.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.set_index
 
 ---
 <head>
-    <meta name="description" content="Set this dataframe’s index to the the index given in keys" />
-    <meta property="og:description" content="Set this dataframe’s index to the the index given in keys" />
+    <meta name="description" content="bach.DataFrame.set_index — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.set_index — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.set_savepoint.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.set_savepoint.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.set_savepoint
 
 ---
 <head>
-    <meta name="description" content="Set the current state as a savepoint in " />
-    <meta property="og:description" content="Set the current state as a savepoint in " />
+    <meta name="description" content="bach.DataFrame.set_savepoint — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.set_savepoint — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.set_variable.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.set_variable.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.set_variable
 
 ---
 <head>
-    <meta name="description" content="Return a copy of this DataFrame with the variable value updated." />
-    <meta property="og:description" content="Return a copy of this DataFrame with the variable value updated." />
+    <meta name="description" content="bach.DataFrame.set_variable — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.set_variable — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.sort_index.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.sort_index.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.sort_index
 
 ---
 <head>
-    <meta name="description" content="Sort dataframe by index levels." />
-    <meta property="og:description" content="Sort dataframe by index levels." />
+    <meta name="description" content="bach.DataFrame.sort_index — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.sort_index — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.sort_values.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.sort_values.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.sort_values
 
 ---
 <head>
-    <meta name="description" content="Create a new DataFrame with the specified sorting order." />
-    <meta property="og:description" content="Create a new DataFrame with the specified sorting order." />
+    <meta name="description" content="bach.DataFrame.sort_values — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.sort_values — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.stack.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.stack.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.stack
 
 ---
 <head>
-    <meta name="description" content="Stacks all data_columns into a single index series." />
-    <meta property="og:description" content="Stacks all data_columns into a single index series." />
+    <meta name="description" content="bach.DataFrame.stack — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.stack — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.std.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.std.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.std
 
 ---
 <head>
-    <meta name="description" content="Returns the sample standard deviation of each column." />
-    <meta property="og:description" content="Returns the sample standard deviation of each column." />
+    <meta name="description" content="bach.DataFrame.std — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.std — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.sum.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.sum.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.sum
 
 ---
 <head>
-    <meta name="description" content="Returns the sum of all values in each column." />
-    <meta property="og:description" content="Returns the sum of all values in each column." />
+    <meta name="description" content="bach.DataFrame.sum — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.sum — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.to_numpy.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.to_numpy.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.to_numpy
 
 ---
 <head>
-    <meta name="description" content="Return a Numpy representation of the DataFrame akin " />
-    <meta property="og:description" content="Return a Numpy representation of the DataFrame akin " />
+    <meta name="description" content="bach.DataFrame.to_numpy — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.to_numpy — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.to_pandas.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.to_pandas.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.to_pandas
 
 ---
 <head>
-    <meta name="description" content="Run a SQL query representing the current state of this DataFrame against the database and return the resulting data as a Pandas DataFrame." />
-    <meta property="og:description" content="Run a SQL query representing the current state of this DataFrame against the database and return the resulting data as a Pandas DataFrame." />
+    <meta name="description" content="bach.DataFrame.to_pandas — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.to_pandas — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.value_counts.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.value_counts.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.value_counts
 
 ---
 <head>
-    <meta name="description" content="Returns a series containing counts of each unique row in the DataFrame" />
-    <meta property="og:description" content="Returns a series containing counts of each unique row in the DataFrame" />
+    <meta name="description" content="bach.DataFrame.value_counts — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.value_counts — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.values.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.values.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.values
 
 ---
 <head>
-    <meta name="description" content="Return a Numpy representation of the DataFrame akin " />
-    <meta property="og:description" content="Return a Numpy representation of the DataFrame akin " />
+    <meta name="description" content="bach.DataFrame.values — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.values — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.var.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.var.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.var
 
 ---
 <head>
-    <meta name="description" content="Returns the unbiased variance of each column." />
-    <meta property="og:description" content="Returns the unbiased variance of each column." />
+    <meta name="description" content="bach.DataFrame.var — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.var — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.variables.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.variables.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.variables
 
 ---
 <head>
-    <meta name="description" content="Get all variables for which values are set, which will be used when querying the database." />
-    <meta property="og:description" content="Get all variables for which values are set, which will be used when querying the database." />
+    <meta name="description" content="bach.DataFrame.variables — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.variables — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.view_sql.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.view_sql.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.view_sql
 
 ---
 <head>
-    <meta name="description" content="Translate the current state of this DataFrame into a SQL query." />
-    <meta property="og:description" content="Translate the current state of this DataFrame into a SQL query." />
+    <meta name="description" content="bach.DataFrame.view_sql — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.view_sql — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/DataFrame/bach.DataFrame.window.mdx
+++ b/docs/docs/modeling/DataFrame/bach.DataFrame.window.mdx
@@ -7,8 +7,8 @@ slug: /modeling/DataFrame/bach.DataFrame.window
 
 ---
 <head>
-    <meta name="description" content="Create a window on the current dataframe grouping and its sorting." />
-    <meta property="og:description" content="Create a window on the current dataframe grouping and its sorting." />
+    <meta name="description" content="bach.DataFrame.window — Bach  documentation" />
+    <meta property="og:description" content="bach.DataFrame.window — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series.mdx
+++ b/docs/docs/modeling/Series.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series
 
 ---
 <head>
-    <meta name="description" content="A typed representation of a single column of data." />
-    <meta property="og:description" content="A typed representation of a single column of data." />
+    <meta name="description" content="Series — Bach  documentation" />
+    <meta property="og:description" content="Series — Bach  documentation" />
 </head>
 
 export const toc = [
@@ -49,61 +49,6 @@ export const toc = [
             {
                 "value": "Types",
                 "id": "types",
-                "children": [],
-                "level": 3
-            }
-        ],
-        "level": 2
-    },
-    {
-        "value": "Reference",
-        "id": "reference",
-        "children": [],
-        "level": 2
-    },
-    {
-        "value": "Reference by function",
-        "id": "reference-by-function",
-        "children": [
-            {
-                "value": "Creation / re-framing",
-                "id": "creation-re-framing",
-                "children": [],
-                "level": 3
-            },
-            {
-                "value": "Value accessors",
-                "id": "value-accessors",
-                "children": [],
-                "level": 3
-            },
-            {
-                "value": "Attributes and underlying data",
-                "id": "attributes-and-underlying-data",
-                "children": [],
-                "level": 3
-            },
-            {
-                "value": "Comparison and set operations",
-                "id": "comparison-and-set-operations",
-                "children": [],
-                "level": 3
-            },
-            {
-                "value": "Conversion, reshaping, sorting",
-                "id": "conversion-reshaping-sorting",
-                "children": [],
-                "level": 3
-            },
-            {
-                "value": "Function application, aggregation & windowing",
-                "id": "function-application-aggregation-windowing",
-                "children": [],
-                "level": 3
-            },
-            {
-                "value": "Computations & descriptive stats",
-                "id": "computations-descriptive-stats",
                 "children": [],
                 "level": 3
             }

--- a/docs/docs/modeling/Series/bach.Series.agg.mdx
+++ b/docs/docs/modeling/Series/bach.Series.agg.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.agg
 
 ---
 <head>
-    <meta name="description" content="Apply one or more aggregation functions to this Series." />
-    <meta property="og:description" content="Apply one or more aggregation functions to this Series." />
+    <meta name="description" content="bach.Series.agg — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.agg — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.aggregate.mdx
+++ b/docs/docs/modeling/Series/bach.Series.aggregate.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.aggregate
 
 ---
 <head>
-    <meta name="description" content="Alias for " />
-    <meta property="og:description" content="Alias for " />
+    <meta name="description" content="bach.Series.aggregate — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.aggregate — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.all_values.mdx
+++ b/docs/docs/modeling/Series/bach.Series.all_values.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.all_values
 
 ---
 <head>
-    <meta name="description" content="For every row in this Series, do multiple evaluations where _all_ sub-evaluations should be True" />
-    <meta property="og:description" content="For every row in this Series, do multiple evaluations where _all_ sub-evaluations should be True" />
+    <meta name="description" content="bach.Series.all_values — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.all_values — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.any_value.mdx
+++ b/docs/docs/modeling/Series/bach.Series.any_value.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.any_value
 
 ---
 <head>
-    <meta name="description" content="For every row in this Series, do multiple evaluations where _any_ sub-evaluation should be True" />
-    <meta property="og:description" content="For every row in this Series, do multiple evaluations where _any_ sub-evaluation should be True" />
+    <meta name="description" content="bach.Series.any_value — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.any_value — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.append.mdx
+++ b/docs/docs/modeling/Series/bach.Series.append.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.append
 
 ---
 <head>
-    <meta name="description" content="Append rows of other series to the caller series." />
-    <meta property="og:description" content="Append rows of other series to the caller series." />
+    <meta name="description" content="bach.Series.append — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.append — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.apply_func.mdx
+++ b/docs/docs/modeling/Series/bach.Series.apply_func.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.apply_func
 
 ---
 <head>
-    <meta name="description" content="Apply the given functions to this Series. If multiple are given, a list of multiple new series will be returned." />
-    <meta property="og:description" content="Apply the given functions to this Series. If multiple are given, a list of multiple new series will be returned." />
+    <meta name="description" content="bach.Series.apply_func — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.apply_func — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.array.mdx
+++ b/docs/docs/modeling/Series/bach.Series.array.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.array
 
 ---
 <head>
-    <meta name="description" content=".array property accessor akin pandas.Series.array" />
-    <meta property="og:description" content=".array property accessor akin pandas.Series.array" />
+    <meta name="description" content="bach.Series.array — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.array — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.astype.mdx
+++ b/docs/docs/modeling/Series/bach.Series.astype.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.astype
 
 ---
 <head>
-    <meta name="description" content="Convert this Series to another type." />
-    <meta property="og:description" content="Convert this Series to another type." />
+    <meta name="description" content="bach.Series.astype — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.astype — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.base_node.mdx
+++ b/docs/docs/modeling/Series/bach.Series.base_node.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.base_node
 
 ---
 <head>
-    <meta name="description" content="Get this Series’ base_node" />
-    <meta property="og:description" content="Get this Series’ base_node" />
+    <meta name="description" content="bach.Series.base_node — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.base_node — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.copy.mdx
+++ b/docs/docs/modeling/Series/bach.Series.copy.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.copy
 
 ---
 <head>
-    <meta name="description" content="Return a copy of this Series." />
-    <meta property="og:description" content="Return a copy of this Series." />
+    <meta name="description" content="bach.Series.copy — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.copy — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.count.mdx
+++ b/docs/docs/modeling/Series/bach.Series.count.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.count
 
 ---
 <head>
-    <meta name="description" content="Returns the amount of rows in each partition or for all values if none is given." />
-    <meta property="og:description" content="Returns the amount of rows in each partition or for all values if none is given." />
+    <meta name="description" content="bach.Series.count — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.count — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.describe.mdx
+++ b/docs/docs/modeling/Series/bach.Series.describe.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.describe
 
 ---
 <head>
-    <meta name="description" content="Returns descriptive statistics, it will vary based on what is provided" />
-    <meta property="og:description" content="Returns descriptive statistics, it will vary based on what is provided" />
+    <meta name="description" content="bach.Series.describe — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.describe — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.drop_duplicates.mdx
+++ b/docs/docs/modeling/Series/bach.Series.drop_duplicates.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.drop_duplicates
 
 ---
 <head>
-    <meta name="description" content="Return a series with duplicated rows removed." />
-    <meta property="og:description" content="Return a series with duplicated rows removed." />
+    <meta name="description" content="bach.Series.drop_duplicates — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.drop_duplicates — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.dropna.mdx
+++ b/docs/docs/modeling/Series/bach.Series.dropna.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.dropna
 
 ---
 <head>
-    <meta name="description" content="Removes rows with missing values." />
-    <meta property="og:description" content="Removes rows with missing values." />
+    <meta name="description" content="bach.Series.dropna — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.dropna — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.dtype.mdx
+++ b/docs/docs/modeling/Series/bach.Series.dtype.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.dtype
 
 ---
 <head>
-    <meta name="description" content="The dtype of this Series. Must be overridden by subclasses." />
-    <meta property="og:description" content="The dtype of this Series. Must be overridden by subclasses." />
+    <meta name="description" content="bach.Series.dtype — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.dtype — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.exists.mdx
+++ b/docs/docs/modeling/Series/bach.Series.exists.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.exists
 
 ---
 <head>
-    <meta name="description" content="Boolean operation that returns True if there are one or more values in this Series" />
-    <meta property="og:description" content="Boolean operation that returns True if there are one or more values in this Series" />
+    <meta name="description" content="bach.Series.exists — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.exists — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.fillna.mdx
+++ b/docs/docs/modeling/Series/bach.Series.fillna.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.fillna
 
 ---
 <head>
-    <meta name="description" content="Fill any NULL value with the given constant or other compatible Series" />
-    <meta property="og:description" content="Fill any NULL value with the given constant or other compatible Series" />
+    <meta name="description" content="bach.Series.fillna — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.fillna — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.from_const.mdx
+++ b/docs/docs/modeling/Series/bach.Series.from_const.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.from_const
 
 ---
 <head>
-    <meta name="description" content="Create an instance of this class, that represents a column with the given value. The returned Series will be similar to the Series given as base. In case a DataFrame is given, it can be used immediately with that frame. :param base:    The DataFrame or Series that the internal parameters are taken from :param value:   The value that this constant Series will have :param name:    The name that it will be known by (only for representation)" />
-    <meta property="og:description" content="Create an instance of this class, that represents a column with the given value. The returned Series will be similar to the Series given as base. In case a DataFrame is given, it can be used immediately with that frame. :param base:    The DataFrame or Series that the internal parameters are taken from :param value:   The value that this constant Series will have :param name:    The name that it will be known by (only for representation)" />
+    <meta name="description" content="bach.Series.from_const — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.from_const — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.group_by.mdx
+++ b/docs/docs/modeling/Series/bach.Series.group_by.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.group_by
 
 ---
 <head>
-    <meta name="description" content="Get this Series’ group_by, if any." />
-    <meta property="og:description" content="Get this Series’ group_by, if any." />
+    <meta name="description" content="bach.Series.group_by — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.group_by — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.head.mdx
+++ b/docs/docs/modeling/Series/bach.Series.head.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.head
 
 ---
 <head>
-    <meta name="description" content="Get the first n rows from this Series as a pandas.Series. :param n: The amount of rows to return." />
-    <meta property="og:description" content="Get the first n rows from this Series as a pandas.Series. :param n: The amount of rows to return." />
+    <meta name="description" content="bach.Series.head — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.head — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.index.mdx
+++ b/docs/docs/modeling/Series/bach.Series.index.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.index
 
 ---
 <head>
-    <meta name="description" content="Get this Series’ index dictionary {name: Series}" />
-    <meta property="og:description" content="Get this Series’ index dictionary {name: Series}" />
+    <meta name="description" content="bach.Series.index — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.index — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.index_sorting.mdx
+++ b/docs/docs/modeling/Series/bach.Series.index_sorting.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.index_sorting
 
 ---
 <head>
-    <meta name="description" content="Get this Series’ index sorting. An empty list indicates no sorting by index." />
-    <meta property="og:description" content="Get this Series’ index sorting. An empty list indicates no sorting by index." />
+    <meta name="description" content="bach.Series.index_sorting — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.index_sorting — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.isin.mdx
+++ b/docs/docs/modeling/Series/bach.Series.isin.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.isin
 
 ---
 <head>
-    <meta name="description" content="Evaluate for every row in this series whether the value is contained in other" />
-    <meta property="og:description" content="Evaluate for every row in this series whether the value is contained in other" />
+    <meta name="description" content="bach.Series.isin — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.isin — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.isnull.mdx
+++ b/docs/docs/modeling/Series/bach.Series.isnull.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.isnull
 
 ---
 <head>
-    <meta name="description" content="Evaluate for every row in this series whether the value is missing or NULL." />
-    <meta property="og:description" content="Evaluate for every row in this series whether the value is missing or NULL." />
+    <meta name="description" content="bach.Series.isnull — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.isnull — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.max.mdx
+++ b/docs/docs/modeling/Series/bach.Series.max.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.max
 
 ---
 <head>
-    <meta name="description" content="Returns the maximum value in each partition or for all values if none is given." />
-    <meta property="og:description" content="Returns the maximum value in each partition or for all values if none is given." />
+    <meta name="description" content="bach.Series.max — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.max — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.mdx
+++ b/docs/docs/modeling/Series/bach.Series.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series
 
 ---
 <head>
-    <meta name="description" content="Series is an abstract class. An instance of Series represents a column of data. Specific subclasses are used to represent specific types of data and enable operations on that data." />
-    <meta property="og:description" content="Series is an abstract class. An instance of Series represents a column of data. Specific subclasses are used to represent specific types of data and enable operations on that data." />
+    <meta name="description" content="bach.Series — Bach  documentation" />
+    <meta property="og:description" content="bach.Series — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.median.mdx
+++ b/docs/docs/modeling/Series/bach.Series.median.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.median
 
 ---
 <head>
-    <meta name="description" content="Returns the median in each partition or for all values if none is given." />
-    <meta property="og:description" content="Returns the median in each partition or for all values if none is given." />
+    <meta name="description" content="bach.Series.median — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.median — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.min.mdx
+++ b/docs/docs/modeling/Series/bach.Series.min.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.min
 
 ---
 <head>
-    <meta name="description" content="Returns the minimum value in each partition or for all values if none is given." />
-    <meta property="og:description" content="Returns the minimum value in each partition or for all values if none is given." />
+    <meta name="description" content="bach.Series.min — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.min — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.mode.mdx
+++ b/docs/docs/modeling/Series/bach.Series.mode.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.mode
 
 ---
 <head>
-    <meta name="description" content="Returns the mode in each partition or for all values if none is given." />
-    <meta property="og:description" content="Returns the mode in each partition or for all values if none is given." />
+    <meta name="description" content="bach.Series.mode — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.mode — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.name.mdx
+++ b/docs/docs/modeling/Series/bach.Series.name.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.name
 
 ---
 <head>
-    <meta name="description" content="Get this Series’ name" />
-    <meta property="og:description" content="Get this Series’ name" />
+    <meta name="description" content="bach.Series.name — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.name — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.notnull.mdx
+++ b/docs/docs/modeling/Series/bach.Series.notnull.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.notnull
 
 ---
 <head>
-    <meta name="description" content="Evaluate for every row in this series whether the value is not missing or NULL." />
-    <meta property="og:description" content="Evaluate for every row in this series whether the value is not missing or NULL." />
+    <meta name="description" content="bach.Series.notnull — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.notnull — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.nunique.mdx
+++ b/docs/docs/modeling/Series/bach.Series.nunique.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.nunique
 
 ---
 <head>
-    <meta name="description" content="Returns the amount of unique values in each partition or for all values if none is given." />
-    <meta property="og:description" content="Returns the amount of unique values in each partition or for all values if none is given." />
+    <meta name="description" content="bach.Series.nunique — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.nunique — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.sort_index.mdx
+++ b/docs/docs/modeling/Series/bach.Series.sort_index.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.sort_index
 
 ---
 <head>
-    <meta name="description" content="Sort this Series by its index. Returns a new instance and does not modify the instance it is called on." />
-    <meta property="og:description" content="Sort this Series by its index. Returns a new instance and does not modify the instance it is called on." />
+    <meta name="description" content="bach.Series.sort_index — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.sort_index — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.sort_values.mdx
+++ b/docs/docs/modeling/Series/bach.Series.sort_values.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.sort_values
 
 ---
 <head>
-    <meta name="description" content="Sort this Series by its values. Returns a new instance and does not actually modify the instance it is called on. :param ascending: Whether to sort ascending (True) or descending (False)" />
-    <meta property="og:description" content="Sort this Series by its values. Returns a new instance and does not actually modify the instance it is called on. :param ascending: Whether to sort ascending (True) or descending (False)" />
+    <meta name="description" content="bach.Series.sort_values — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.sort_values — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.sorted_ascending.mdx
+++ b/docs/docs/modeling/Series/bach.Series.sorted_ascending.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.sorted_ascending
 
 ---
 <head>
-    <meta name="description" content="Get this Series’ sorting by value. None indicates that the Series is not sorted by value." />
-    <meta property="og:description" content="Get this Series’ sorting by value. None indicates that the Series is not sorted by value." />
+    <meta name="description" content="bach.Series.sorted_ascending — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.sorted_ascending — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.to_frame.mdx
+++ b/docs/docs/modeling/Series/bach.Series.to_frame.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.to_frame
 
 ---
 <head>
-    <meta name="description" content="Create a DataFrame with the index and data from this Series." />
-    <meta property="og:description" content="Create a DataFrame with the index and data from this Series." />
+    <meta name="description" content="bach.Series.to_frame — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.to_frame — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.to_numpy.mdx
+++ b/docs/docs/modeling/Series/bach.Series.to_numpy.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.to_numpy
 
 ---
 <head>
-    <meta name="description" content="Return a Numpy representation of the Series akin " />
-    <meta property="og:description" content="Return a Numpy representation of the Series akin " />
+    <meta name="description" content="bach.Series.to_numpy — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.to_numpy — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.to_pandas.mdx
+++ b/docs/docs/modeling/Series/bach.Series.to_pandas.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.to_pandas
 
 ---
 <head>
-    <meta name="description" content="Get the data from this series as a pandas.Series :param limit: The limit to apply, either as a max amount of rows or a slice." />
-    <meta property="og:description" content="Get the data from this series as a pandas.Series :param limit: The limit to apply, either as a max amount of rows or a slice." />
+    <meta name="description" content="bach.Series.to_pandas — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.to_pandas — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.unique.mdx
+++ b/docs/docs/modeling/Series/bach.Series.unique.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.unique
 
 ---
 <head>
-    <meta name="description" content="Return all unique values in this Series." />
-    <meta property="og:description" content="Return all unique values in this Series." />
+    <meta name="description" content="bach.Series.unique — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.unique — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.unstack.mdx
+++ b/docs/docs/modeling/Series/bach.Series.unstack.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.unstack
 
 ---
 <head>
-    <meta name="description" content="Pivot a level of the index labels." />
-    <meta property="og:description" content="Pivot a level of the index labels." />
+    <meta name="description" content="bach.Series.unstack — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.unstack — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.value.mdx
+++ b/docs/docs/modeling/Series/bach.Series.value.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.value
 
 ---
 <head>
-    <meta name="description" content="Retrieve the actual single value of this series. If it’s not sure that there is only one value, a ValueError is raised. In that case use Series.values[0] to retrieve the value." />
-    <meta property="og:description" content="Retrieve the actual single value of this series. If it’s not sure that there is only one value, a ValueError is raised. In that case use Series.values[0] to retrieve the value." />
+    <meta name="description" content="bach.Series.value — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.value — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.value_counts.mdx
+++ b/docs/docs/modeling/Series/bach.Series.value_counts.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.value_counts
 
 ---
 <head>
-    <meta name="description" content="Returns a series containing counts per unique value" />
-    <meta property="og:description" content="Returns a series containing counts per unique value" />
+    <meta name="description" content="bach.Series.value_counts — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.value_counts — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.values.mdx
+++ b/docs/docs/modeling/Series/bach.Series.values.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.values
 
 ---
 <head>
-    <meta name="description" content=".values property accessor akin pandas.Series.values" />
-    <meta property="og:description" content=".values property accessor akin pandas.Series.values" />
+    <meta name="description" content="bach.Series.values — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.values — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.window_cume_dist.mdx
+++ b/docs/docs/modeling/Series/bach.Series.window_cume_dist.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.window_cume_dist
 
 ---
 <head>
-    <meta name="description" content="Returns the cumulative distribution, that is (number of partition rows preceding or peers with current row) / (total partition rows). The value thus ranges from 1/N to 1." />
-    <meta property="og:description" content="Returns the cumulative distribution, that is (number of partition rows preceding or peers with current row) / (total partition rows). The value thus ranges from 1/N to 1." />
+    <meta name="description" content="bach.Series.window_cume_dist — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.window_cume_dist — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.window_dense_rank.mdx
+++ b/docs/docs/modeling/Series/bach.Series.window_dense_rank.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.window_dense_rank
 
 ---
 <head>
-    <meta name="description" content="Returns the rank of the current row, without gaps; this function effectively counts peer groups." />
-    <meta property="og:description" content="Returns the rank of the current row, without gaps; this function effectively counts peer groups." />
+    <meta name="description" content="bach.Series.window_dense_rank — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.window_dense_rank — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.window_first_value.mdx
+++ b/docs/docs/modeling/Series/bach.Series.window_first_value.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.window_first_value
 
 ---
 <head>
-    <meta name="description" content="Returns value evaluated at the row that is the first row of the window frame." />
-    <meta property="og:description" content="Returns value evaluated at the row that is the first row of the window frame." />
+    <meta name="description" content="bach.Series.window_first_value — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.window_first_value — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.window_lag.mdx
+++ b/docs/docs/modeling/Series/bach.Series.window_lag.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.window_lag
 
 ---
 <head>
-    <meta name="description" content="Returns value evaluated at the row that is offset rows before the current row within the window" />
-    <meta property="og:description" content="Returns value evaluated at the row that is offset rows before the current row within the window" />
+    <meta name="description" content="bach.Series.window_lag — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.window_lag — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.window_last_value.mdx
+++ b/docs/docs/modeling/Series/bach.Series.window_last_value.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.window_last_value
 
 ---
 <head>
-    <meta name="description" content="Returns value evaluated at the row that is the last row of the window frame." />
-    <meta property="og:description" content="Returns value evaluated at the row that is the last row of the window frame." />
+    <meta name="description" content="bach.Series.window_last_value — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.window_last_value — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.window_lead.mdx
+++ b/docs/docs/modeling/Series/bach.Series.window_lead.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.window_lead
 
 ---
 <head>
-    <meta name="description" content="Returns value evaluated at the row that is offset rows after the current row within the window." />
-    <meta property="og:description" content="Returns value evaluated at the row that is offset rows after the current row within the window." />
+    <meta name="description" content="bach.Series.window_lead — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.window_lead — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.window_nth_value.mdx
+++ b/docs/docs/modeling/Series/bach.Series.window_nth_value.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.window_nth_value
 
 ---
 <head>
-    <meta name="description" content="Returns value evaluated at the row that is the n’th row of the window frame. (counting from 1); returns NULL if there is no such row." />
-    <meta property="og:description" content="Returns value evaluated at the row that is the n’th row of the window frame. (counting from 1); returns NULL if there is no such row." />
+    <meta name="description" content="bach.Series.window_nth_value — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.window_nth_value — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.window_ntile.mdx
+++ b/docs/docs/modeling/Series/bach.Series.window_ntile.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.window_ntile
 
 ---
 <head>
-    <meta name="description" content="Returns an integer ranging from 1 to the argument value, dividing the partition as equally as possible." />
-    <meta property="og:description" content="Returns an integer ranging from 1 to the argument value, dividing the partition as equally as possible." />
+    <meta name="description" content="bach.Series.window_ntile — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.window_ntile — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.window_percent_rank.mdx
+++ b/docs/docs/modeling/Series/bach.Series.window_percent_rank.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.window_percent_rank
 
 ---
 <head>
-    <meta name="description" content="Returns the relative rank of the current row, that is (rank - 1) / (total partition rows - 1). The value thus ranges from 0 to 1 inclusive." />
-    <meta property="og:description" content="Returns the relative rank of the current row, that is (rank - 1) / (total partition rows - 1). The value thus ranges from 0 to 1 inclusive." />
+    <meta name="description" content="bach.Series.window_percent_rank — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.window_percent_rank — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.window_rank.mdx
+++ b/docs/docs/modeling/Series/bach.Series.window_rank.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.window_rank
 
 ---
 <head>
-    <meta name="description" content="Returns the rank of the current row, with gaps; that is, the row_number of the first row in its peer group." />
-    <meta property="og:description" content="Returns the rank of the current row, with gaps; that is, the row_number of the first row in its peer group." />
+    <meta name="description" content="bach.Series.window_rank — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.window_rank — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.Series.window_row_number.mdx
+++ b/docs/docs/modeling/Series/bach.Series.window_row_number.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.Series.window_row_number
 
 ---
 <head>
-    <meta name="description" content="Returns the number of the current row within its window, counting from 1." />
-    <meta property="og:description" content="Returns the number of the current row within its window, counting from 1." />
+    <meta name="description" content="bach.Series.window_row_number — Bach  documentation" />
+    <meta property="og:description" content="bach.Series.window_row_number — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.SeriesAbstractDateTime.dt.mdx
+++ b/docs/docs/modeling/Series/bach.SeriesAbstractDateTime.dt.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.SeriesAbstractDateTime.dt
 
 ---
 <head>
-    <meta name="description" content="Get access to date operations." />
-    <meta property="og:description" content="Get access to date operations." />
+    <meta name="description" content="bach.SeriesAbstractDateTime.dt — Bach  documentation" />
+    <meta property="og:description" content="bach.SeriesAbstractDateTime.dt — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.SeriesAbstractDateTime.mdx
+++ b/docs/docs/modeling/Series/bach.SeriesAbstractDateTime.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.SeriesAbstractDateTime
 
 ---
 <head>
-    <meta name="description" content="A Series that represents the generic date/time type and its specific operations. Selected arithmetic operations are accepted using the usual operators." />
-    <meta property="og:description" content="A Series that represents the generic date/time type and its specific operations. Selected arithmetic operations are accepted using the usual operators." />
+    <meta name="description" content="bach.SeriesAbstractDateTime — Bach  documentation" />
+    <meta property="og:description" content="bach.SeriesAbstractDateTime — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.SeriesAbstractNumeric.cut.mdx
+++ b/docs/docs/modeling/Series/bach.SeriesAbstractNumeric.cut.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.SeriesAbstractNumeric.cut
 
 ---
 <head>
-    <meta name="description" content="Segments values into bins." />
-    <meta property="og:description" content="Segments values into bins." />
+    <meta name="description" content="bach.SeriesAbstractNumeric.cut — Bach  documentation" />
+    <meta property="og:description" content="bach.SeriesAbstractNumeric.cut — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.SeriesAbstractNumeric.mdx
+++ b/docs/docs/modeling/Series/bach.SeriesAbstractNumeric.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.SeriesAbstractNumeric
 
 ---
 <head>
-    <meta name="description" content="A Series that represents the base numeric types and its specific operations" />
-    <meta property="og:description" content="A Series that represents the base numeric types and its specific operations" />
+    <meta name="description" content="bach.SeriesAbstractNumeric — Bach  documentation" />
+    <meta property="og:description" content="bach.SeriesAbstractNumeric — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.SeriesAbstractNumeric.mean.mdx
+++ b/docs/docs/modeling/Series/bach.SeriesAbstractNumeric.mean.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.SeriesAbstractNumeric.mean
 
 ---
 <head>
-    <meta name="description" content="Get the mean/average of the input values." />
-    <meta property="og:description" content="Get the mean/average of the input values." />
+    <meta name="description" content="bach.SeriesAbstractNumeric.mean — Bach  documentation" />
+    <meta property="og:description" content="bach.SeriesAbstractNumeric.mean — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.SeriesAbstractNumeric.qcut.mdx
+++ b/docs/docs/modeling/Series/bach.SeriesAbstractNumeric.qcut.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.SeriesAbstractNumeric.qcut
 
 ---
 <head>
-    <meta name="description" content="Segments values into equal-sized buckets based on rank or sample quantiles." />
-    <meta property="og:description" content="Segments values into equal-sized buckets based on rank or sample quantiles." />
+    <meta name="description" content="bach.SeriesAbstractNumeric.qcut — Bach  documentation" />
+    <meta property="og:description" content="bach.SeriesAbstractNumeric.qcut — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.SeriesAbstractNumeric.quantile.mdx
+++ b/docs/docs/modeling/Series/bach.SeriesAbstractNumeric.quantile.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.SeriesAbstractNumeric.quantile
 
 ---
 <head>
-    <meta name="description" content="When q is a float or len(q) == 1, the resultant series index will remain In case multiple quantiles are calculated, the resultant series index will have all calculated quantiles as index values." />
-    <meta property="og:description" content="When q is a float or len(q) == 1, the resultant series index will remain In case multiple quantiles are calculated, the resultant series index will have all calculated quantiles as index values." />
+    <meta name="description" content="bach.SeriesAbstractNumeric.quantile — Bach  documentation" />
+    <meta property="og:description" content="bach.SeriesAbstractNumeric.quantile — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.SeriesAbstractNumeric.round.mdx
+++ b/docs/docs/modeling/Series/bach.SeriesAbstractNumeric.round.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.SeriesAbstractNumeric.round
 
 ---
 <head>
-    <meta name="description" content="Round the value of this series to the given amount of decimals." />
-    <meta property="og:description" content="Round the value of this series to the given amount of decimals." />
+    <meta name="description" content="bach.SeriesAbstractNumeric.round — Bach  documentation" />
+    <meta property="og:description" content="bach.SeriesAbstractNumeric.round — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.SeriesAbstractNumeric.sem.mdx
+++ b/docs/docs/modeling/Series/bach.SeriesAbstractNumeric.sem.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.SeriesAbstractNumeric.sem
 
 ---
 <head>
-    <meta name="description" content="Get the unbiased standard error of the mean. Normalized by N-1 by default." />
-    <meta property="og:description" content="Get the unbiased standard error of the mean. Normalized by N-1 by default." />
+    <meta name="description" content="bach.SeriesAbstractNumeric.sem — Bach  documentation" />
+    <meta property="og:description" content="bach.SeriesAbstractNumeric.sem — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.SeriesAbstractNumeric.std.mdx
+++ b/docs/docs/modeling/Series/bach.SeriesAbstractNumeric.std.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.SeriesAbstractNumeric.std
 
 ---
 <head>
-    <meta name="description" content="Get the sample standard deviation of the input values Normalized by N-1 by default." />
-    <meta property="og:description" content="Get the sample standard deviation of the input values Normalized by N-1 by default." />
+    <meta name="description" content="bach.SeriesAbstractNumeric.std — Bach  documentation" />
+    <meta property="og:description" content="bach.SeriesAbstractNumeric.std — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.SeriesAbstractNumeric.sum.mdx
+++ b/docs/docs/modeling/Series/bach.SeriesAbstractNumeric.sum.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.SeriesAbstractNumeric.sum
 
 ---
 <head>
-    <meta name="description" content="Get the sum of the input values." />
-    <meta property="og:description" content="Get the sum of the input values." />
+    <meta name="description" content="bach.SeriesAbstractNumeric.sum — Bach  documentation" />
+    <meta property="og:description" content="bach.SeriesAbstractNumeric.sum — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.SeriesAbstractNumeric.var.mdx
+++ b/docs/docs/modeling/Series/bach.SeriesAbstractNumeric.var.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.SeriesAbstractNumeric.var
 
 ---
 <head>
-    <meta name="description" content="Get the sample variance of the input values (square of the sample standard deviation) Normalized by N-1 by default." />
-    <meta property="og:description" content="Get the sample variance of the input values (square of the sample standard deviation) Normalized by N-1 by default." />
+    <meta name="description" content="bach.SeriesAbstractNumeric.var — Bach  documentation" />
+    <meta property="og:description" content="bach.SeriesAbstractNumeric.var — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.SeriesBoolean.max.mdx
+++ b/docs/docs/modeling/Series/bach.SeriesBoolean.max.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.SeriesBoolean.max
 
 ---
 <head>
-    <meta name="description" content="Returns the maximum value in the partition." />
-    <meta property="og:description" content="Returns the maximum value in the partition." />
+    <meta name="description" content="bach.SeriesBoolean.max — Bach  documentation" />
+    <meta property="og:description" content="bach.SeriesBoolean.max — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.SeriesBoolean.mdx
+++ b/docs/docs/modeling/Series/bach.SeriesBoolean.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.SeriesBoolean
 
 ---
 <head>
-    <meta name="description" content="A Series that represents the Boolean type and its specific operations" />
-    <meta property="og:description" content="A Series that represents the Boolean type and its specific operations" />
+    <meta name="description" content="bach.SeriesBoolean — Bach  documentation" />
+    <meta property="og:description" content="bach.SeriesBoolean — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.SeriesBoolean.min.mdx
+++ b/docs/docs/modeling/Series/bach.SeriesBoolean.min.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.SeriesBoolean.min
 
 ---
 <head>
-    <meta name="description" content="Returns the minimum value in the partition." />
-    <meta property="og:description" content="Returns the minimum value in the partition." />
+    <meta name="description" content="bach.SeriesBoolean.min — Bach  documentation" />
+    <meta property="og:description" content="bach.SeriesBoolean.min — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.SeriesJson.mdx
+++ b/docs/docs/modeling/Series/bach.SeriesJson.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.SeriesJson
 
 ---
 <head>
-    <meta name="description" content="A Series that represents the json type." />
-    <meta property="og:description" content="A Series that represents the json type." />
+    <meta name="description" content="bach.SeriesJson — Bach  documentation" />
+    <meta property="og:description" content="bach.SeriesJson — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.SeriesJsonb.json.mdx
+++ b/docs/docs/modeling/Series/bach.SeriesJsonb.json.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.SeriesJsonb.json
 
 ---
 <head>
-    <meta name="description" content="Get access to json operations via the class that’s return through this accessor. Use as " />
-    <meta property="og:description" content="Get access to json operations via the class that’s return through this accessor. Use as " />
+    <meta name="description" content="bach.SeriesJsonb.json — Bach  documentation" />
+    <meta property="og:description" content="bach.SeriesJsonb.json — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.SeriesJsonb.mdx
+++ b/docs/docs/modeling/Series/bach.SeriesJsonb.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.SeriesJsonb
 
 ---
 <head>
-    <meta name="description" content="A Series that represents the postgres jsonb type and its specific operations." />
-    <meta property="og:description" content="A Series that represents the postgres jsonb type and its specific operations." />
+    <meta name="description" content="bach.SeriesJsonb — Bach  documentation" />
+    <meta property="og:description" content="bach.SeriesJsonb — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.SeriesString.mdx
+++ b/docs/docs/modeling/Series/bach.SeriesString.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.SeriesString
 
 ---
 <head>
-    <meta name="description" content="A Series that represents the string type and its specific operations" />
-    <meta property="og:description" content="A Series that represents the string type and its specific operations" />
+    <meta name="description" content="bach.SeriesString — Bach  documentation" />
+    <meta property="og:description" content="bach.SeriesString — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/Series/bach.SeriesString.str.mdx
+++ b/docs/docs/modeling/Series/bach.SeriesString.str.mdx
@@ -7,8 +7,8 @@ slug: /modeling/Series/bach.SeriesString.str
 
 ---
 <head>
-    <meta name="description" content="Get access to string operations." />
-    <meta property="og:description" content="Get access to string operations." />
+    <meta name="description" content="bach.SeriesString.str — Bach  documentation" />
+    <meta property="og:description" content="bach.SeriesString.str — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/bach.mdx
+++ b/docs/docs/modeling/bach.mdx
@@ -7,8 +7,8 @@ slug: /modeling/bach
 
 ---
 <head>
-    <meta name="description" content="Bach is Objectiv’s data modeling library. With Bach, you can compose models with familiar Pandas-like dataframe operations in your notebook. It uses a SQL abstraction layer that enables models to run on the full dataset, and you can output models to SQL with a single command. It includes a set of operations that enable effective feature creation for datasets that embrace the open taxonomy of analytics." />
-    <meta property="og:description" content="Bach is Objectiv’s data modeling library. With Bach, you can compose models with familiar Pandas-like dataframe operations in your notebook. It uses a SQL abstraction layer that enables models to run on the full dataset, and you can output models to SQL with a single command. It includes a set of operations that enable effective feature creation for datasets that embrace the open taxonomy of analytics." />
+    <meta name="description" content="Bach — Bach  documentation" />
+    <meta property="og:description" content="Bach — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/bach_core_concepts.mdx
+++ b/docs/docs/modeling/bach_core_concepts.mdx
@@ -7,8 +7,8 @@ slug: /modeling/bach_core_concepts
 
 ---
 <head>
-    <meta name="description" content="Bach aims to make life for the DS as simple and powerful as possible by using a very familiar interface. We use two main concepts to achieve that." />
-    <meta property="og:description" content="Bach aims to make life for the DS as simple and powerful as possible by using a very familiar interface. We use two main concepts to achieve that." />
+    <meta name="description" content="Core Concepts — Bach  documentation" />
+    <meta property="og:description" content="Core Concepts — Bach  documentation" />
 </head>
 
 export const toc = [

--- a/docs/docs/modeling/bach_examples.mdx
+++ b/docs/docs/modeling/bach_examples.mdx
@@ -7,8 +7,8 @@ slug: /modeling/bach_examples
 
 ---
 <head>
-    <meta name="description" content="Here we’ll give some very basic examples of the usage of Bach: creating a DataFrame, basic operations, aggregate operations, and getting the resulting data filtered and sorted. For this example there is no separate notebook available, but the operations demonstrated here are used in the other example notebooks." />
-    <meta property="og:description" content="Here we’ll give some very basic examples of the usage of Bach: creating a DataFrame, basic operations, aggregate operations, and getting the resulting data filtered and sorted. For this example there is no separate notebook available, but the operations demonstrated here are used in the other example notebooks." />
+    <meta name="description" content="Bach basics — Bach  documentation" />
+    <meta property="og:description" content="Bach basics — Bach  documentation" />
 </head>
 
 export const toc = [

--- a/docs/docs/modeling/bach_reference_dataframe.mdx
+++ b/docs/docs/modeling/bach_reference_dataframe.mdx
@@ -1,0 +1,21 @@
+---
+id: bach_reference_dataframe
+title: Reference — Bach  documentation
+hide_title: true
+slug: /modeling/bach_reference_dataframe
+
+
+---
+<head>
+    <meta name="description" content="Reference — Bach  documentation" />
+    <meta property="og:description" content="Reference — Bach  documentation" />
+</head>
+
+export const toc = [];
+
+
+import SphinxPages from '@site/src/components/sphinx-page'
+import useBaseUrl from '@docusaurus/useBaseUrl'
+
+
+<SphinxPages url={useBaseUrl('modeling/bach_reference_dataframe.html')} />

--- a/docs/docs/modeling/bach_reference_dataframe_by_function.mdx
+++ b/docs/docs/modeling/bach_reference_dataframe_by_function.mdx
@@ -1,0 +1,96 @@
+---
+id: bach_reference_dataframe_by_function
+title: Reference by function — Bach  documentation
+hide_title: true
+slug: /modeling/bach_reference_dataframe_by_function
+
+
+---
+<head>
+    <meta name="description" content="Reference by function — Bach  documentation" />
+    <meta property="og:description" content="Reference by function — Bach  documentation" />
+</head>
+
+export const toc = [
+    {
+        "value": "Creation",
+        "id": "creation",
+        "children": [],
+        "level": 2
+    },
+    {
+        "value": "Value accessors",
+        "id": "value-accessors",
+        "children": [],
+        "level": 2
+    },
+    {
+        "value": "Attributes and underlying data",
+        "id": "attributes-and-underlying-data",
+        "children": [
+            {
+                "value": "Axes",
+                "id": "axes",
+                "children": [],
+                "level": 3
+            },
+            {
+                "value": "Types",
+                "id": "types",
+                "children": [],
+                "level": 3
+            },
+            {
+                "value": "Sql Model",
+                "id": "sql-model",
+                "children": [],
+                "level": 3
+            },
+            {
+                "value": "Variables",
+                "id": "variables",
+                "children": [],
+                "level": 3
+            }
+        ],
+        "level": 2
+    },
+    {
+        "value": "Reshaping, indexing, sorting & merging",
+        "id": "reshaping-indexing-sorting-merging",
+        "children": [],
+        "level": 2
+    },
+    {
+        "value": "Aggregation & windowing",
+        "id": "aggregation-windowing",
+        "children": [],
+        "level": 2
+    },
+    {
+        "value": "Computations & descriptive stats",
+        "id": "computations-descriptive-stats",
+        "children": [
+            {
+                "value": "All types",
+                "id": "all-types",
+                "children": [],
+                "level": 3
+            },
+            {
+                "value": "Numeric",
+                "id": "numeric",
+                "children": [],
+                "level": 3
+            }
+        ],
+        "level": 2
+    }
+];
+
+
+import SphinxPages from '@site/src/components/sphinx-page'
+import useBaseUrl from '@docusaurus/useBaseUrl'
+
+
+<SphinxPages url={useBaseUrl('modeling/bach_reference_dataframe_by_function.html')} />

--- a/docs/docs/modeling/bach_reference_series.mdx
+++ b/docs/docs/modeling/bach_reference_series.mdx
@@ -1,0 +1,21 @@
+---
+id: bach_reference_series
+title: Reference — Bach  documentation
+hide_title: true
+slug: /modeling/bach_reference_series
+
+
+---
+<head>
+    <meta name="description" content="Reference — Bach  documentation" />
+    <meta property="og:description" content="Reference — Bach  documentation" />
+</head>
+
+export const toc = [];
+
+
+import SphinxPages from '@site/src/components/sphinx-page'
+import useBaseUrl from '@docusaurus/useBaseUrl'
+
+
+<SphinxPages url={useBaseUrl('modeling/bach_reference_series.html')} />

--- a/docs/docs/modeling/bach_reference_series_by_function.mdx
+++ b/docs/docs/modeling/bach_reference_series_by_function.mdx
@@ -1,0 +1,102 @@
+---
+id: bach_reference_series_by_function
+title: Reference by function — Bach  documentation
+hide_title: true
+slug: /modeling/bach_reference_series_by_function
+
+
+---
+<head>
+    <meta name="description" content="Reference by function — Bach  documentation" />
+    <meta property="og:description" content="Reference by function — Bach  documentation" />
+</head>
+
+export const toc = [
+    {
+        "value": "Creation / re-framing",
+        "id": "creation-re-framing",
+        "children": [],
+        "level": 2
+    },
+    {
+        "value": "Value accessors",
+        "id": "value-accessors",
+        "children": [],
+        "level": 2
+    },
+    {
+        "value": "Attributes and underlying data",
+        "id": "attributes-and-underlying-data",
+        "children": [
+            {
+                "value": "Axes",
+                "id": "axes",
+                "children": [],
+                "level": 3
+            },
+            {
+                "value": "Types",
+                "id": "types",
+                "children": [],
+                "level": 3
+            },
+            {
+                "value": "Sql Model",
+                "id": "sql-model",
+                "children": [],
+                "level": 3
+            }
+        ],
+        "level": 2
+    },
+    {
+        "value": "Comparison and set operations",
+        "id": "comparison-and-set-operations",
+        "children": [],
+        "level": 2
+    },
+    {
+        "value": "Conversion, reshaping, sorting",
+        "id": "conversion-reshaping-sorting",
+        "children": [],
+        "level": 2
+    },
+    {
+        "value": "Function application, aggregation & windowing",
+        "id": "function-application-aggregation-windowing",
+        "children": [],
+        "level": 2
+    },
+    {
+        "value": "Computations & descriptive stats",
+        "id": "computations-descriptive-stats",
+        "children": [
+            {
+                "value": "All types",
+                "id": "all-types",
+                "children": [],
+                "level": 3
+            },
+            {
+                "value": "Numeric",
+                "id": "numeric",
+                "children": [],
+                "level": 3
+            },
+            {
+                "value": "Window",
+                "id": "window",
+                "children": [],
+                "level": 3
+            }
+        ],
+        "level": 2
+    }
+];
+
+
+import SphinxPages from '@site/src/components/sphinx-page'
+import useBaseUrl from '@docusaurus/useBaseUrl'
+
+
+<SphinxPages url={useBaseUrl('modeling/bach_reference_series_by_function.html')} />

--- a/docs/docs/modeling/bach_whatisbach.mdx
+++ b/docs/docs/modeling/bach_whatisbach.mdx
@@ -7,8 +7,8 @@ slug: /modeling/bach_whatisbach
 
 ---
 <head>
-    <meta name="description" content="Bach is a library for analysing data that is stored in a SQL database. Currently we only support Postgres, but we plan on supporting more databases. We’re using an interface that’s mostly compatible with " />
-    <meta property="og:description" content="Bach is a library for analysing data that is stored in a SQL database. Currently we only support Postgres, but we plan on supporting more databases. We’re using an interface that’s mostly compatible with " />
+    <meta name="description" content="What is Bach? — Bach  documentation" />
+    <meta property="og:description" content="What is Bach? — Bach  documentation" />
 </head>
 
 export const toc = [

--- a/docs/docs/modeling/example_notebooks.mdx
+++ b/docs/docs/modeling/example_notebooks.mdx
@@ -7,20 +7,14 @@ slug: /modeling/example_notebooks
 
 ---
 <head>
-    <meta name="description" content="Here are several examples of how you can analyze and model data using the open model hub. All examples are also available as Jupyter notebooks from our " />
-    <meta property="og:description" content="Here are several examples of how you can analyze and model data using the open model hub. All examples are also available as Jupyter notebooks from our " />
+    <meta name="description" content="Example notebooks — Bach  documentation" />
+    <meta property="og:description" content="Example notebooks — Bach  documentation" />
 </head>
 
 export const toc = [
     {
         "value": "Getting started with Objectiv",
         "id": "getting-started-with-objectiv",
-        "children": [],
-        "level": 2
-    },
-    {
-        "value": "Examples",
-        "id": "examples",
         "children": [],
         "level": 2
     }

--- a/docs/docs/modeling/feature_engineering.mdx
+++ b/docs/docs/modeling/feature_engineering.mdx
@@ -7,8 +7,8 @@ slug: /modeling/feature_engineering
 
 ---
 <head>
-    <meta name="description" content="This example shows how Bach can be used for feature engineering. We’ll go through describing the data, finding outliers, transforming data and grouping and aggregating data so that a useful feature set is created that can be used for machine learning. We have a separate example available that goes into the details of how a data set prepared in Bach can be used for machine learning with sklearn " />
-    <meta property="og:description" content="This example shows how Bach can be used for feature engineering. We’ll go through describing the data, finding outliers, transforming data and grouping and aggregating data so that a useful feature set is created that can be used for machine learning. We have a separate example available that goes into the details of how a data set prepared in Bach can be used for machine learning with sklearn " />
+    <meta name="description" content="Feature engineering with Bach — Bach  documentation" />
+    <meta property="og:description" content="Feature engineering with Bach — Bach  documentation" />
 </head>
 
 export const toc = [

--- a/docs/docs/modeling/intro.mdx
+++ b/docs/docs/modeling/intro.mdx
@@ -7,8 +7,8 @@ sidebar_label: Introduction
 
 ---
 <head>
-    <meta name="description" content="Data collected with Objectiv’s Tracker and stored in an SQL database can be analyzed in a Jupyter notebook with the open model hub. The open model hub is a growing collection of open-source, free to use data models that you can take, combine and run for product analysis and exploration. It includes models for a wide range of typical product analytics use cases." />
-    <meta property="og:description" content="Data collected with Objectiv’s Tracker and stored in an SQL database can be analyzed in a Jupyter notebook with the open model hub. The open model hub is a growing collection of open-source, free to use data models that you can take, combine and run for product analysis and exploration. It includes models for a wide range of typical product analytics use cases." />
+    <meta name="description" content="Introduction — Bach  documentation" />
+    <meta property="og:description" content="Introduction — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/machine_learning.mdx
+++ b/docs/docs/modeling/machine_learning.mdx
@@ -7,8 +7,8 @@ slug: /modeling/machine_learning
 
 ---
 <head>
-    <meta name="description" content="With Objectiv you can do all your analysis and Machine Learning directly on the raw data in your SQL database. This example shows in the simplest way possible how you can use Objectiv to create a basic feature set and use sklearn to do machine learning on this data set. We also have an example that goes deeper into feature engineering " />
-    <meta property="og:description" content="With Objectiv you can do all your analysis and Machine Learning directly on the raw data in your SQL database. This example shows in the simplest way possible how you can use Objectiv to create a basic feature set and use sklearn to do machine learning on this data set. We also have an example that goes deeper into feature engineering " />
+    <meta name="description" content="Bach and sklearn — Bach  documentation" />
+    <meta property="og:description" content="Bach and sklearn — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference.mdx
+++ b/docs/docs/modeling/modelhub_api_reference.mdx
@@ -7,18 +7,11 @@ slug: /modeling/modelhub_api_reference
 
 ---
 <head>
-    <meta name="description" content="This is the complete API reference of the model hub." />
-    <meta property="og:description" content="This is the complete API reference of the model hub." />
+    <meta name="description" content="Open model hub API reference — Bach  documentation" />
+    <meta property="og:description" content="Open model hub API reference — Bach  documentation" />
 </head>
 
-export const toc = [
-    {
-        "value": "Reference",
-        "id": "reference",
-        "children": [],
-        "level": 2
-    }
-];
+export const toc = [];
 
 
 import SphinxPages from '@site/src/components/sphinx-page'

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.Aggregate.frequency.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.Aggregate.frequency.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.Aggregate.frequency
 
 ---
 <head>
-    <meta name="description" content="Calculate a frequency table for the number of users by number of sessions." />
-    <meta property="og:description" content="Calculate a frequency table for the number of users by number of sessions." />
+    <meta name="description" content="modelhub.Aggregate.frequency — Bach  documentation" />
+    <meta property="og:description" content="modelhub.Aggregate.frequency — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.Aggregate.session_duration.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.Aggregate.session_duration.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.Aggregate.session_duration
 
 ---
 <head>
-    <meta name="description" content="Calculate the average duration of sessions." />
-    <meta property="og:description" content="Calculate the average duration of sessions." />
+    <meta name="description" content="modelhub.Aggregate.session_duration — Bach  documentation" />
+    <meta property="og:description" content="modelhub.Aggregate.session_duration — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.Aggregate.unique_sessions.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.Aggregate.unique_sessions.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.Aggregate.unique_sessions
 
 ---
 <head>
-    <meta name="description" content="Calculate the unique sessions in the Objectiv " />
-    <meta property="og:description" content="Calculate the unique sessions in the Objectiv " />
+    <meta name="description" content="modelhub.Aggregate.unique_sessions — Bach  documentation" />
+    <meta property="og:description" content="modelhub.Aggregate.unique_sessions — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.Aggregate.unique_users.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.Aggregate.unique_users.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.Aggregate.unique_users
 
 ---
 <head>
-    <meta name="description" content="Calculate the unique users in the Objectiv " />
-    <meta property="og:description" content="Calculate the unique users in the Objectiv " />
+    <meta name="description" content="modelhub.Aggregate.unique_users — Bach  documentation" />
+    <meta property="og:description" content="modelhub.Aggregate.unique_users — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.Map.conversions_counter.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.Map.conversions_counter.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.Map.conversions_counter
 
 ---
 <head>
-    <meta name="description" content="Counts the total number of conversions given a partition (ie session_id or user_id)." />
-    <meta property="og:description" content="Counts the total number of conversions given a partition (ie session_id or user_id)." />
+    <meta name="description" content="modelhub.Map.conversions_counter — Bach  documentation" />
+    <meta property="og:description" content="modelhub.Map.conversions_counter — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.Map.conversions_in_time.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.Map.conversions_in_time.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.Map.conversions_in_time
 
 ---
 <head>
-    <meta name="description" content="Counts the number of time a user is converted at a moment in time given a partition (ie ‘session_id’ or ‘user_id’)." />
-    <meta property="og:description" content="Counts the number of time a user is converted at a moment in time given a partition (ie ‘session_id’ or ‘user_id’)." />
+    <meta name="description" content="modelhub.Map.conversions_in_time — Bach  documentation" />
+    <meta property="og:description" content="modelhub.Map.conversions_in_time — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.Map.is_conversion_event.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.Map.is_conversion_event.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.Map.is_conversion_event
 
 ---
 <head>
-    <meta name="description" content="Labels a hit True if it is a conversion event, all other hits are labeled False." />
-    <meta property="og:description" content="Labels a hit True if it is a conversion event, all other hits are labeled False." />
+    <meta name="description" content="modelhub.Map.is_conversion_event — Bach  documentation" />
+    <meta property="og:description" content="modelhub.Map.is_conversion_event — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.Map.is_first_session.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.Map.is_first_session.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.Map.is_first_session
 
 ---
 <head>
-    <meta name="description" content="Labels all hits in a session True if that session is the first session of that user in the data." />
-    <meta property="og:description" content="Labels all hits in a session True if that session is the first session of that user in the data." />
+    <meta name="description" content="modelhub.Map.is_first_session — Bach  documentation" />
+    <meta property="og:description" content="modelhub.Map.is_first_session — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.Map.is_new_user.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.Map.is_new_user.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.Map.is_new_user
 
 ---
 <head>
-    <meta name="description" content="Labels all hits True if the user is first seen in the period given " />
-    <meta property="og:description" content="Labels all hits True if the user is first seen in the period given " />
+    <meta name="description" content="modelhub.Map.is_new_user — Bach  documentation" />
+    <meta property="og:description" content="modelhub.Map.is_new_user — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.Map.pre_conversion_hit_number.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.Map.pre_conversion_hit_number.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.Map.pre_conversion_hit_number
 
 ---
 <head>
-    <meta name="description" content="Returns a count backwards from the first conversion, given the partition. I.e. first hit before converting is 1, second hit before converting 2, etc. Returns None if there are no conversions in the partition or after the first conversion." />
-    <meta property="og:description" content="Returns a count backwards from the first conversion, given the partition. I.e. first hit before converting is 1, second hit before converting 2, etc. Returns None if there are no conversions in the partition or after the first conversion." />
+    <meta name="description" content="modelhub.Map.pre_conversion_hit_number — Bach  documentation" />
+    <meta property="og:description" content="modelhub.Map.pre_conversion_hit_number — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.ModelHub.add_conversion_event.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.ModelHub.add_conversion_event.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.ModelHub.add_conversion_event
 
 ---
 <head>
-    <meta name="description" content="Label events that are used as conversions. All labeled conversion events are set in " />
-    <meta property="og:description" content="Label events that are used as conversions. All labeled conversion events are set in " />
+    <meta name="description" content="modelhub.ModelHub.add_conversion_event — Bach  documentation" />
+    <meta property="og:description" content="modelhub.ModelHub.add_conversion_event — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.ModelHub.agg.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.ModelHub.agg.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.ModelHub.agg
 
 ---
 <head>
-    <meta name="description" content="Access aggregation methods from the model hub. Same as " />
-    <meta property="og:description" content="Access aggregation methods from the model hub. Same as " />
+    <meta name="description" content="modelhub.ModelHub.agg — Bach  documentation" />
+    <meta property="og:description" content="modelhub.ModelHub.agg — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.ModelHub.aggregate.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.ModelHub.aggregate.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.ModelHub.aggregate
 
 ---
 <head>
-    <meta name="description" content="Access aggregation methods from the model hub. Same as " />
-    <meta property="og:description" content="Access aggregation methods from the model hub. Same as " />
+    <meta name="description" content="modelhub.ModelHub.aggregate — Bach  documentation" />
+    <meta property="og:description" content="modelhub.ModelHub.aggregate — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.ModelHub.conversion_events.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.ModelHub.conversion_events.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.ModelHub.conversion_events
 
 ---
 <head>
-    <meta name="description" content="Dictionary of all events that are labeled as conversion." />
-    <meta property="og:description" content="Dictionary of all events that are labeled as conversion." />
+    <meta name="description" content="modelhub.ModelHub.conversion_events — Bach  documentation" />
+    <meta property="og:description" content="modelhub.ModelHub.conversion_events — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.ModelHub.get_objectiv_dataframe.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.ModelHub.get_objectiv_dataframe.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.ModelHub.get_objectiv_dataframe
 
 ---
 <head>
-    <meta name="description" content="Sets data from sql table into an " />
-    <meta property="og:description" content="Sets data from sql table into an " />
+    <meta name="description" content="modelhub.ModelHub.get_objectiv_dataframe — Bach  documentation" />
+    <meta property="og:description" content="modelhub.ModelHub.get_objectiv_dataframe — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.ModelHub.map.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.ModelHub.map.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.ModelHub.map
 
 ---
 <head>
-    <meta name="description" content="Access map methods from the model hub." />
-    <meta property="og:description" content="Access map methods from the model hub." />
+    <meta name="description" content="modelhub.ModelHub.map — Bach  documentation" />
+    <meta property="og:description" content="modelhub.ModelHub.map — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.ModelHub.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.ModelHub.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.ModelHub
 
 ---
 <head>
-    <meta name="description" content="The model hub contains collection of data models and convenience functions that you can take, combine and run on Bach data frames to quickly build highly specific model stacks for product analysis and exploration. It includes models for a wide range of typical product analytics use cases." />
-    <meta property="og:description" content="The model hub contains collection of data models and convenience functions that you can take, combine and run on Bach data frames to quickly build highly specific model stacks for product analysis and exploration. It includes models for a wide range of typical product analytics use cases." />
+    <meta name="description" content="modelhub.ModelHub — Bach  documentation" />
+    <meta property="og:description" content="modelhub.ModelHub — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.ModelHub.time_agg.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.ModelHub.time_agg.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.ModelHub.time_agg
 
 ---
 <head>
-    <meta name="description" content="Formats the moment column in the DataFrame, returns a SeriesString." />
-    <meta property="og:description" content="Formats the moment column in the DataFrame, returns a SeriesString." />
+    <meta name="description" content="modelhub.ModelHub.time_agg — Bach  documentation" />
+    <meta property="og:description" content="modelhub.ModelHub.time_agg — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.ModelHub.time_aggregation.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.ModelHub.time_aggregation.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.ModelHub.time_aggregation
 
 ---
 <head>
-    <meta name="description" content="Time aggregation used for aggregation models, set when object is instantiated." />
-    <meta property="og:description" content="Time aggregation used for aggregation models, set when object is instantiated." />
+    <meta name="description" content="modelhub.ModelHub.time_aggregation — Bach  documentation" />
+    <meta property="og:description" content="modelhub.ModelHub.time_aggregation — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.ModelHub.to_metabase.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.ModelHub.to_metabase.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.ModelHub.to_metabase
 
 ---
 <head>
-    <meta name="description" content="Plot data in " />
-    <meta property="og:description" content="Plot data in " />
+    <meta name="description" content="modelhub.ModelHub.to_metabase — Bach  documentation" />
+    <meta property="og:description" content="modelhub.ModelHub.to_metabase — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.gc.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.gc.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.gc
 
 ---
 <head>
-    <meta name="description" content="Accessor for Objectiv global context data. All methods of " />
-    <meta property="og:description" content="Accessor for Objectiv global context data. All methods of " />
+    <meta name="description" content="modelhub.SeriesGlobalContexts.gc — Bach  documentation" />
+    <meta property="og:description" content="modelhub.SeriesGlobalContexts.gc — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.global_contexts.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.global_contexts.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.global_cont
 
 ---
 <head>
-    <meta name="description" content="Accessor for Objectiv global context data. All methods of " />
-    <meta property="og:description" content="Accessor for Objectiv global context data. All methods of " />
+    <meta name="description" content="modelhub.SeriesGlobalContexts.global_contexts — Bach  documentation" />
+    <meta property="og:description" content="modelhub.SeriesGlobalContexts.global_contexts — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts
 
 ---
 <head>
-    <meta name="description" content="Objectiv Global Contexts series. This series type contains functionality specific to the Objectiv Global Contexts." />
-    <meta property="og:description" content="Objectiv Global Contexts series. This series type contains functionality specific to the Objectiv Global Contexts." />
+    <meta name="description" content="modelhub.SeriesGlobalContexts — Bach  documentation" />
+    <meta property="og:description" content="modelhub.SeriesGlobalContexts — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.obj.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.obj.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.obj
 
 ---
 <head>
-    <meta name="description" content="Accessor for Objectiv stack data. All methods of " />
-    <meta property="og:description" content="Accessor for Objectiv stack data. All methods of " />
+    <meta name="description" content="modelhub.SeriesGlobalContexts.obj — Bach  documentation" />
+    <meta property="og:description" content="modelhub.SeriesGlobalContexts.obj — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.objectiv.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.objectiv.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.objectiv
 
 ---
 <head>
-    <meta name="description" content="Accessor for Objectiv stack data. All methods of " />
-    <meta property="og:description" content="Accessor for Objectiv stack data. All methods of " />
+    <meta name="description" content="modelhub.SeriesGlobalContexts.objectiv — Bach  documentation" />
+    <meta property="og:description" content="modelhub.SeriesGlobalContexts.objectiv — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.SeriesLocationStack.location_stack.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.SeriesLocationStack.location_stack.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.SeriesLocationStack.location_sta
 
 ---
 <head>
-    <meta name="description" content="Accessor for Objectiv location stack data. All methods of " />
-    <meta property="og:description" content="Accessor for Objectiv location stack data. All methods of " />
+    <meta name="description" content="modelhub.SeriesLocationStack.location_stack — Bach  documentation" />
+    <meta property="og:description" content="modelhub.SeriesLocationStack.location_stack — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.SeriesLocationStack.ls.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.SeriesLocationStack.ls.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.SeriesLocationStack.ls
 
 ---
 <head>
-    <meta name="description" content="Accessor for Objectiv location stack data. All methods of " />
-    <meta property="og:description" content="Accessor for Objectiv location stack data. All methods of " />
+    <meta name="description" content="modelhub.SeriesLocationStack.ls — Bach  documentation" />
+    <meta property="og:description" content="modelhub.SeriesLocationStack.ls — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.SeriesLocationStack.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.SeriesLocationStack.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.SeriesLocationStack
 
 ---
 <head>
-    <meta name="description" content="Objectiv Location Stack series. This series type contains functionality specific to the Objectiv Location Stack." />
-    <meta property="og:description" content="Objectiv Location Stack series. This series type contains functionality specific to the Objectiv Location Stack." />
+    <meta name="description" content="modelhub.SeriesLocationStack — Bach  documentation" />
+    <meta property="og:description" content="modelhub.SeriesLocationStack — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.SeriesLocationStack.obj.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.SeriesLocationStack.obj.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.SeriesLocationStack.obj
 
 ---
 <head>
-    <meta name="description" content="Accessor for Objectiv stack data. All methods of " />
-    <meta property="og:description" content="Accessor for Objectiv stack data. All methods of " />
+    <meta name="description" content="modelhub.SeriesLocationStack.obj — Bach  documentation" />
+    <meta property="og:description" content="modelhub.SeriesLocationStack.obj — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_api_reference/modelhub.SeriesLocationStack.objectiv.mdx
+++ b/docs/docs/modeling/modelhub_api_reference/modelhub.SeriesLocationStack.objectiv.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_api_reference/modelhub.SeriesLocationStack.objectiv
 
 ---
 <head>
-    <meta name="description" content="Accessor for Objectiv stack data. All methods of " />
-    <meta property="og:description" content="Accessor for Objectiv stack data. All methods of " />
+    <meta name="description" content="modelhub.SeriesLocationStack.objectiv — Bach  documentation" />
+    <meta property="og:description" content="modelhub.SeriesLocationStack.objectiv — Bach  documentation" />
 </head>
 
 export const toc = [];

--- a/docs/docs/modeling/modelhub_basics.mdx
+++ b/docs/docs/modeling/modelhub_basics.mdx
@@ -7,8 +7,8 @@ slug: /modeling/modelhub_basics
 
 ---
 <head>
-    <meta name="description" content="In this example, we briefly demonstrate how you can use pre-built models from the open model hub in conjunction with, " />
-    <meta property="og:description" content="In this example, we briefly demonstrate how you can use pre-built models from the open model hub in conjunction with, " />
+    <meta name="description" content="Open model hub basics — Bach  documentation" />
+    <meta property="og:description" content="Open model hub basics — Bach  documentation" />
 </head>
 
 export const toc = [

--- a/docs/docs/modeling/models.mdx
+++ b/docs/docs/modeling/models.mdx
@@ -7,24 +7,11 @@ slug: /modeling/models
 
 ---
 <head>
-    <meta name="description" content="The model hub has two main type of functions: " />
-    <meta property="og:description" content="The model hub has two main type of functions: " />
+    <meta name="description" content="Model overview — Bach  documentation" />
+    <meta property="og:description" content="Model overview — Bach  documentation" />
 </head>
 
-export const toc = [
-    {
-        "value": "Mapping",
-        "id": "mapping",
-        "children": [],
-        "level": 2
-    },
-    {
-        "value": "Aggregation",
-        "id": "aggregation",
-        "children": [],
-        "level": 2
-    }
-];
+export const toc = [];
 
 
 import SphinxPages from '@site/src/components/sphinx-page'

--- a/docs/docs/modeling/models_aggregation.mdx
+++ b/docs/docs/modeling/models_aggregation.mdx
@@ -1,0 +1,21 @@
+---
+id: models_aggregation
+title: Aggregation — Bach  documentation
+hide_title: true
+slug: /modeling/models_aggregation
+
+
+---
+<head>
+    <meta name="description" content="Aggregation — Bach  documentation" />
+    <meta property="og:description" content="Aggregation — Bach  documentation" />
+</head>
+
+export const toc = [];
+
+
+import SphinxPages from '@site/src/components/sphinx-page'
+import useBaseUrl from '@docusaurus/useBaseUrl'
+
+
+<SphinxPages url={useBaseUrl('modeling/models_aggregation.html')} />

--- a/docs/docs/modeling/models_mapping.mdx
+++ b/docs/docs/modeling/models_mapping.mdx
@@ -1,0 +1,21 @@
+---
+id: models_mapping
+title: Mapping — Bach  documentation
+hide_title: true
+slug: /modeling/models_mapping
+
+
+---
+<head>
+    <meta name="description" content="Mapping — Bach  documentation" />
+    <meta property="og:description" content="Mapping — Bach  documentation" />
+</head>
+
+export const toc = [];
+
+
+import SphinxPages from '@site/src/components/sphinx-page'
+import useBaseUrl from '@docusaurus/useBaseUrl'
+
+
+<SphinxPages url={useBaseUrl('modeling/models_mapping.html')} />

--- a/docs/docs/modeling/open_taxonomy.mdx
+++ b/docs/docs/modeling/open_taxonomy.mdx
@@ -7,8 +7,8 @@ slug: /modeling/open_taxonomy
 
 ---
 <head>
-    <meta name="description" content="This example demonstrates what you can do with the Objectiv Bach modeling library and a dataset that was validated against the " />
-    <meta property="og:description" content="This example demonstrates what you can do with the Objectiv Bach modeling library and a dataset that was validated against the " />
+    <meta name="description" content="Open taxonomy how-to — Bach  documentation" />
+    <meta property="og:description" content="Open taxonomy how-to — Bach  documentation" />
 </head>
 
 export const toc = [

--- a/docs/docs/modeling/product_analytics.mdx
+++ b/docs/docs/modeling/product_analytics.mdx
@@ -7,8 +7,8 @@ slug: /modeling/product_analytics
 
 ---
 <head>
-    <meta name="description" content="This example shows how the open model hub can be used for basic product analysis." />
-    <meta property="og:description" content="This example shows how the open model hub can be used for basic product analysis." />
+    <meta name="description" content="Basic product analytics — Bach  documentation" />
+    <meta property="og:description" content="Basic product analytics — Bach  documentation" />
 </head>
 
 export const toc = [

--- a/docs/docs/modeling/sidebar.js
+++ b/docs/docs/modeling/sidebar.js
@@ -8,73 +8,70 @@ module.exports = [
     {
         "type": "category",
         "label": "Example notebooks",
+        "link": {
+            "type": "doc",
+            "id": "modeling/example_notebooks"
+        },
         "items": [
             {
-                "type": "doc",
-                "label": "Overview",
-                "id": "modeling/example_notebooks"
-            },
-            {
-                "type": "link",
-                "label": "Getting started with Objectiv",
-                "href": "/modeling/example_notebooks#getting-started-with-objectiv"
+                "type": "category",
+                "label": "Open model hub basics",
+                "link": {
+                    "type": "doc",
+                    "id": "modeling/modelhub_basics"
+                },
+                "items": []
             },
             {
                 "type": "category",
-                "label": "Examples",
-                "items": [
-                    {
-                        "type": "link",
-                        "label": "Overview",
-                        "href": "/modeling/example_notebooks#examples"
-                    },
-                    {
-                        "type": "doc",
-                        "label": "Open model hub basics",
-                        "id": "modeling/modelhub_basics"
-                    },
-                    {
-                        "type": "doc",
-                        "label": "Basic product analytics",
-                        "id": "modeling/product_analytics"
-                    },
-                    {
-                        "type": "doc",
-                        "label": "Open taxonomy how-to",
-                        "id": "modeling/open_taxonomy"
-                    },
-                    {
-                        "type": "doc",
-                        "label": "Feature engineering with Bach",
-                        "id": "modeling/feature_engineering"
-                    },
-                    {
-                        "type": "doc",
-                        "label": "Bach and sklearn",
-                        "id": "modeling/machine_learning"
-                    }
-                ]
+                "label": "Basic product analytics",
+                "link": {
+                    "type": "doc",
+                    "id": "modeling/product_analytics"
+                },
+                "items": []
+            },
+            {
+                "type": "category",
+                "label": "Open taxonomy how-to",
+                "link": {
+                    "type": "doc",
+                    "id": "modeling/open_taxonomy"
+                },
+                "items": []
+            },
+            {
+                "type": "category",
+                "label": "Feature engineering with Bach",
+                "link": {
+                    "type": "doc",
+                    "id": "modeling/feature_engineering"
+                },
+                "items": []
+            },
+            {
+                "type": "doc",
+                "label": "Bach and sklearn",
+                "id": "modeling/machine_learning"
             }
         ]
     },
     {
         "type": "category",
         "label": "Model overview",
+        "link": {
+            "type": "doc",
+            "id": "modeling/models"
+        },
         "items": [
-            {
-                "type": "doc",
-                "label": "Overview",
-                "id": "modeling/models"
-            },
             {
                 "type": "category",
                 "label": "Mapping",
+                "link": {
+                    "type": "doc",
+                    "id": "modeling/models_mapping"
+                },
                 "items": [
-                    {
-                        "type": "link",
-                        "label": "Overview",
-                        "href": "/modeling/models#mapping"
-                    },
                     {
                         "type": "doc",
                         "label": "is_first_session",
@@ -110,12 +107,11 @@ module.exports = [
             {
                 "type": "category",
                 "label": "Aggregation",
+                "link": {
+                    "type": "doc",
+                    "id": "modeling/models_aggregation"
+                },
                 "items": [
-                    {
-                        "type": "link",
-                        "label": "Overview",
-                        "href": "/modeling/models#aggregation"
-                    },
                     {
                         "type": "doc",
                         "label": "unique_users",
@@ -143,138 +139,123 @@ module.exports = [
     {
         "type": "category",
         "label": "Open model hub API reference",
+        "link": {
+            "type": "doc",
+            "id": "modeling/modelhub_api_reference"
+        },
         "items": [
             {
-                "type": "doc",
-                "label": "Overview",
-                "id": "modeling/modelhub_api_reference"
+                "type": "category",
+                "label": "ModelHub",
+                "link": {
+                    "type": "doc",
+                    "id": "modeling/modelhub_api_reference/modelhub.ModelHub"
+                },
+                "items": [
+                    {
+                        "type": "doc",
+                        "label": "add_conversion_event",
+                        "id": "modeling/modelhub_api_reference/modelhub.ModelHub.add_conversion_event"
+                    },
+                    {
+                        "type": "doc",
+                        "label": "get_objectiv_dataframe",
+                        "id": "modeling/modelhub_api_reference/modelhub.ModelHub.get_objectiv_dataframe"
+                    },
+                    {
+                        "type": "doc",
+                        "label": "time_agg",
+                        "id": "modeling/modelhub_api_reference/modelhub.ModelHub.time_agg"
+                    },
+                    {
+                        "type": "doc",
+                        "label": "to_metabase",
+                        "id": "modeling/modelhub_api_reference/modelhub.ModelHub.to_metabase"
+                    },
+                    {
+                        "type": "doc",
+                        "label": "agg",
+                        "id": "modeling/modelhub_api_reference/modelhub.ModelHub.agg"
+                    },
+                    {
+                        "type": "doc",
+                        "label": "aggregate",
+                        "id": "modeling/modelhub_api_reference/modelhub.ModelHub.aggregate"
+                    },
+                    {
+                        "type": "doc",
+                        "label": "conversion_events",
+                        "id": "modeling/modelhub_api_reference/modelhub.ModelHub.conversion_events"
+                    },
+                    {
+                        "type": "doc",
+                        "label": "map",
+                        "id": "modeling/modelhub_api_reference/modelhub.ModelHub.map"
+                    },
+                    {
+                        "type": "doc",
+                        "label": "time_aggregation",
+                        "id": "modeling/modelhub_api_reference/modelhub.ModelHub.time_aggregation"
+                    }
+                ]
             },
             {
                 "type": "category",
-                "label": "Reference",
+                "label": "SeriesGlobalContexts",
+                "link": {
+                    "type": "doc",
+                    "id": "modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts"
+                },
                 "items": [
                     {
-                        "type": "link",
-                        "label": "Overview",
-                        "href": "/modeling/modelhub_api_reference#reference"
+                        "type": "doc",
+                        "label": "gc",
+                        "id": "modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.gc"
                     },
                     {
-                        "type": "category",
-                        "label": "ModelHub",
-                        "items": [
-                            {
-                                "type": "doc",
-                                "label": "Overview",
-                                "id": "modeling/modelhub_api_reference/modelhub.ModelHub"
-                            },
-                            {
-                                "type": "doc",
-                                "label": "add_conversion_event",
-                                "id": "modeling/modelhub_api_reference/modelhub.ModelHub.add_conversion_event"
-                            },
-                            {
-                                "type": "doc",
-                                "label": "get_objectiv_dataframe",
-                                "id": "modeling/modelhub_api_reference/modelhub.ModelHub.get_objectiv_dataframe"
-                            },
-                            {
-                                "type": "doc",
-                                "label": "time_agg",
-                                "id": "modeling/modelhub_api_reference/modelhub.ModelHub.time_agg"
-                            },
-                            {
-                                "type": "doc",
-                                "label": "to_metabase",
-                                "id": "modeling/modelhub_api_reference/modelhub.ModelHub.to_metabase"
-                            },
-                            {
-                                "type": "doc",
-                                "label": "agg",
-                                "id": "modeling/modelhub_api_reference/modelhub.ModelHub.agg"
-                            },
-                            {
-                                "type": "doc",
-                                "label": "aggregate",
-                                "id": "modeling/modelhub_api_reference/modelhub.ModelHub.aggregate"
-                            },
-                            {
-                                "type": "doc",
-                                "label": "conversion_events",
-                                "id": "modeling/modelhub_api_reference/modelhub.ModelHub.conversion_events"
-                            },
-                            {
-                                "type": "doc",
-                                "label": "map",
-                                "id": "modeling/modelhub_api_reference/modelhub.ModelHub.map"
-                            },
-                            {
-                                "type": "doc",
-                                "label": "time_aggregation",
-                                "id": "modeling/modelhub_api_reference/modelhub.ModelHub.time_aggregation"
-                            }
-                        ]
+                        "type": "doc",
+                        "label": "global_contexts",
+                        "id": "modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.global_contexts"
                     },
                     {
-                        "type": "category",
-                        "label": "SeriesGlobalContexts",
-                        "items": [
-                            {
-                                "type": "doc",
-                                "label": "Overview",
-                                "id": "modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts"
-                            },
-                            {
-                                "type": "doc",
-                                "label": "gc",
-                                "id": "modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.gc"
-                            },
-                            {
-                                "type": "doc",
-                                "label": "global_contexts",
-                                "id": "modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.global_contexts"
-                            },
-                            {
-                                "type": "doc",
-                                "label": "obj",
-                                "id": "modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.obj"
-                            },
-                            {
-                                "type": "doc",
-                                "label": "objectiv",
-                                "id": "modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.objectiv"
-                            }
-                        ]
+                        "type": "doc",
+                        "label": "obj",
+                        "id": "modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.obj"
                     },
                     {
-                        "type": "category",
-                        "label": "SeriesLocationStack",
-                        "items": [
-                            {
-                                "type": "doc",
-                                "label": "Overview",
-                                "id": "modeling/modelhub_api_reference/modelhub.SeriesLocationStack"
-                            },
-                            {
-                                "type": "doc",
-                                "label": "location_stack",
-                                "id": "modeling/modelhub_api_reference/modelhub.SeriesLocationStack.location_stack"
-                            },
-                            {
-                                "type": "doc",
-                                "label": "ls",
-                                "id": "modeling/modelhub_api_reference/modelhub.SeriesLocationStack.ls"
-                            },
-                            {
-                                "type": "doc",
-                                "label": "obj",
-                                "id": "modeling/modelhub_api_reference/modelhub.SeriesLocationStack.obj"
-                            },
-                            {
-                                "type": "doc",
-                                "label": "objectiv",
-                                "id": "modeling/modelhub_api_reference/modelhub.SeriesLocationStack.objectiv"
-                            }
-                        ]
+                        "type": "doc",
+                        "label": "objectiv",
+                        "id": "modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.objectiv"
+                    }
+                ]
+            },
+            {
+                "type": "category",
+                "label": "SeriesLocationStack",
+                "link": {
+                    "type": "doc",
+                    "id": "modeling/modelhub_api_reference/modelhub.SeriesLocationStack"
+                },
+                "items": [
+                    {
+                        "type": "doc",
+                        "label": "location_stack",
+                        "id": "modeling/modelhub_api_reference/modelhub.SeriesLocationStack.location_stack"
+                    },
+                    {
+                        "type": "doc",
+                        "label": "ls",
+                        "id": "modeling/modelhub_api_reference/modelhub.SeriesLocationStack.ls"
+                    },
+                    {
+                        "type": "doc",
+                        "label": "obj",
+                        "id": "modeling/modelhub_api_reference/modelhub.SeriesLocationStack.obj"
+                    },
+                    {
+                        "type": "doc",
+                        "label": "objectiv",
+                        "id": "modeling/modelhub_api_reference/modelhub.SeriesLocationStack.objectiv"
                     }
                 ]
             }
@@ -283,162 +264,70 @@ module.exports = [
     {
         "type": "category",
         "label": "Bach",
+        "link": {
+            "type": "doc",
+            "id": "modeling/bach"
+        },
         "items": [
-            {
-                "type": "doc",
-                "label": "Overview",
-                "id": "modeling/bach"
-            },
             {
                 "type": "category",
                 "label": "What is Bach?",
-                "items": [
-                    {
-                        "type": "doc",
-                        "label": "Overview",
-                        "id": "modeling/bach_whatisbach"
-                    },
-                    {
-                        "type": "link",
-                        "label": "Get started with Bach",
-                        "href": "/modeling/bach_whatisbach#get-started-with-bach"
-                    }
-                ]
+                "link": {
+                    "type": "doc",
+                    "id": "modeling/bach_whatisbach"
+                },
+                "items": []
             },
             {
                 "type": "category",
                 "label": "Core Concepts",
-                "items": [
-                    {
-                        "type": "doc",
-                        "label": "Overview",
-                        "id": "modeling/bach_core_concepts"
-                    },
-                    {
-                        "type": "link",
-                        "label": "Delayed database operations",
-                        "href": "/modeling/bach_core_concepts#delayed-database-operations"
-                    },
-                    {
-                        "type": "link",
-                        "label": "Compatibility with pandas",
-                        "href": "/modeling/bach_core_concepts#compatibility-with-pandas"
-                    }
-                ]
+                "link": {
+                    "type": "doc",
+                    "id": "modeling/bach_core_concepts"
+                },
+                "items": []
             },
             {
                 "type": "category",
                 "label": "Bach basics",
-                "items": [
-                    {
-                        "type": "doc",
-                        "label": "Overview",
-                        "id": "modeling/bach_examples"
-                    },
-                    {
-                        "type": "link",
-                        "label": "Create a DataFrame from a database table",
-                        "href": "/modeling/bach_examples#create-a-dataframe-from-a-database-table"
-                    },
-                    {
-                        "type": "link",
-                        "label": "Basic operations",
-                        "href": "/modeling/bach_examples#basic-operations"
-                    },
-                    {
-                        "type": "link",
-                        "label": "Aggregate operations",
-                        "href": "/modeling/bach_examples#aggregate-operations"
-                    },
-                    {
-                        "type": "link",
-                        "label": "Filtering, sorting, and output",
-                        "href": "/modeling/bach_examples#filtering-sorting-and-output"
-                    },
-                    {
-                        "type": "link",
-                        "label": "Filtering by Index Labels",
-                        "href": "/modeling/bach_examples#filtering-by-index-labels"
-                    },
-                    {
-                        "type": "link",
-                        "label": "Setting Values to DataFrame Subset",
-                        "href": "/modeling/bach_examples#setting-values-to-dataframe-subset"
-                    },
-                    {
-                        "type": "link",
-                        "label": "Appendix: Example Data",
-                        "href": "/modeling/bach_examples#appendix-example-data"
-                    }
-                ]
+                "link": {
+                    "type": "doc",
+                    "id": "modeling/bach_examples"
+                },
+                "items": []
             },
             {
                 "type": "category",
                 "label": "API Reference",
+                "link": {
+                    "type": "doc",
+                    "id": "modeling/bach_reference"
+                },
                 "items": [
-                    {
-                        "type": "doc",
-                        "label": "Overview",
-                        "id": "modeling/bach_reference"
-                    },
                     {
                         "type": "category",
                         "label": "DataFrame",
+                        "link": {
+                            "type": "doc",
+                            "id": "modeling/DataFrame"
+                        },
                         "items": [
-                            {
-                                "type": "doc",
-                                "label": "Overview",
-                                "id": "modeling/DataFrame"
-                            },
-                            {
-                                "type": "category",
-                                "label": "Usage",
-                                "items": [
-                                    {
-                                        "type": "link",
-                                        "label": "Overview",
-                                        "href": "/modeling/DataFrame#usage"
-                                    },
-                                    {
-                                        "type": "link",
-                                        "label": "Getting & Setting columns",
-                                        "href": "/modeling/DataFrame#getting-setting-columns"
-                                    },
-                                    {
-                                        "type": "link",
-                                        "label": "Moving Series around",
-                                        "href": "/modeling/DataFrame#moving-series-around"
-                                    },
-                                    {
-                                        "type": "link",
-                                        "label": "Examples",
-                                        "href": "/modeling/DataFrame#examples"
-                                    },
-                                    {
-                                        "type": "link",
-                                        "label": "Database access",
-                                        "href": "/modeling/DataFrame#database-access"
-                                    }
-                                ]
-                            },
                             {
                                 "type": "category",
                                 "label": "Reference",
+                                "link": {
+                                    "type": "doc",
+                                    "id": "modeling/bach_reference_dataframe"
+                                },
                                 "items": [
-                                    {
-                                        "type": "link",
-                                        "label": "Overview",
-                                        "href": "/modeling/DataFrame#reference"
-                                    },
                                     {
                                         "type": "category",
                                         "label": "DataFrame",
+                                        "link": {
+                                            "type": "doc",
+                                            "id": "modeling/DataFrame/bach.DataFrame"
+                                        },
                                         "items": [
-                                            {
-                                                "type": "doc",
-                                                "label": "Overview",
-                                                "id": "modeling/DataFrame/bach.DataFrame"
-                                            },
                                             {
                                                 "type": "doc",
                                                 "label": "agg",
@@ -781,21 +670,15 @@ module.exports = [
                             {
                                 "type": "category",
                                 "label": "Reference by function",
+                                "link": {
+                                    "type": "doc",
+                                    "id": "modeling/bach_reference_dataframe_by_function"
+                                },
                                 "items": [
-                                    {
-                                        "type": "link",
-                                        "label": "Overview",
-                                        "href": "/modeling/DataFrame#reference-by-function"
-                                    },
                                     {
                                         "type": "category",
                                         "label": "Creation",
                                         "items": [
-                                            {
-                                                "type": "link",
-                                                "label": "Overview",
-                                                "href": "/modeling/DataFrame#creation"
-                                            },
                                             {
                                                 "type": "doc",
                                                 "label": "from_table",
@@ -823,11 +706,6 @@ module.exports = [
                                         "label": "Value accessors",
                                         "items": [
                                             {
-                                                "type": "link",
-                                                "label": "Overview",
-                                                "href": "/modeling/DataFrame#value-accessors"
-                                            },
-                                            {
                                                 "type": "doc",
                                                 "label": "head",
                                                 "id": "modeling/DataFrame/bach.DataFrame.head"
@@ -854,29 +732,113 @@ module.exports = [
                                         "label": "Attributes and underlying data",
                                         "items": [
                                             {
-                                                "type": "link",
-                                                "label": "Overview",
-                                                "href": "/modeling/DataFrame#attributes-and-underlying-data"
-                                            },
-                                            {
-                                                "type": "link",
+                                                "type": "category",
                                                 "label": "Axes",
-                                                "href": "/modeling/DataFrame#axes"
+                                                "items": [
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "index",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.index"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "data",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.data"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "all_series",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.all_series"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "index_columns",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.index_columns"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "data_columns",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.data_columns"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "group_by",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.group_by"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "order_by",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.order_by"
+                                                    }
+                                                ]
                                             },
                                             {
-                                                "type": "link",
+                                                "type": "category",
                                                 "label": "Types",
-                                                "href": "/modeling/DataFrame#types"
+                                                "items": [
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "dtypes",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.dtypes"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "index_dtypes",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.index_dtypes"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "astype",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.astype"
+                                                    }
+                                                ]
                                             },
                                             {
-                                                "type": "link",
+                                                "type": "category",
                                                 "label": "Sql Model",
-                                                "href": "/modeling/DataFrame#sql-model"
+                                                "items": [
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "materialize",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.materialize"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "get_sample",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.get_sample"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "get_unsampled",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.get_unsampled"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "view_sql",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.view_sql"
+                                                    }
+                                                ]
                                             },
                                             {
-                                                "type": "link",
+                                                "type": "category",
                                                 "label": "Variables",
-                                                "href": "/modeling/DataFrame#variables"
+                                                "items": [
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "create_variable",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.create_variable"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "set_variable",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.set_variable"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "get_all_variable_usage",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.get_all_variable_usage"
+                                                    }
+                                                ]
                                             }
                                         ]
                                     },
@@ -884,11 +846,6 @@ module.exports = [
                                         "type": "category",
                                         "label": "Reshaping, indexing, sorting & merging",
                                         "items": [
-                                            {
-                                                "type": "link",
-                                                "label": "Overview",
-                                                "href": "/modeling/DataFrame#reshaping-indexing-sorting-merging"
-                                            },
                                             {
                                                 "type": "doc",
                                                 "label": "sort_index",
@@ -966,11 +923,6 @@ module.exports = [
                                         "label": "Aggregation & windowing",
                                         "items": [
                                             {
-                                                "type": "link",
-                                                "label": "Overview",
-                                                "href": "/modeling/DataFrame#aggregation-windowing"
-                                            },
-                                            {
                                                 "type": "doc",
                                                 "label": "agg",
                                                 "id": "modeling/DataFrame/bach.DataFrame.agg"
@@ -1017,19 +969,86 @@ module.exports = [
                                         "label": "Computations & descriptive stats",
                                         "items": [
                                             {
-                                                "type": "link",
-                                                "label": "Overview",
-                                                "href": "/modeling/DataFrame#computations-descriptive-stats"
-                                            },
-                                            {
-                                                "type": "link",
+                                                "type": "category",
                                                 "label": "All types",
-                                                "href": "/modeling/DataFrame#all-types"
+                                                "items": [
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "describe",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.describe"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "count",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.count"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "min",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.min"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "max",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.max"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "median",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.median"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "mode",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.mode"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "nunique",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.nunique"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "value_counts",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.value_counts"
+                                                    }
+                                                ]
                                             },
                                             {
-                                                "type": "link",
+                                                "type": "category",
                                                 "label": "Numeric",
-                                                "href": "/modeling/DataFrame#numeric"
+                                                "items": [
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "mean",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.mean"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "quantile",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.quantile"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "sem",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.sem"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "sum",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.sum"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "std",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.std"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "var",
+                                                        "id": "modeling/DataFrame/bach.DataFrame.var"
+                                                    }
+                                                ]
                                             }
                                         ]
                                     }
@@ -1040,71 +1059,27 @@ module.exports = [
                     {
                         "type": "category",
                         "label": "Series",
+                        "link": {
+                            "type": "doc",
+                            "id": "modeling/Series"
+                        },
                         "items": [
-                            {
-                                "type": "doc",
-                                "label": "Overview",
-                                "id": "modeling/Series"
-                            },
-                            {
-                                "type": "category",
-                                "label": "Usage",
-                                "items": [
-                                    {
-                                        "type": "link",
-                                        "label": "Overview",
-                                        "href": "/modeling/Series#usage"
-                                    },
-                                    {
-                                        "type": "link",
-                                        "label": "Slicing and index access",
-                                        "href": "/modeling/Series#slicing-and-index-access"
-                                    },
-                                    {
-                                        "type": "link",
-                                        "label": "Database access",
-                                        "href": "/modeling/Series#database-access"
-                                    },
-                                    {
-                                        "type": "link",
-                                        "label": "Boolean Operations",
-                                        "href": "/modeling/Series#boolean-operations"
-                                    },
-                                    {
-                                        "type": "link",
-                                        "label": "Aggregations",
-                                        "href": "/modeling/Series#aggregations"
-                                    },
-                                    {
-                                        "type": "link",
-                                        "label": "Window Functions",
-                                        "href": "/modeling/Series#window-functions"
-                                    },
-                                    {
-                                        "type": "link",
-                                        "label": "Types",
-                                        "href": "/modeling/Series#types"
-                                    }
-                                ]
-                            },
                             {
                                 "type": "category",
                                 "label": "Reference",
+                                "link": {
+                                    "type": "doc",
+                                    "id": "modeling/bach_reference_series"
+                                },
                                 "items": [
-                                    {
-                                        "type": "link",
-                                        "label": "Overview",
-                                        "href": "/modeling/Series#reference"
-                                    },
                                     {
                                         "type": "category",
                                         "label": "Series",
+                                        "link": {
+                                            "type": "doc",
+                                            "id": "modeling/Series/bach.Series"
+                                        },
                                         "items": [
-                                            {
-                                                "type": "doc",
-                                                "label": "Overview",
-                                                "id": "modeling/Series/bach.Series"
-                                            },
                                             {
                                                 "type": "doc",
                                                 "label": "agg",
@@ -1375,12 +1350,11 @@ module.exports = [
                                     {
                                         "type": "category",
                                         "label": "SeriesBoolean",
+                                        "link": {
+                                            "type": "doc",
+                                            "id": "modeling/Series/bach.SeriesBoolean"
+                                        },
                                         "items": [
-                                            {
-                                                "type": "doc",
-                                                "label": "Overview",
-                                                "id": "modeling/Series/bach.SeriesBoolean"
-                                            },
                                             {
                                                 "type": "doc",
                                                 "label": "max",
@@ -1396,12 +1370,11 @@ module.exports = [
                                     {
                                         "type": "category",
                                         "label": "SeriesAbstractNumeric",
+                                        "link": {
+                                            "type": "doc",
+                                            "id": "modeling/Series/bach.SeriesAbstractNumeric"
+                                        },
                                         "items": [
-                                            {
-                                                "type": "doc",
-                                                "label": "Overview",
-                                                "id": "modeling/Series/bach.SeriesAbstractNumeric"
-                                            },
                                             {
                                                 "type": "doc",
                                                 "label": "cut",
@@ -1452,12 +1425,11 @@ module.exports = [
                                     {
                                         "type": "category",
                                         "label": "SeriesAbstractDateTime",
+                                        "link": {
+                                            "type": "doc",
+                                            "id": "modeling/Series/bach.SeriesAbstractDateTime"
+                                        },
                                         "items": [
-                                            {
-                                                "type": "doc",
-                                                "label": "Overview",
-                                                "id": "modeling/Series/bach.SeriesAbstractDateTime"
-                                            },
                                             {
                                                 "type": "doc",
                                                 "label": "dt",
@@ -1468,12 +1440,11 @@ module.exports = [
                                     {
                                         "type": "category",
                                         "label": "SeriesString",
+                                        "link": {
+                                            "type": "doc",
+                                            "id": "modeling/Series/bach.SeriesString"
+                                        },
                                         "items": [
-                                            {
-                                                "type": "doc",
-                                                "label": "Overview",
-                                                "id": "modeling/Series/bach.SeriesString"
-                                            },
                                             {
                                                 "type": "doc",
                                                 "label": "str",
@@ -1484,12 +1455,11 @@ module.exports = [
                                     {
                                         "type": "category",
                                         "label": "SeriesJsonb",
+                                        "link": {
+                                            "type": "doc",
+                                            "id": "modeling/Series/bach.SeriesJsonb"
+                                        },
                                         "items": [
-                                            {
-                                                "type": "doc",
-                                                "label": "Overview",
-                                                "id": "modeling/Series/bach.SeriesJsonb"
-                                            },
                                             {
                                                 "type": "doc",
                                                 "label": "json",
@@ -1507,21 +1477,15 @@ module.exports = [
                             {
                                 "type": "category",
                                 "label": "Reference by function",
+                                "link": {
+                                    "type": "doc",
+                                    "id": "modeling/bach_reference_series_by_function"
+                                },
                                 "items": [
-                                    {
-                                        "type": "link",
-                                        "label": "Overview",
-                                        "href": "/modeling/Series#reference-by-function"
-                                    },
                                     {
                                         "type": "category",
                                         "label": "Creation / re-framing",
                                         "items": [
-                                            {
-                                                "type": "link",
-                                                "label": "Overview",
-                                                "href": "/modeling/Series#creation-re-framing"
-                                            },
                                             {
                                                 "type": "doc",
                                                 "label": "from_const",
@@ -1543,11 +1507,6 @@ module.exports = [
                                         "type": "category",
                                         "label": "Value accessors",
                                         "items": [
-                                            {
-                                                "type": "link",
-                                                "label": "Overview",
-                                                "href": "/modeling/Series#value-accessors"
-                                            },
                                             {
                                                 "type": "doc",
                                                 "label": "head",
@@ -1580,24 +1539,62 @@ module.exports = [
                                         "label": "Attributes and underlying data",
                                         "items": [
                                             {
-                                                "type": "link",
-                                                "label": "Overview",
-                                                "href": "/modeling/Series#attributes-and-underlying-data"
-                                            },
-                                            {
-                                                "type": "link",
+                                                "type": "category",
                                                 "label": "Axes",
-                                                "href": "/modeling/Series#axes"
+                                                "items": [
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "name",
+                                                        "id": "modeling/Series/bach.Series.name"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "index",
+                                                        "id": "modeling/Series/bach.Series.index"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "group_by",
+                                                        "id": "modeling/Series/bach.Series.group_by"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "sorted_ascending",
+                                                        "id": "modeling/Series/bach.Series.sorted_ascending"
+                                                    }
+                                                ]
                                             },
                                             {
-                                                "type": "link",
+                                                "type": "category",
                                                 "label": "Types",
-                                                "href": "/modeling/Series#id1"
+                                                "items": [
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "dtype",
+                                                        "id": "modeling/Series/bach.Series.dtype"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "astype",
+                                                        "id": "modeling/Series/bach.Series.astype"
+                                                    }
+                                                ]
                                             },
                                             {
-                                                "type": "link",
+                                                "type": "category",
                                                 "label": "Sql Model",
-                                                "href": "/modeling/Series#sql-model"
+                                                "items": [
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "base_node",
+                                                        "id": "modeling/Series/bach.Series.base_node"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "view_sql",
+                                                        "id": "modeling/Series/bach.Series.view_sql"
+                                                    }
+                                                ]
                                             }
                                         ]
                                     },
@@ -1605,11 +1602,6 @@ module.exports = [
                                         "type": "category",
                                         "label": "Comparison and set operations",
                                         "items": [
-                                            {
-                                                "type": "link",
-                                                "label": "Overview",
-                                                "href": "/modeling/Series#comparison-and-set-operations"
-                                            },
                                             {
                                                 "type": "doc",
                                                 "label": "all_values",
@@ -1646,11 +1638,6 @@ module.exports = [
                                         "type": "category",
                                         "label": "Conversion, reshaping, sorting",
                                         "items": [
-                                            {
-                                                "type": "link",
-                                                "label": "Overview",
-                                                "href": "/modeling/Series#conversion-reshaping-sorting"
-                                            },
                                             {
                                                 "type": "doc",
                                                 "label": "sort_index",
@@ -1693,11 +1680,6 @@ module.exports = [
                                         "label": "Function application, aggregation & windowing",
                                         "items": [
                                             {
-                                                "type": "link",
-                                                "label": "Overview",
-                                                "href": "/modeling/Series#function-application-aggregation-windowing"
-                                            },
-                                            {
                                                 "type": "doc",
                                                 "label": "agg",
                                                 "id": "modeling/Series/bach.Series.agg"
@@ -1719,24 +1701,157 @@ module.exports = [
                                         "label": "Computations & descriptive stats",
                                         "items": [
                                             {
-                                                "type": "link",
-                                                "label": "Overview",
-                                                "href": "/modeling/Series#computations-descriptive-stats"
-                                            },
-                                            {
-                                                "type": "link",
+                                                "type": "category",
                                                 "label": "All types",
-                                                "href": "/modeling/Series#all-types"
+                                                "items": [
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "describe",
+                                                        "id": "modeling/Series/bach.Series.describe"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "count",
+                                                        "id": "modeling/Series/bach.Series.count"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "min",
+                                                        "id": "modeling/Series/bach.Series.min"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "max",
+                                                        "id": "modeling/Series/bach.Series.max"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "median",
+                                                        "id": "modeling/Series/bach.Series.median"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "mode",
+                                                        "id": "modeling/Series/bach.Series.mode"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "nunique",
+                                                        "id": "modeling/Series/bach.Series.nunique"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "value_counts",
+                                                        "id": "modeling/Series/bach.Series.value_counts"
+                                                    }
+                                                ]
                                             },
                                             {
-                                                "type": "link",
+                                                "type": "category",
                                                 "label": "Numeric",
-                                                "href": "/modeling/Series#numeric"
+                                                "items": [
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "cut",
+                                                        "id": "modeling/Series/bach.SeriesAbstractNumeric.cut"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "qcut",
+                                                        "id": "modeling/Series/bach.SeriesAbstractNumeric.qcut"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "mean",
+                                                        "id": "modeling/Series/bach.SeriesAbstractNumeric.mean"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "quantile",
+                                                        "id": "modeling/Series/bach.SeriesAbstractNumeric.quantile"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "sem",
+                                                        "id": "modeling/Series/bach.SeriesAbstractNumeric.sem"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "sum",
+                                                        "id": "modeling/Series/bach.SeriesAbstractNumeric.sum"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "std",
+                                                        "id": "modeling/Series/bach.SeriesAbstractNumeric.std"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "var",
+                                                        "id": "modeling/Series/bach.SeriesAbstractNumeric.var"
+                                                    }
+                                                ]
                                             },
                                             {
-                                                "type": "link",
+                                                "type": "category",
                                                 "label": "Window",
-                                                "href": "/modeling/Series#window"
+                                                "items": [
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "window_first_value",
+                                                        "id": "modeling/Series/bach.Series.window_first_value"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "window_lag",
+                                                        "id": "modeling/Series/bach.Series.window_lag"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "window_nth_value",
+                                                        "id": "modeling/Series/bach.Series.window_nth_value"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "window_lead",
+                                                        "id": "modeling/Series/bach.Series.window_lead"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "window_last_value",
+                                                        "id": "modeling/Series/bach.Series.window_last_value"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "window_row_number",
+                                                        "id": "modeling/Series/bach.Series.window_row_number"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "window_rank",
+                                                        "id": "modeling/Series/bach.Series.window_rank"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "window_dense_rank",
+                                                        "id": "modeling/Series/bach.Series.window_dense_rank"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "window_percent_rank",
+                                                        "id": "modeling/Series/bach.Series.window_percent_rank"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "window_ntile",
+                                                        "id": "modeling/Series/bach.Series.window_ntile"
+                                                    },
+                                                    {
+                                                        "type": "doc",
+                                                        "label": "window_cume_dist",
+                                                        "id": "modeling/Series/bach.Series.window_cume_dist"
+                                                    }
+                                                ]
                                             }
                                         ]
                                     }

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -301,12 +301,19 @@ div.docs-wrapper footer div.col:nth-child(2) {
 /** DOCS - Modeling **/
 
 /* Make API reference titles a bit smaller */
-h1[id^=bach], h1[id^=modelhub] {
+h1[id^=bach-dataframe], h1[id^=bach-series], h1[id^=modelhub] {
   font-size: 32px;
 }
+
+/* Hide a TOC tree if it's only used for generating navigation in the sidebar */
 .hide-toctree-ul {
   display: none;
-} 
+}
+
+/* List-items get <p>'s, so let's decrease the margin */
+ul.simple p {
+  margin: 0;
+}
 
 /* Hide/show anchors on auto-generated modeling docs */
 .sphinxAnchor:hover > a.headerlink {

--- a/docs/src/theme/DocSidebarItem/index.tsx
+++ b/docs/src/theme/DocSidebarItem/index.tsx
@@ -30,13 +30,11 @@ import type {
   PropSidebarItemLink,
 } from '@docusaurus/plugin-content-docs';
 
-// OBJECTIV: tracking + use history auto-select the first item in the category if it's a link
+// OBJECTIV: tracking
 import {
   tagExpandable,
   tagLink,
 } from "@objectiv/tracker-browser";
-import { useHistory } from "react-router-dom";
-import useBaseUrl from '@docusaurus/useBaseUrl';
 // END OBJECTIV
 
 import styles from './styles.module.css';
@@ -151,14 +149,6 @@ function DocSidebarItemCategory({
     autoCollapseSidebarCategories,
   ]);
 
-  // OBJECTIV: use history auto-select the first item in the category if it's a link
-  let history = useHistory();
-  let firstItemInCategoryLink = "";
-  if (items && items.length > 0 && items[0].type == 'link') {
-    firstItemInCategoryLink = useBaseUrl(items[0].href);
-  }
-  // OBJECTIV END
-
   return (
     <li
       // OBJECTIV
@@ -195,9 +185,6 @@ function DocSidebarItemCategory({
                   if (href) {
                     updateCollapsed(false);
                   } else {
-                    // OBJECTIV: auto-select the first item in the category if it's a link
-                    firstItemInCategoryLink != "" ? history.push(firstItemInCategoryLink) : null;
-                    // OBJECTIV END
                     e.preventDefault();
                     updateCollapsed();
                   }

--- a/docs/static/_modeling/DataFrame.html
+++ b/docs/static/_modeling/DataFrame.html
@@ -2,6 +2,187 @@
                 
   <section id="dataframe">
 <h1>DataFrame<a class="headerlink" href="#dataframe" title="Permalink to this headline">#</a></h1>
+<div class="toctree-wrapper hide-toctree-ul compound">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="bach_reference_dataframe.html">Reference</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="DataFrame/bach.DataFrame.html">bach.DataFrame</a><ul>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.agg.html">bach.DataFrame.agg</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.aggregate.html">bach.DataFrame.aggregate</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.append.html">bach.DataFrame.append</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.astype.html">bach.DataFrame.astype</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.bfill.html">bach.DataFrame.bfill</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.copy.html">bach.DataFrame.copy</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.count.html">bach.DataFrame.count</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.create_variable.html">bach.DataFrame.create_variable</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.cube.html">bach.DataFrame.cube</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.describe.html">bach.DataFrame.describe</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.drop.html">bach.DataFrame.drop</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.drop_duplicates.html">bach.DataFrame.drop_duplicates</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.dropna.html">bach.DataFrame.dropna</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.expanding.html">bach.DataFrame.expanding</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.ffill.html">bach.DataFrame.ffill</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.fillna.html">bach.DataFrame.fillna</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.from_model.html">bach.DataFrame.from_model</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.from_pandas.html">bach.DataFrame.from_pandas</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.from_table.html">bach.DataFrame.from_table</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.get_all_variable_usage.html">bach.DataFrame.get_all_variable_usage</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.get_sample.html">bach.DataFrame.get_sample</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.get_unsampled.html">bach.DataFrame.get_unsampled</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.groupby.html">bach.DataFrame.groupby</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.head.html">bach.DataFrame.head</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.materialize.html">bach.DataFrame.materialize</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.max.html">bach.DataFrame.max</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.mean.html">bach.DataFrame.mean</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.median.html">bach.DataFrame.median</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.merge.html">bach.DataFrame.merge</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.min.html">bach.DataFrame.min</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.mode.html">bach.DataFrame.mode</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.nunique.html">bach.DataFrame.nunique</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.quantile.html">bach.DataFrame.quantile</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.rename.html">bach.DataFrame.rename</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.reset_index.html">bach.DataFrame.reset_index</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.rolling.html">bach.DataFrame.rolling</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.rollup.html">bach.DataFrame.rollup</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.round.html">bach.DataFrame.round</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.sem.html">bach.DataFrame.sem</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.set_index.html">bach.DataFrame.set_index</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.set_savepoint.html">bach.DataFrame.set_savepoint</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.set_variable.html">bach.DataFrame.set_variable</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.sort_index.html">bach.DataFrame.sort_index</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.sort_values.html">bach.DataFrame.sort_values</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.stack.html">bach.DataFrame.stack</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.std.html">bach.DataFrame.std</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.sum.html">bach.DataFrame.sum</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.to_numpy.html">bach.DataFrame.to_numpy</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.to_pandas.html">bach.DataFrame.to_pandas</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.value_counts.html">bach.DataFrame.value_counts</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.var.html">bach.DataFrame.var</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.view_sql.html">bach.DataFrame.view_sql</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.window.html">bach.DataFrame.window</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.all_series.html">bach.DataFrame.all_series</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.data.html">bach.DataFrame.data</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.data_columns.html">bach.DataFrame.data_columns</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.dtypes.html">bach.DataFrame.dtypes</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.group_by.html">bach.DataFrame.group_by</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.index.html">bach.DataFrame.index</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.index_columns.html">bach.DataFrame.index_columns</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.index_dtypes.html">bach.DataFrame.index_dtypes</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.is_materialized.html">bach.DataFrame.is_materialized</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.loc.html">bach.DataFrame.loc</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.order_by.html">bach.DataFrame.order_by</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.savepoints.html">bach.DataFrame.savepoints</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.values.html">bach.DataFrame.values</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.variables.html">bach.DataFrame.variables</a></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</div>
+<div class="toctree-wrapper hide-toctree-ul compound">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="bach_reference_dataframe_by_function.html">Reference by function</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="bach_reference_dataframe_by_function.html#creation">Creation</a><ul>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.from_table.html">bach.DataFrame.from_table</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.from_model.html">bach.DataFrame.from_model</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.from_pandas.html">bach.DataFrame.from_pandas</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.copy.html">bach.DataFrame.copy</a></li>
+</ul>
+</li>
+<li class="toctree-l2"><a class="reference internal" href="bach_reference_dataframe_by_function.html#value-accessors">Value accessors</a><ul>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.head.html">bach.DataFrame.head</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.to_pandas.html">bach.DataFrame.to_pandas</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.values.html">bach.DataFrame.values</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.loc.html">bach.DataFrame.loc</a></li>
+</ul>
+</li>
+<li class="toctree-l2"><a class="reference internal" href="bach_reference_dataframe_by_function.html#attributes-and-underlying-data">Attributes and underlying data</a><ul>
+<li class="toctree-l3"><a class="reference internal" href="bach_reference_dataframe_by_function.html#axes">Axes</a><ul>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.index.html">bach.DataFrame.index</a></li>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.data.html">bach.DataFrame.data</a></li>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.all_series.html">bach.DataFrame.all_series</a></li>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.index_columns.html">bach.DataFrame.index_columns</a></li>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.data_columns.html">bach.DataFrame.data_columns</a></li>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.group_by.html">bach.DataFrame.group_by</a></li>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.order_by.html">bach.DataFrame.order_by</a></li>
+</ul>
+</li>
+<li class="toctree-l3"><a class="reference internal" href="bach_reference_dataframe_by_function.html#types">Types</a><ul>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.dtypes.html">bach.DataFrame.dtypes</a></li>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.index_dtypes.html">bach.DataFrame.index_dtypes</a></li>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.astype.html">bach.DataFrame.astype</a></li>
+</ul>
+</li>
+<li class="toctree-l3"><a class="reference internal" href="bach_reference_dataframe_by_function.html#sql-model">Sql Model</a><ul>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.materialize.html">bach.DataFrame.materialize</a></li>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.get_sample.html">bach.DataFrame.get_sample</a></li>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.get_unsampled.html">bach.DataFrame.get_unsampled</a></li>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.view_sql.html">bach.DataFrame.view_sql</a></li>
+</ul>
+</li>
+<li class="toctree-l3"><a class="reference internal" href="bach_reference_dataframe_by_function.html#variables">Variables</a><ul>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.create_variable.html">bach.DataFrame.create_variable</a></li>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.set_variable.html">bach.DataFrame.set_variable</a></li>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.get_all_variable_usage.html">bach.DataFrame.get_all_variable_usage</a></li>
+</ul>
+</li>
+</ul>
+</li>
+<li class="toctree-l2"><a class="reference internal" href="bach_reference_dataframe_by_function.html#reshaping-indexing-sorting-merging">Reshaping, indexing, sorting &amp; merging</a><ul>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.sort_index.html">bach.DataFrame.sort_index</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.sort_values.html">bach.DataFrame.sort_values</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.rename.html">bach.DataFrame.rename</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.drop.html">bach.DataFrame.drop</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.drop_duplicates.html">bach.DataFrame.drop_duplicates</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.dropna.html">bach.DataFrame.dropna</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.reset_index.html">bach.DataFrame.reset_index</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.set_index.html">bach.DataFrame.set_index</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.merge.html">bach.DataFrame.merge</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.append.html">bach.DataFrame.append</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.fillna.html">bach.DataFrame.fillna</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.ffill.html">bach.DataFrame.ffill</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.bfill.html">bach.DataFrame.bfill</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.stack.html">bach.DataFrame.stack</a></li>
+</ul>
+</li>
+<li class="toctree-l2"><a class="reference internal" href="bach_reference_dataframe_by_function.html#aggregation-windowing">Aggregation &amp; windowing</a><ul>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.agg.html">bach.DataFrame.agg</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.aggregate.html">bach.DataFrame.aggregate</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.groupby.html">bach.DataFrame.groupby</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.rollup.html">bach.DataFrame.rollup</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.cube.html">bach.DataFrame.cube</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.window.html">bach.DataFrame.window</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.rolling.html">bach.DataFrame.rolling</a></li>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.expanding.html">bach.DataFrame.expanding</a></li>
+</ul>
+</li>
+<li class="toctree-l2"><a class="reference internal" href="bach_reference_dataframe_by_function.html#computations-descriptive-stats">Computations &amp; descriptive stats</a><ul>
+<li class="toctree-l3"><a class="reference internal" href="bach_reference_dataframe_by_function.html#all-types">All types</a><ul>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.describe.html">bach.DataFrame.describe</a></li>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.count.html">bach.DataFrame.count</a></li>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.min.html">bach.DataFrame.min</a></li>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.max.html">bach.DataFrame.max</a></li>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.median.html">bach.DataFrame.median</a></li>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.mode.html">bach.DataFrame.mode</a></li>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.nunique.html">bach.DataFrame.nunique</a></li>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.value_counts.html">bach.DataFrame.value_counts</a></li>
+</ul>
+</li>
+<li class="toctree-l3"><a class="reference internal" href="bach_reference_dataframe_by_function.html#numeric">Numeric</a><ul>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.mean.html">bach.DataFrame.mean</a></li>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.quantile.html">bach.DataFrame.quantile</a></li>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.sem.html">bach.DataFrame.sem</a></li>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.sum.html">bach.DataFrame.sum</a></li>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.std.html">bach.DataFrame.std</a></li>
+<li class="toctree-l4"><a class="reference internal" href="DataFrame/bach.DataFrame.var.html">bach.DataFrame.var</a></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</div>
 <p>A mutable DataFrame representing tabular data in a database and enabling operations on that data.</p>
 <p>A Bach DataFrame object can be used to process large amounts of data on a database, while using an api
 that is based on the pandas api. This allows the database to group and aggregate data, sample data and
@@ -61,322 +242,6 @@ Operations on the DataFrame are combined and translated to a single SQL query, w
 only when one of the above mentioned data-transfer functions is called.</p>
 <p>The API of this DataFrame is partially compatible with Pandas DataFrames. For more on Pandas
 DataFrames see <a class="reference external" href="https://pandas.pydata.org/docs/reference/frame.html">https://pandas.pydata.org/docs/reference/frame.html</a></p>
-</section>
-</section>
-<section id="reference">
-<h2>Reference<a class="headerlink" href="#reference" title="Permalink to this headline">#</a></h2>
-<table class="autosummary longtable table autosummary">
-<colgroup>
-<col style="width: 10%"/>
-<col style="width: 90%"/>
-</colgroup>
-<tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.html#bach.DataFrame" title="bach.DataFrame"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame</span></code></a>(engine,&#160;base_node,&#160;index,&#160;series,&#160;...)</p></td>
-<td><p>A mutable DataFrame representing tabular data in a database and enabling operations on that data.</p></td>
-</tr>
-</tbody>
-</table>
-</section>
-<section id="reference-by-function">
-<h2>Reference by function<a class="headerlink" href="#reference-by-function" title="Permalink to this headline">#</a></h2>
-<section id="creation">
-<h3>Creation<a class="headerlink" href="#creation" title="Permalink to this headline">#</a></h3>
-<table class="autosummary longtable table autosummary">
-<colgroup>
-<col style="width: 10%"/>
-<col style="width: 90%"/>
-</colgroup>
-<tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.from_table.html#bach.DataFrame.from_table" title="bach.DataFrame.from_table"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.from_table</span></code></a>(engine,&#160;table_name,&#160;index)</p></td>
-<td><p>Instantiate a new DataFrame based on the content of an existing table in the database.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.from_model.html#bach.DataFrame.from_model" title="bach.DataFrame.from_model"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.from_model</span></code></a>(engine,&#160;model,&#160;index[,&#160;...])</p></td>
-<td><p>Instantiate a new DataFrame based on the result of the query defined in <cite>model</cite>.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.from_pandas.html#bach.DataFrame.from_pandas" title="bach.DataFrame.from_pandas"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.from_pandas</span></code></a>(engine,&#160;df,&#160;...[,&#160;...])</p></td>
-<td><p>Instantiate a new DataFrame based on the content of a Pandas DataFrame.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.copy.html#bach.DataFrame.copy" title="bach.DataFrame.copy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.copy</span></code></a>()</p></td>
-<td><p>Return a copy of this DataFrame.</p></td>
-</tr>
-</tbody>
-</table>
-</section>
-<section id="value-accessors">
-<h3>Value accessors<a class="headerlink" href="#value-accessors" title="Permalink to this headline">#</a></h3>
-<table class="autosummary longtable table autosummary">
-<colgroup>
-<col style="width: 10%"/>
-<col style="width: 90%"/>
-</colgroup>
-<tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.head.html#bach.DataFrame.head" title="bach.DataFrame.head"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.head</span></code></a>([n])</p></td>
-<td><p>Similar to <code class="xref py py-meth docutils literal notranslate"><span class="pre">to_pandas()</span></code> but only returns the first <cite>n</cite> rows.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.to_pandas.html#bach.DataFrame.to_pandas" title="bach.DataFrame.to_pandas"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.to_pandas</span></code></a>([limit])</p></td>
-<td><p>Run a SQL query representing the current state of this DataFrame against the database and return the resulting data as a Pandas DataFrame.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.values.html#bach.DataFrame.values" title="bach.DataFrame.values"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.values</span></code></a></p></td>
-<td><p>Return a Numpy representation of the DataFrame akin <code class="xref py py-attr docutils literal notranslate"><span class="pre">pandas.Dataframe.values</span></code></p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.loc.html#bach.DataFrame.loc" title="bach.DataFrame.loc"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.loc</span></code></a></p></td>
-<td><p>The <code class="docutils literal notranslate"><span class="pre">.loc</span></code> accessor offers different methods for label-based selection.</p></td>
-</tr>
-</tbody>
-</table>
-</section>
-<section id="attributes-and-underlying-data">
-<h3>Attributes and underlying data<a class="headerlink" href="#attributes-and-underlying-data" title="Permalink to this headline">#</a></h3>
-<section id="axes">
-<h4>Axes<a class="headerlink" href="#axes" title="Permalink to this headline">#</a></h4>
-<table class="autosummary longtable table autosummary">
-<colgroup>
-<col style="width: 10%"/>
-<col style="width: 90%"/>
-</colgroup>
-<tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.index.html#bach.DataFrame.index" title="bach.DataFrame.index"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.index</span></code></a></p></td>
-<td><p>Get the index dictionary <cite>{name: Series}</cite></p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.data.html#bach.DataFrame.data" title="bach.DataFrame.data"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.data</span></code></a></p></td>
-<td><p>Get the data dictionary <cite>{name: Series}</cite></p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.all_series.html#bach.DataFrame.all_series" title="bach.DataFrame.all_series"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.all_series</span></code></a></p></td>
-<td><p>Get all index and data Series in a dictionary <cite>{name: Series}</cite></p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.index_columns.html#bach.DataFrame.index_columns" title="bach.DataFrame.index_columns"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.index_columns</span></code></a></p></td>
-<td><p>Get all the index columns' names in a List</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.data_columns.html#bach.DataFrame.data_columns" title="bach.DataFrame.data_columns"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.data_columns</span></code></a></p></td>
-<td><p>Get all the data Series' names in a List</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.group_by.html#bach.DataFrame.group_by" title="bach.DataFrame.group_by"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.group_by</span></code></a></p></td>
-<td><p>Get this DataFrame's grouping, if any.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.order_by.html#bach.DataFrame.order_by" title="bach.DataFrame.order_by"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.order_by</span></code></a></p></td>
-<td><p>Get the current sort order, if any.</p></td>
-</tr>
-</tbody>
-</table>
-</section>
-<section id="types">
-<h4>Types<a class="headerlink" href="#types" title="Permalink to this headline">#</a></h4>
-<table class="autosummary longtable table autosummary">
-<colgroup>
-<col style="width: 10%"/>
-<col style="width: 90%"/>
-</colgroup>
-<tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.dtypes.html#bach.DataFrame.dtypes" title="bach.DataFrame.dtypes"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.dtypes</span></code></a></p></td>
-<td><p>Get the data Series' dtypes in a dictionary <cite>{name: dtype}</cite></p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.index_dtypes.html#bach.DataFrame.index_dtypes" title="bach.DataFrame.index_dtypes"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.index_dtypes</span></code></a></p></td>
-<td><p>Get the index Series' dtypes in a dictionary <cite>{name: dtype}</cite></p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.astype.html#bach.DataFrame.astype" title="bach.DataFrame.astype"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.astype</span></code></a>(dtype)</p></td>
-<td><p>Cast all or some of the data columns to a certain dtype.</p></td>
-</tr>
-</tbody>
-</table>
-</section>
-<section id="sql-model">
-<h4>Sql Model<a class="headerlink" href="#sql-model" title="Permalink to this headline">#</a></h4>
-<table class="autosummary longtable table autosummary">
-<colgroup>
-<col style="width: 10%"/>
-<col style="width: 90%"/>
-</colgroup>
-<tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.materialize.html#bach.DataFrame.materialize" title="bach.DataFrame.materialize"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.materialize</span></code></a>([node_name,&#160;inplace,&#160;...])</p></td>
-<td><p>Create a copy of this DataFrame with as base_node the current DataFrame's state.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.get_sample.html#bach.DataFrame.get_sample" title="bach.DataFrame.get_sample"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.get_sample</span></code></a>(table_name[,&#160;filter,&#160;...])</p></td>
-<td><p>Returns a DataFrame whose data is a sample of the current DataFrame object.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.get_unsampled.html#bach.DataFrame.get_unsampled" title="bach.DataFrame.get_unsampled"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.get_unsampled</span></code></a>()</p></td>
-<td><p>Return a copy of the current sampled DataFrame, that undoes calling <code class="xref py py-meth docutils literal notranslate"><span class="pre">get_sample()</span></code> earlier.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.view_sql.html#bach.DataFrame.view_sql" title="bach.DataFrame.view_sql"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.view_sql</span></code></a>([limit])</p></td>
-<td><p>Translate the current state of this DataFrame into a SQL query.</p></td>
-</tr>
-</tbody>
-</table>
-</section>
-<section id="variables">
-<h4>Variables<a class="headerlink" href="#variables" title="Permalink to this headline">#</a></h4>
-<table class="autosummary longtable table autosummary">
-<colgroup>
-<col style="width: 10%"/>
-<col style="width: 90%"/>
-</colgroup>
-<tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.create_variable.html#bach.DataFrame.create_variable" title="bach.DataFrame.create_variable"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.create_variable</span></code></a>(name,&#160;value,&#160;*[,&#160;...])</p></td>
-<td><p>Create a Series object that can be used as a variable, within the returned DataFrame.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.set_variable.html#bach.DataFrame.set_variable" title="bach.DataFrame.set_variable"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.set_variable</span></code></a>(name,&#160;value,&#160;*[,&#160;dtype])</p></td>
-<td><p>Return a copy of this DataFrame with the variable value updated.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.get_all_variable_usage.html#bach.DataFrame.get_all_variable_usage" title="bach.DataFrame.get_all_variable_usage"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.get_all_variable_usage</span></code></a>()</p></td>
-<td><p>Get all variables that influence the values of this DataFrame.</p></td>
-</tr>
-</tbody>
-</table>
-</section>
-</section>
-<section id="reshaping-indexing-sorting-merging">
-<h3>Reshaping, indexing, sorting &amp; merging<a class="headerlink" href="#reshaping-indexing-sorting-merging" title="Permalink to this headline">#</a></h3>
-<table class="autosummary longtable table autosummary">
-<colgroup>
-<col style="width: 10%"/>
-<col style="width: 90%"/>
-</colgroup>
-<tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.sort_index.html#bach.DataFrame.sort_index" title="bach.DataFrame.sort_index"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.sort_index</span></code></a>([level,&#160;ascending])</p></td>
-<td><p>Sort dataframe by index levels.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.sort_values.html#bach.DataFrame.sort_values" title="bach.DataFrame.sort_values"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.sort_values</span></code></a>(by[,&#160;ascending])</p></td>
-<td><p>Create a new DataFrame with the specified sorting order.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.rename.html#bach.DataFrame.rename" title="bach.DataFrame.rename"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.rename</span></code></a>([mapper,&#160;index,&#160;columns,&#160;...])</p></td>
-<td><p>Rename columns.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.drop.html#bach.DataFrame.drop" title="bach.DataFrame.drop"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.drop</span></code></a>([labels,&#160;index,&#160;columns,&#160;...])</p></td>
-<td><p>Drop columns from the DataFrame</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.drop_duplicates.html#bach.DataFrame.drop_duplicates" title="bach.DataFrame.drop_duplicates"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.drop_duplicates</span></code></a>([subset,&#160;keep,&#160;...])</p></td>
-<td><p>Return a dataframe with duplicated rows removed based on all series labels or a subset of labels.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.dropna.html#bach.DataFrame.dropna" title="bach.DataFrame.dropna"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.dropna</span></code></a>(*[,&#160;axis,&#160;how,&#160;thresh,&#160;subset])</p></td>
-<td><p>Removes rows with missing values (NaN, None and SQL NULL).</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.reset_index.html#bach.DataFrame.reset_index" title="bach.DataFrame.reset_index"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.reset_index</span></code></a>([level,&#160;drop])</p></td>
-<td><p>Drops the current index.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.set_index.html#bach.DataFrame.set_index" title="bach.DataFrame.set_index"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.set_index</span></code></a>(keys[,&#160;drop,&#160;append])</p></td>
-<td><p>Set this dataframe's index to the the index given in keys</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.merge.html#bach.DataFrame.merge" title="bach.DataFrame.merge"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.merge</span></code></a>(right[,&#160;how,&#160;on,&#160;left_on,&#160;...])</p></td>
-<td><p>Join the right Dataframe or Series on self.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.append.html#bach.DataFrame.append" title="bach.DataFrame.append"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.append</span></code></a>(other[,&#160;ignore_index,&#160;sort])</p></td>
-<td><p>Append rows of other dataframes to the the caller dataframe.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.fillna.html#bach.DataFrame.fillna" title="bach.DataFrame.fillna"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.fillna</span></code></a>(*[,&#160;value,&#160;method,&#160;axis,&#160;...])</p></td>
-<td><p>Fill any NULL value using a method or with a given value.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.ffill.html#bach.DataFrame.ffill" title="bach.DataFrame.ffill"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.ffill</span></code></a>([sort_by,&#160;ascending])</p></td>
-<td><p>Fill missing values by propagating the last non-nullable value in each series.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.bfill.html#bach.DataFrame.bfill" title="bach.DataFrame.bfill"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.bfill</span></code></a>([sort_by,&#160;ascending])</p></td>
-<td><p>Fill missing values by using the next non-nullable value in each series.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.stack.html#bach.DataFrame.stack" title="bach.DataFrame.stack"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.stack</span></code></a>([dropna])</p></td>
-<td><p>Stacks all data_columns into a single index series.</p></td>
-</tr>
-</tbody>
-</table>
-</section>
-<section id="aggregation-windowing">
-<h3>Aggregation &amp; windowing<a class="headerlink" href="#aggregation-windowing" title="Permalink to this headline">#</a></h3>
-<table class="autosummary longtable table autosummary">
-<colgroup>
-<col style="width: 10%"/>
-<col style="width: 90%"/>
-</colgroup>
-<tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.agg.html#bach.DataFrame.agg" title="bach.DataFrame.agg"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.agg</span></code></a>(func[,&#160;axis,&#160;numeric_only])</p></td>
-<td><p>Aggregate using one or more operations over the specified axis.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.aggregate.html#bach.DataFrame.aggregate" title="bach.DataFrame.aggregate"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.aggregate</span></code></a>(func[,&#160;axis,&#160;numeric_only])</p></td>
-<td><p>Alias for <code class="xref py py-meth docutils literal notranslate"><span class="pre">agg()</span></code></p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.groupby.html#bach.DataFrame.groupby" title="bach.DataFrame.groupby"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.groupby</span></code></a>([by])</p></td>
-<td><p>Group by any of the series currently in this DataDrame, both from index as well as data.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.rollup.html#bach.DataFrame.rollup" title="bach.DataFrame.rollup"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.rollup</span></code></a>(by)</p></td>
-<td><p>Group by and roll up over the column(s) <cite>by</cite>, replacing any current grouping.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.cube.html#bach.DataFrame.cube" title="bach.DataFrame.cube"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.cube</span></code></a>(by)</p></td>
-<td><p>Group by and cube over the column(s) <cite>by</cite>.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.window.html#bach.DataFrame.window" title="bach.DataFrame.window"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.window</span></code></a>(**frame_args)</p></td>
-<td><p>Create a window on the current dataframe grouping and its sorting.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.rolling.html#bach.DataFrame.rolling" title="bach.DataFrame.rolling"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.rolling</span></code></a>(window[,&#160;min_periods,&#160;...])</p></td>
-<td><p>A rolling window of size 'window', by default right aligned.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.expanding.html#bach.DataFrame.expanding" title="bach.DataFrame.expanding"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.expanding</span></code></a>([min_periods,&#160;center])</p></td>
-<td><p>Create an expanding window starting with the first row in the group, with at least <cite>min_period</cite> observations.</p></td>
-</tr>
-</tbody>
-</table>
-</section>
-<section id="computations-descriptive-stats">
-<span id="dataframe-stats"/><h3>Computations &amp; descriptive stats<a class="headerlink" href="#computations-descriptive-stats" title="Permalink to this headline">#</a></h3>
-<section id="all-types">
-<h4>All types<a class="headerlink" href="#all-types" title="Permalink to this headline">#</a></h4>
-<table class="autosummary longtable table autosummary">
-<colgroup>
-<col style="width: 10%"/>
-<col style="width: 90%"/>
-</colgroup>
-<tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.describe.html#bach.DataFrame.describe" title="bach.DataFrame.describe"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.describe</span></code></a>([percentiles,&#160;include,&#160;...])</p></td>
-<td><p>Returns descriptive statistics.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.count.html#bach.DataFrame.count" title="bach.DataFrame.count"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.count</span></code></a>([axis,&#160;level,&#160;numeric_only])</p></td>
-<td><p>Count all non-NULL values in each column.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.min.html#bach.DataFrame.min" title="bach.DataFrame.min"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.min</span></code></a>([axis,&#160;skipna,&#160;level,&#160;...])</p></td>
-<td><p>Returns the minimum of all values in each column.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.max.html#bach.DataFrame.max" title="bach.DataFrame.max"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.max</span></code></a>([axis,&#160;skipna,&#160;level,&#160;...])</p></td>
-<td><p>Returns the maximum of all values in each column.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.median.html#bach.DataFrame.median" title="bach.DataFrame.median"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.median</span></code></a>([axis,&#160;skipna,&#160;level,&#160;...])</p></td>
-<td><p>Returns the median of all values in each column.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.mode.html#bach.DataFrame.mode" title="bach.DataFrame.mode"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.mode</span></code></a>([axis,&#160;skipna,&#160;level,&#160;...])</p></td>
-<td><p>Returns the mode of all values in each column.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.nunique.html#bach.DataFrame.nunique" title="bach.DataFrame.nunique"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.nunique</span></code></a>([axis,&#160;skipna])</p></td>
-<td><p>Returns the number of unique values in each column.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.value_counts.html#bach.DataFrame.value_counts" title="bach.DataFrame.value_counts"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.value_counts</span></code></a>([subset,&#160;normalize,&#160;...])</p></td>
-<td><p>Returns a series containing counts of each unique row in the DataFrame</p></td>
-</tr>
-</tbody>
-</table>
-</section>
-<section id="numeric">
-<h4>Numeric<a class="headerlink" href="#numeric" title="Permalink to this headline">#</a></h4>
-<table class="autosummary longtable table autosummary">
-<colgroup>
-<col style="width: 10%"/>
-<col style="width: 90%"/>
-</colgroup>
-<tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.mean.html#bach.DataFrame.mean" title="bach.DataFrame.mean"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.mean</span></code></a>([axis,&#160;skipna,&#160;level,&#160;...])</p></td>
-<td><p>Returns the mean of all values in each column.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.quantile.html#bach.DataFrame.quantile" title="bach.DataFrame.quantile"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.quantile</span></code></a>([q,&#160;axis])</p></td>
-<td><p>Returns the quantile per numeric/timedelta column.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.sem.html#bach.DataFrame.sem" title="bach.DataFrame.sem"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.sem</span></code></a>([axis,&#160;skipna,&#160;level,&#160;ddof,&#160;...])</p></td>
-<td><p>Returns the unbiased standard error of the mean of each column.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.sum.html#bach.DataFrame.sum" title="bach.DataFrame.sum"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.sum</span></code></a>([axis,&#160;skipna,&#160;level,&#160;...])</p></td>
-<td><p>Returns the sum of all values in each column.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.std.html#bach.DataFrame.std" title="bach.DataFrame.std"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.std</span></code></a>([axis,&#160;skipna,&#160;level,&#160;ddof,&#160;...])</p></td>
-<td><p>Returns the sample standard deviation of each column.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.var.html#bach.DataFrame.var" title="bach.DataFrame.var"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.var</span></code></a>([axis,&#160;skipna,&#160;level,&#160;ddof,&#160;...])</p></td>
-<td><p>Returns the unbiased variance of each column.</p></td>
-</tr>
-</tbody>
-</table>
-</section>
 </section>
 </section>
 </section>

--- a/docs/static/_modeling/Series.html
+++ b/docs/static/_modeling/Series.html
@@ -2,6 +2,204 @@
                 
   <section id="series">
 <h1>Series<a class="headerlink" href="#series" title="Permalink to this headline">#</a></h1>
+<div class="toctree-wrapper hide-toctree-ul compound">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="bach_reference_series.html">Reference</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="Series/bach.Series.html">bach.Series</a><ul>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.agg.html">bach.Series.agg</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.aggregate.html">bach.Series.aggregate</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.all_values.html">bach.Series.all_values</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.any_value.html">bach.Series.any_value</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.append.html">bach.Series.append</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.apply_func.html">bach.Series.apply_func</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.astype.html">bach.Series.astype</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.copy.html">bach.Series.copy</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.count.html">bach.Series.count</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.describe.html">bach.Series.describe</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.drop_duplicates.html">bach.Series.drop_duplicates</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.dropna.html">bach.Series.dropna</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.exists.html">bach.Series.exists</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.fillna.html">bach.Series.fillna</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.from_const.html">bach.Series.from_const</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.head.html">bach.Series.head</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.isin.html">bach.Series.isin</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.isnull.html">bach.Series.isnull</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.max.html">bach.Series.max</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.median.html">bach.Series.median</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.min.html">bach.Series.min</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.mode.html">bach.Series.mode</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.notnull.html">bach.Series.notnull</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.nunique.html">bach.Series.nunique</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.sort_index.html">bach.Series.sort_index</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.sort_values.html">bach.Series.sort_values</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.to_frame.html">bach.Series.to_frame</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.to_numpy.html">bach.Series.to_numpy</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.to_pandas.html">bach.Series.to_pandas</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.unique.html">bach.Series.unique</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.unstack.html">bach.Series.unstack</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.value_counts.html">bach.Series.value_counts</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.view_sql.html">bach.Series.view_sql</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.window_cume_dist.html">bach.Series.window_cume_dist</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.window_dense_rank.html">bach.Series.window_dense_rank</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.window_first_value.html">bach.Series.window_first_value</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.window_lag.html">bach.Series.window_lag</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.window_last_value.html">bach.Series.window_last_value</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.window_lead.html">bach.Series.window_lead</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.window_nth_value.html">bach.Series.window_nth_value</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.window_ntile.html">bach.Series.window_ntile</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.window_percent_rank.html">bach.Series.window_percent_rank</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.window_rank.html">bach.Series.window_rank</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.window_row_number.html">bach.Series.window_row_number</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.array.html">bach.Series.array</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.base_node.html">bach.Series.base_node</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.group_by.html">bach.Series.group_by</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.index.html">bach.Series.index</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.index_sorting.html">bach.Series.index_sorting</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.name.html">bach.Series.name</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.sorted_ascending.html">bach.Series.sorted_ascending</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.value.html">bach.Series.value</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.values.html">bach.Series.values</a></li>
+</ul>
+</li>
+<li class="toctree-l2"><a class="reference internal" href="Series/bach.SeriesBoolean.html">bach.SeriesBoolean</a><ul>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.SeriesBoolean.max.html">bach.SeriesBoolean.max</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.SeriesBoolean.min.html">bach.SeriesBoolean.min</a></li>
+</ul>
+</li>
+<li class="toctree-l2"><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.html">bach.SeriesAbstractNumeric</a><ul>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.cut.html">bach.SeriesAbstractNumeric.cut</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.mean.html">bach.SeriesAbstractNumeric.mean</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.qcut.html">bach.SeriesAbstractNumeric.qcut</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.quantile.html">bach.SeriesAbstractNumeric.quantile</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.round.html">bach.SeriesAbstractNumeric.round</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.sem.html">bach.SeriesAbstractNumeric.sem</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.std.html">bach.SeriesAbstractNumeric.std</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.sum.html">bach.SeriesAbstractNumeric.sum</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.var.html">bach.SeriesAbstractNumeric.var</a></li>
+</ul>
+</li>
+<li class="toctree-l2"><a class="reference internal" href="Series/bach.SeriesAbstractDateTime.html">bach.SeriesAbstractDateTime</a><ul>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.SeriesAbstractDateTime.dt.html">bach.SeriesAbstractDateTime.dt</a></li>
+</ul>
+</li>
+<li class="toctree-l2"><a class="reference internal" href="Series/bach.SeriesString.html">bach.SeriesString</a><ul>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.SeriesString.str.html">bach.SeriesString.str</a></li>
+</ul>
+</li>
+<li class="toctree-l2"><a class="reference internal" href="Series/bach.SeriesJsonb.html">bach.SeriesJsonb</a><ul>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.SeriesJsonb.json.html">bach.SeriesJsonb.json</a></li>
+</ul>
+</li>
+<li class="toctree-l2"><a class="reference internal" href="Series/bach.SeriesJson.html">bach.SeriesJson</a></li>
+</ul>
+</li>
+</ul>
+</div>
+<div class="toctree-wrapper hide-toctree-ul compound">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="bach_reference_series_by_function.html">Reference by function</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="bach_reference_series_by_function.html#creation-re-framing">Creation / re-framing</a><ul>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.from_const.html">bach.Series.from_const</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.to_frame.html">bach.Series.to_frame</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.copy.html">bach.Series.copy</a></li>
+</ul>
+</li>
+<li class="toctree-l2"><a class="reference internal" href="bach_reference_series_by_function.html#value-accessors">Value accessors</a><ul>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.head.html">bach.Series.head</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.to_pandas.html">bach.Series.to_pandas</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.array.html">bach.Series.array</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.values.html">bach.Series.values</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.value.html">bach.Series.value</a></li>
+</ul>
+</li>
+<li class="toctree-l2"><a class="reference internal" href="bach_reference_series_by_function.html#attributes-and-underlying-data">Attributes and underlying data</a><ul>
+<li class="toctree-l3"><a class="reference internal" href="bach_reference_series_by_function.html#axes">Axes</a><ul>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.Series.name.html">bach.Series.name</a></li>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.Series.index.html">bach.Series.index</a></li>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.Series.group_by.html">bach.Series.group_by</a></li>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.Series.sorted_ascending.html">bach.Series.sorted_ascending</a></li>
+</ul>
+</li>
+<li class="toctree-l3"><a class="reference internal" href="bach_reference_series_by_function.html#types">Types</a><ul>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.Series.dtype.html">bach.Series.dtype</a></li>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.Series.astype.html">bach.Series.astype</a></li>
+</ul>
+</li>
+<li class="toctree-l3"><a class="reference internal" href="bach_reference_series_by_function.html#sql-model">Sql Model</a><ul>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.Series.base_node.html">bach.Series.base_node</a></li>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.Series.view_sql.html">bach.Series.view_sql</a></li>
+</ul>
+</li>
+</ul>
+</li>
+<li class="toctree-l2"><a class="reference internal" href="bach_reference_series_by_function.html#comparison-and-set-operations">Comparison and set operations</a><ul>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.all_values.html">bach.Series.all_values</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.any_value.html">bach.Series.any_value</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.exists.html">bach.Series.exists</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.isin.html">bach.Series.isin</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.isnull.html">bach.Series.isnull</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.notnull.html">bach.Series.notnull</a></li>
+</ul>
+</li>
+<li class="toctree-l2"><a class="reference internal" href="bach_reference_series_by_function.html#conversion-reshaping-sorting">Conversion, reshaping, sorting</a><ul>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.sort_index.html">bach.Series.sort_index</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.sort_values.html">bach.Series.sort_values</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.fillna.html">bach.Series.fillna</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.append.html">bach.Series.append</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.drop_duplicates.html">bach.Series.drop_duplicates</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.dropna.html">bach.Series.dropna</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.unstack.html">bach.Series.unstack</a></li>
+</ul>
+</li>
+<li class="toctree-l2"><a class="reference internal" href="bach_reference_series_by_function.html#function-application-aggregation-windowing">Function application, aggregation &amp; windowing</a><ul>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.agg.html">bach.Series.agg</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.aggregate.html">bach.Series.aggregate</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.apply_func.html">bach.Series.apply_func</a></li>
+</ul>
+</li>
+<li class="toctree-l2"><a class="reference internal" href="bach_reference_series_by_function.html#computations-descriptive-stats">Computations &amp; descriptive stats</a><ul>
+<li class="toctree-l3"><a class="reference internal" href="bach_reference_series_by_function.html#all-types">All types</a><ul>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.Series.describe.html">bach.Series.describe</a></li>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.Series.count.html">bach.Series.count</a></li>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.Series.min.html">bach.Series.min</a></li>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.Series.max.html">bach.Series.max</a></li>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.Series.median.html">bach.Series.median</a></li>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.Series.mode.html">bach.Series.mode</a></li>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.Series.nunique.html">bach.Series.nunique</a></li>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.Series.value_counts.html">bach.Series.value_counts</a></li>
+</ul>
+</li>
+<li class="toctree-l3"><a class="reference internal" href="bach_reference_series_by_function.html#numeric">Numeric</a><ul>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.cut.html">bach.SeriesAbstractNumeric.cut</a></li>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.qcut.html">bach.SeriesAbstractNumeric.qcut</a></li>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.mean.html">bach.SeriesAbstractNumeric.mean</a></li>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.quantile.html">bach.SeriesAbstractNumeric.quantile</a></li>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.sem.html">bach.SeriesAbstractNumeric.sem</a></li>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.sum.html">bach.SeriesAbstractNumeric.sum</a></li>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.std.html">bach.SeriesAbstractNumeric.std</a></li>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.var.html">bach.SeriesAbstractNumeric.var</a></li>
+</ul>
+</li>
+<li class="toctree-l3"><a class="reference internal" href="bach_reference_series_by_function.html#window">Window</a><ul>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.Series.window_first_value.html">bach.Series.window_first_value</a></li>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.Series.window_lag.html">bach.Series.window_lag</a></li>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.Series.window_nth_value.html">bach.Series.window_nth_value</a></li>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.Series.window_lead.html">bach.Series.window_lead</a></li>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.Series.window_last_value.html">bach.Series.window_last_value</a></li>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.Series.window_row_number.html">bach.Series.window_row_number</a></li>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.Series.window_rank.html">bach.Series.window_rank</a></li>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.Series.window_dense_rank.html">bach.Series.window_dense_rank</a></li>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.Series.window_percent_rank.html">bach.Series.window_percent_rank</a></li>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.Series.window_ntile.html">bach.Series.window_ntile</a></li>
+<li class="toctree-l4"><a class="reference internal" href="Series/bach.Series.window_cume_dist.html">bach.Series.window_cume_dist</a></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</div>
 <p>A typed representation of a single column of data.</p>
 <p>It can be used as a separate object to just deal with a single list of values. There are many standard
 operations on Series available to do operations like add or subtract, to create aggregations like
@@ -69,345 +267,6 @@ support arithmetic operations and aggregations for example. It may or may not be
 operations on different types. A comparison or arithmetic operation between a Int64 and Float Series
 is okay, while a comparison operation is not.</p>
 <p>The type of a Series can generally be changed by calling <a class="reference internal" href="Series/bach.Series.astype.html#bach.Series.astype" title="bach.Series.astype"><code class="xref py py-meth docutils literal notranslate"><span class="pre">Series.astype()</span></code></a>.</p>
-</section>
-</section>
-<section id="reference">
-<h2>Reference<a class="headerlink" href="#reference" title="Permalink to this headline">#</a></h2>
-<table class="autosummary longtable table autosummary">
-<colgroup>
-<col style="width: 10%"/>
-<col style="width: 90%"/>
-</colgroup>
-<tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.html#bach.Series" title="bach.Series"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series</span></code></a>(engine,&#160;base_node,&#160;index,&#160;name,&#160;...)</p></td>
-<td><p>Series is an abstract class.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.SeriesBoolean.html#bach.SeriesBoolean" title="bach.SeriesBoolean"><code class="xref py py-obj docutils literal notranslate"><span class="pre">SeriesBoolean</span></code></a>(engine,&#160;base_node,&#160;index,&#160;...)</p></td>
-<td><p>A Series that represents the Boolean type and its specific operations</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.html#bach.SeriesAbstractNumeric" title="bach.SeriesAbstractNumeric"><code class="xref py py-obj docutils literal notranslate"><span class="pre">SeriesAbstractNumeric</span></code></a>(engine,&#160;base_node,&#160;...)</p></td>
-<td><p>A Series that represents the base numeric types and its specific operations</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.SeriesAbstractDateTime.html#bach.SeriesAbstractDateTime" title="bach.SeriesAbstractDateTime"><code class="xref py py-obj docutils literal notranslate"><span class="pre">SeriesAbstractDateTime</span></code></a>(engine,&#160;base_node,&#160;...)</p></td>
-<td><p>A Series that represents the generic date/time type and its specific operations.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.SeriesString.html#bach.SeriesString" title="bach.SeriesString"><code class="xref py py-obj docutils literal notranslate"><span class="pre">SeriesString</span></code></a>(engine,&#160;base_node,&#160;index,&#160;name,&#160;...)</p></td>
-<td><p>A Series that represents the string type and its specific operations</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.SeriesJsonb.html#bach.SeriesJsonb" title="bach.SeriesJsonb"><code class="xref py py-obj docutils literal notranslate"><span class="pre">SeriesJsonb</span></code></a>(engine,&#160;base_node,&#160;index,&#160;name,&#160;...)</p></td>
-<td><p>A Series that represents the postgres jsonb type and its specific operations.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.SeriesJson.html#bach.SeriesJson" title="bach.SeriesJson"><code class="xref py py-obj docutils literal notranslate"><span class="pre">SeriesJson</span></code></a>(engine,&#160;base_node,&#160;index,&#160;name,&#160;...)</p></td>
-<td><p>A Series that represents the json type.</p></td>
-</tr>
-</tbody>
-</table>
-</section>
-<section id="reference-by-function">
-<h2>Reference by function<a class="headerlink" href="#reference-by-function" title="Permalink to this headline">#</a></h2>
-<section id="creation-re-framing">
-<h3>Creation / re-framing<a class="headerlink" href="#creation-re-framing" title="Permalink to this headline">#</a></h3>
-<table class="autosummary longtable table autosummary">
-<colgroup>
-<col style="width: 10%"/>
-<col style="width: 90%"/>
-</colgroup>
-<tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.from_const.html#bach.Series.from_const" title="bach.Series.from_const"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.from_const</span></code></a>(base,&#160;value,&#160;name)</p></td>
-<td><p>Create an instance of this class, that represents a column with the given value.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.to_frame.html#bach.Series.to_frame" title="bach.Series.to_frame"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.to_frame</span></code></a>()</p></td>
-<td><p>Create a DataFrame with the index and data from this Series.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.copy.html#bach.Series.copy" title="bach.Series.copy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.copy</span></code></a>()</p></td>
-<td><p>Return a copy of this Series.</p></td>
-</tr>
-</tbody>
-</table>
-</section>
-<section id="value-accessors">
-<h3>Value accessors<a class="headerlink" href="#value-accessors" title="Permalink to this headline">#</a></h3>
-<table class="autosummary longtable table autosummary">
-<colgroup>
-<col style="width: 10%"/>
-<col style="width: 90%"/>
-</colgroup>
-<tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.head.html#bach.Series.head" title="bach.Series.head"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.head</span></code></a>([n])</p></td>
-<td><p>Get the first n rows from this Series as a pandas.Series.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.to_pandas.html#bach.Series.to_pandas" title="bach.Series.to_pandas"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.to_pandas</span></code></a>([limit])</p></td>
-<td><p>Get the data from this series as a pandas.Series :param limit: The limit to apply, either as a max amount of rows or a slice.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.array.html#bach.Series.array" title="bach.Series.array"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.array</span></code></a></p></td>
-<td><p>.array property accessor akin pandas.Series.array</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.values.html#bach.Series.values" title="bach.Series.values"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.values</span></code></a></p></td>
-<td><p>.values property accessor akin pandas.Series.values</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.value.html#bach.Series.value" title="bach.Series.value"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.value</span></code></a></p></td>
-<td><p>Retrieve the actual single value of this series.</p></td>
-</tr>
-</tbody>
-</table>
-</section>
-<section id="attributes-and-underlying-data">
-<h3>Attributes and underlying data<a class="headerlink" href="#attributes-and-underlying-data" title="Permalink to this headline">#</a></h3>
-<section id="axes">
-<h4>Axes<a class="headerlink" href="#axes" title="Permalink to this headline">#</a></h4>
-<table class="autosummary longtable table autosummary">
-<colgroup>
-<col style="width: 10%"/>
-<col style="width: 90%"/>
-</colgroup>
-<tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.name.html#bach.Series.name" title="bach.Series.name"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.name</span></code></a></p></td>
-<td><p>Get this Series' name</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.index.html#bach.Series.index" title="bach.Series.index"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.index</span></code></a></p></td>
-<td><p>Get this Series' index dictionary {name: Series}</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.group_by.html#bach.Series.group_by" title="bach.Series.group_by"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.group_by</span></code></a></p></td>
-<td><p>Get this Series' group_by, if any.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.sorted_ascending.html#bach.Series.sorted_ascending" title="bach.Series.sorted_ascending"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.sorted_ascending</span></code></a></p></td>
-<td><p>Get this Series' sorting by value.</p></td>
-</tr>
-</tbody>
-</table>
-</section>
-<section id="id1">
-<h4>Types<a class="headerlink" href="#id1" title="Permalink to this headline">#</a></h4>
-<table class="autosummary longtable table autosummary">
-<colgroup>
-<col style="width: 10%"/>
-<col style="width: 90%"/>
-</colgroup>
-<tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.dtype.html#bach.Series.dtype" title="bach.Series.dtype"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.dtype</span></code></a></p></td>
-<td><p>The dtype of this Series.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.astype.html#bach.Series.astype" title="bach.Series.astype"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.astype</span></code></a>(dtype)</p></td>
-<td><p>Convert this Series to another type.</p></td>
-</tr>
-</tbody>
-</table>
-</section>
-<section id="sql-model">
-<h4>Sql Model<a class="headerlink" href="#sql-model" title="Permalink to this headline">#</a></h4>
-<table class="autosummary longtable table autosummary">
-<colgroup>
-<col style="width: 10%"/>
-<col style="width: 90%"/>
-</colgroup>
-<tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.base_node.html#bach.Series.base_node" title="bach.Series.base_node"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.base_node</span></code></a></p></td>
-<td><p>Get this Series' base_node</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.view_sql.html#bach.Series.view_sql" title="bach.Series.view_sql"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.view_sql</span></code></a>()</p></td>
-<td><p/></td>
-</tr>
-</tbody>
-</table>
-</section>
-</section>
-<section id="comparison-and-set-operations">
-<h3>Comparison and set operations<a class="headerlink" href="#comparison-and-set-operations" title="Permalink to this headline">#</a></h3>
-<table class="autosummary longtable table autosummary">
-<colgroup>
-<col style="width: 10%"/>
-<col style="width: 90%"/>
-</colgroup>
-<tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.all_values.html#bach.Series.all_values" title="bach.Series.all_values"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.all_values</span></code></a>()</p></td>
-<td><p>For every row in this Series, do multiple evaluations where _all_ sub-evaluations should be True</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.any_value.html#bach.Series.any_value" title="bach.Series.any_value"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.any_value</span></code></a>()</p></td>
-<td><p>For every row in this Series, do multiple evaluations where _any_ sub-evaluation should be True</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.exists.html#bach.Series.exists" title="bach.Series.exists"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.exists</span></code></a>()</p></td>
-<td><p>Boolean operation that returns True if there are one or more values in this Series</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.isin.html#bach.Series.isin" title="bach.Series.isin"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.isin</span></code></a>(other)</p></td>
-<td><p>Evaluate for every row in this series whether the value is contained in other</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.isnull.html#bach.Series.isnull" title="bach.Series.isnull"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.isnull</span></code></a>()</p></td>
-<td><p>Evaluate for every row in this series whether the value is missing or NULL.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.notnull.html#bach.Series.notnull" title="bach.Series.notnull"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.notnull</span></code></a>()</p></td>
-<td><p>Evaluate for every row in this series whether the value is not missing or NULL.</p></td>
-</tr>
-</tbody>
-</table>
-</section>
-<section id="conversion-reshaping-sorting">
-<h3>Conversion, reshaping, sorting<a class="headerlink" href="#conversion-reshaping-sorting" title="Permalink to this headline">#</a></h3>
-<table class="autosummary longtable table autosummary">
-<colgroup>
-<col style="width: 10%"/>
-<col style="width: 90%"/>
-</colgroup>
-<tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.sort_index.html#bach.Series.sort_index" title="bach.Series.sort_index"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.sort_index</span></code></a>(*[,&#160;ascending])</p></td>
-<td><p>Sort this Series by its index.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.sort_values.html#bach.Series.sort_values" title="bach.Series.sort_values"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.sort_values</span></code></a>(*[,&#160;ascending])</p></td>
-<td><p>Sort this Series by its values.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.fillna.html#bach.Series.fillna" title="bach.Series.fillna"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.fillna</span></code></a>(other)</p></td>
-<td><p>Fill any NULL value with the given constant or other compatible Series</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.append.html#bach.Series.append" title="bach.Series.append"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.append</span></code></a>(other[,&#160;ignore_index])</p></td>
-<td><p>Append rows of other series to the caller series.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.drop_duplicates.html#bach.Series.drop_duplicates" title="bach.Series.drop_duplicates"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.drop_duplicates</span></code></a>([keep])</p></td>
-<td><p>Return a series with duplicated rows removed.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.dropna.html#bach.Series.dropna" title="bach.Series.dropna"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.dropna</span></code></a>()</p></td>
-<td><p>Removes rows with missing values.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.unstack.html#bach.Series.unstack" title="bach.Series.unstack"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.unstack</span></code></a>([level,&#160;fill_value,&#160;aggregation])</p></td>
-<td><p>Pivot a level of the index labels.</p></td>
-</tr>
-</tbody>
-</table>
-</section>
-<section id="function-application-aggregation-windowing">
-<h3>Function application, aggregation &amp; windowing<a class="headerlink" href="#function-application-aggregation-windowing" title="Permalink to this headline">#</a></h3>
-<table class="autosummary longtable table autosummary">
-<colgroup>
-<col style="width: 10%"/>
-<col style="width: 90%"/>
-</colgroup>
-<tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.agg.html#bach.Series.agg" title="bach.Series.agg"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.agg</span></code></a>(func[,&#160;group_by])</p></td>
-<td><p>Apply one or more aggregation functions to this Series.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.aggregate.html#bach.Series.aggregate" title="bach.Series.aggregate"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.aggregate</span></code></a>(func[,&#160;group_by])</p></td>
-<td><p>Alias for <code class="xref py py-meth docutils literal notranslate"><span class="pre">agg()</span></code>.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.apply_func.html#bach.Series.apply_func" title="bach.Series.apply_func"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.apply_func</span></code></a>(func,&#160;*args,&#160;**kwargs)</p></td>
-<td><p>Apply the given functions to this Series.</p></td>
-</tr>
-</tbody>
-</table>
-</section>
-<section id="computations-descriptive-stats">
-<h3>Computations &amp; descriptive stats<a class="headerlink" href="#computations-descriptive-stats" title="Permalink to this headline">#</a></h3>
-<section id="all-types">
-<h4>All types<a class="headerlink" href="#all-types" title="Permalink to this headline">#</a></h4>
-<table class="autosummary longtable table autosummary">
-<colgroup>
-<col style="width: 10%"/>
-<col style="width: 90%"/>
-</colgroup>
-<tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.describe.html#bach.Series.describe" title="bach.Series.describe"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.describe</span></code></a>([percentiles,&#160;...])</p></td>
-<td><p>Returns descriptive statistics, it will vary based on what is provided</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.count.html#bach.Series.count" title="bach.Series.count"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.count</span></code></a>([partition,&#160;skipna])</p></td>
-<td><p>Returns the amount of rows in each partition or for all values if none is given.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.min.html#bach.Series.min" title="bach.Series.min"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.min</span></code></a>([partition,&#160;skipna])</p></td>
-<td><p>Returns the minimum value in each partition or for all values if none is given.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.max.html#bach.Series.max" title="bach.Series.max"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.max</span></code></a>([partition,&#160;skipna])</p></td>
-<td><p>Returns the maximum value in each partition or for all values if none is given.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.median.html#bach.Series.median" title="bach.Series.median"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.median</span></code></a>([partition,&#160;skipna])</p></td>
-<td><p>Returns the median in each partition or for all values if none is given.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.mode.html#bach.Series.mode" title="bach.Series.mode"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.mode</span></code></a>([partition,&#160;skipna])</p></td>
-<td><p>Returns the mode in each partition or for all values if none is given.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.nunique.html#bach.Series.nunique" title="bach.Series.nunique"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.nunique</span></code></a>([partition,&#160;skipna])</p></td>
-<td><p>Returns the amount of unique values in each partition or for all values if none is given.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.value_counts.html#bach.Series.value_counts" title="bach.Series.value_counts"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.value_counts</span></code></a>([normalize,&#160;sort,&#160;...])</p></td>
-<td><p>Returns a series containing counts per unique value</p></td>
-</tr>
-</tbody>
-</table>
-</section>
-<section id="numeric">
-<h4>Numeric<a class="headerlink" href="#numeric" title="Permalink to this headline">#</a></h4>
-<table class="autosummary longtable table autosummary">
-<colgroup>
-<col style="width: 10%"/>
-<col style="width: 90%"/>
-</colgroup>
-<tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.cut.html#bach.SeriesAbstractNumeric.cut" title="bach.SeriesAbstractNumeric.cut"><code class="xref py py-obj docutils literal notranslate"><span class="pre">SeriesAbstractNumeric.cut</span></code></a>(bins[,&#160;right])</p></td>
-<td><p>Segments values into bins.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.qcut.html#bach.SeriesAbstractNumeric.qcut" title="bach.SeriesAbstractNumeric.qcut"><code class="xref py py-obj docutils literal notranslate"><span class="pre">SeriesAbstractNumeric.qcut</span></code></a>(q)</p></td>
-<td><p>Segments values into equal-sized buckets based on rank or sample quantiles.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.mean.html#bach.SeriesAbstractNumeric.mean" title="bach.SeriesAbstractNumeric.mean"><code class="xref py py-obj docutils literal notranslate"><span class="pre">SeriesAbstractNumeric.mean</span></code></a>([partition,&#160;skipna])</p></td>
-<td><p>Get the mean/average of the input values.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.quantile.html#bach.SeriesAbstractNumeric.quantile" title="bach.SeriesAbstractNumeric.quantile"><code class="xref py py-obj docutils literal notranslate"><span class="pre">SeriesAbstractNumeric.quantile</span></code></a>([partition,&#160;q])</p></td>
-<td><p>When q is a float or len(q) == 1, the resultant series index will remain In case multiple quantiles are calculated, the resultant series index will have all calculated quantiles as index values.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.sem.html#bach.SeriesAbstractNumeric.sem" title="bach.SeriesAbstractNumeric.sem"><code class="xref py py-obj docutils literal notranslate"><span class="pre">SeriesAbstractNumeric.sem</span></code></a>([partition,&#160;...])</p></td>
-<td><p>Get the unbiased standard error of the mean.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.sum.html#bach.SeriesAbstractNumeric.sum" title="bach.SeriesAbstractNumeric.sum"><code class="xref py py-obj docutils literal notranslate"><span class="pre">SeriesAbstractNumeric.sum</span></code></a>([partition,&#160;...])</p></td>
-<td><p>Get the sum of the input values.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.std.html#bach.SeriesAbstractNumeric.std" title="bach.SeriesAbstractNumeric.std"><code class="xref py py-obj docutils literal notranslate"><span class="pre">SeriesAbstractNumeric.std</span></code></a>([partition,&#160;...])</p></td>
-<td><p>Get the sample standard deviation of the input values Normalized by N-1 by default.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.var.html#bach.SeriesAbstractNumeric.var" title="bach.SeriesAbstractNumeric.var"><code class="xref py py-obj docutils literal notranslate"><span class="pre">SeriesAbstractNumeric.var</span></code></a>([partition,&#160;...])</p></td>
-<td><p>Get the sample variance of the input values (square of the sample standard deviation) Normalized by N-1 by default.</p></td>
-</tr>
-</tbody>
-</table>
-</section>
-<section id="window">
-<h4>Window<a class="headerlink" href="#window" title="Permalink to this headline">#</a></h4>
-<table class="autosummary longtable table autosummary">
-<colgroup>
-<col style="width: 10%"/>
-<col style="width: 90%"/>
-</colgroup>
-<tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.window_first_value.html#bach.Series.window_first_value" title="bach.Series.window_first_value"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.window_first_value</span></code></a>([window])</p></td>
-<td><p>Returns value evaluated at the row that is the first row of the window frame.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.window_lag.html#bach.Series.window_lag" title="bach.Series.window_lag"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.window_lag</span></code></a>([offset,&#160;default,&#160;window])</p></td>
-<td><p>Returns value evaluated at the row that is offset rows before the current row within the window</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.window_nth_value.html#bach.Series.window_nth_value" title="bach.Series.window_nth_value"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.window_nth_value</span></code></a>(n[,&#160;window])</p></td>
-<td><p>Returns value evaluated at the row that is the n'th row of the window frame.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.window_lead.html#bach.Series.window_lead" title="bach.Series.window_lead"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.window_lead</span></code></a>([offset,&#160;default,&#160;window])</p></td>
-<td><p>Returns value evaluated at the row that is offset rows after the current row within the window.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.window_last_value.html#bach.Series.window_last_value" title="bach.Series.window_last_value"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.window_last_value</span></code></a>([window])</p></td>
-<td><p>Returns value evaluated at the row that is the last row of the window frame.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.window_row_number.html#bach.Series.window_row_number" title="bach.Series.window_row_number"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.window_row_number</span></code></a>([window])</p></td>
-<td><p>Returns the number of the current row within its window, counting from 1.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.window_rank.html#bach.Series.window_rank" title="bach.Series.window_rank"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.window_rank</span></code></a>([window])</p></td>
-<td><p>Returns the rank of the current row, with gaps; that is, the row_number of the first row in its peer group.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.window_dense_rank.html#bach.Series.window_dense_rank" title="bach.Series.window_dense_rank"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.window_dense_rank</span></code></a>([window])</p></td>
-<td><p>Returns the rank of the current row, without gaps; this function effectively counts peer groups.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.window_percent_rank.html#bach.Series.window_percent_rank" title="bach.Series.window_percent_rank"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.window_percent_rank</span></code></a>([window])</p></td>
-<td><p>Returns the relative rank of the current row, that is (rank - 1) / (total partition rows - 1).</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.window_ntile.html#bach.Series.window_ntile" title="bach.Series.window_ntile"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.window_ntile</span></code></a>([num_buckets,&#160;window])</p></td>
-<td><p>Returns an integer ranging from 1 to the argument value, dividing the partition as equally as possible.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.window_cume_dist.html#bach.Series.window_cume_dist" title="bach.Series.window_cume_dist"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.window_cume_dist</span></code></a>([window])</p></td>
-<td><p>Returns the cumulative distribution, that is (number of partition rows preceding or peers with current row) / (total partition rows).</p></td>
-</tr>
-</tbody>
-</table>
-</section>
 </section>
 </section>
 </section>

--- a/docs/static/_modeling/bach_reference.html
+++ b/docs/static/_modeling/bach_reference.html
@@ -5,6 +5,19 @@
 <div class="toctree-wrapper compound">
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="DataFrame.html">DataFrame</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="bach_reference_dataframe.html">Reference</a><ul>
+<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.html">bach.DataFrame</a></li>
+</ul>
+</li>
+<li class="toctree-l2"><a class="reference internal" href="bach_reference_dataframe_by_function.html">Reference by function</a><ul>
+<li class="toctree-l3"><a class="reference internal" href="bach_reference_dataframe_by_function.html#creation">Creation</a></li>
+<li class="toctree-l3"><a class="reference internal" href="bach_reference_dataframe_by_function.html#value-accessors">Value accessors</a></li>
+<li class="toctree-l3"><a class="reference internal" href="bach_reference_dataframe_by_function.html#attributes-and-underlying-data">Attributes and underlying data</a></li>
+<li class="toctree-l3"><a class="reference internal" href="bach_reference_dataframe_by_function.html#reshaping-indexing-sorting-merging">Reshaping, indexing, sorting &amp; merging</a></li>
+<li class="toctree-l3"><a class="reference internal" href="bach_reference_dataframe_by_function.html#aggregation-windowing">Aggregation &amp; windowing</a></li>
+<li class="toctree-l3"><a class="reference internal" href="bach_reference_dataframe_by_function.html#computations-descriptive-stats">Computations &amp; descriptive stats</a></li>
+</ul>
+</li>
 <li class="toctree-l2"><a class="reference internal" href="DataFrame.html#usage">Usage</a><ul>
 <li class="toctree-l3"><a class="reference internal" href="DataFrame.html#getting-setting-columns">Getting &amp; Setting columns</a></li>
 <li class="toctree-l3"><a class="reference internal" href="DataFrame.html#moving-series-around">Moving Series around</a></li>
@@ -12,32 +25,10 @@
 <li class="toctree-l3"><a class="reference internal" href="DataFrame.html#database-access">Database access</a></li>
 </ul>
 </li>
-<li class="toctree-l2"><a class="reference internal" href="DataFrame.html#reference">Reference</a><ul>
-<li class="toctree-l3"><a class="reference internal" href="DataFrame/bach.DataFrame.html">bach.DataFrame</a></li>
-</ul>
-</li>
-<li class="toctree-l2"><a class="reference internal" href="DataFrame.html#reference-by-function">Reference by function</a><ul>
-<li class="toctree-l3"><a class="reference internal" href="DataFrame.html#creation">Creation</a></li>
-<li class="toctree-l3"><a class="reference internal" href="DataFrame.html#value-accessors">Value accessors</a></li>
-<li class="toctree-l3"><a class="reference internal" href="DataFrame.html#attributes-and-underlying-data">Attributes and underlying data</a></li>
-<li class="toctree-l3"><a class="reference internal" href="DataFrame.html#reshaping-indexing-sorting-merging">Reshaping, indexing, sorting &amp; merging</a></li>
-<li class="toctree-l3"><a class="reference internal" href="DataFrame.html#aggregation-windowing">Aggregation &amp; windowing</a></li>
-<li class="toctree-l3"><a class="reference internal" href="DataFrame.html#computations-descriptive-stats">Computations &amp; descriptive stats</a></li>
-</ul>
-</li>
 </ul>
 </li>
 <li class="toctree-l1"><a class="reference internal" href="Series.html">Series</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="Series.html#usage">Usage</a><ul>
-<li class="toctree-l3"><a class="reference internal" href="Series.html#slicing-and-index-access">Slicing and index access</a></li>
-<li class="toctree-l3"><a class="reference internal" href="Series.html#database-access">Database access</a></li>
-<li class="toctree-l3"><a class="reference internal" href="Series.html#boolean-operations">Boolean Operations</a></li>
-<li class="toctree-l3"><a class="reference internal" href="Series.html#aggregations">Aggregations</a></li>
-<li class="toctree-l3"><a class="reference internal" href="Series.html#window-functions">Window Functions</a></li>
-<li class="toctree-l3"><a class="reference internal" href="Series.html#types">Types</a></li>
-</ul>
-</li>
-<li class="toctree-l2"><a class="reference internal" href="Series.html#reference">Reference</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="bach_reference_series.html">Reference</a><ul>
 <li class="toctree-l3"><a class="reference internal" href="Series/bach.Series.html">bach.Series</a></li>
 <li class="toctree-l3"><a class="reference internal" href="Series/bach.SeriesBoolean.html">bach.SeriesBoolean</a></li>
 <li class="toctree-l3"><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.html">bach.SeriesAbstractNumeric</a></li>
@@ -47,14 +38,23 @@
 <li class="toctree-l3"><a class="reference internal" href="Series/bach.SeriesJson.html">bach.SeriesJson</a></li>
 </ul>
 </li>
-<li class="toctree-l2"><a class="reference internal" href="Series.html#reference-by-function">Reference by function</a><ul>
-<li class="toctree-l3"><a class="reference internal" href="Series.html#creation-re-framing">Creation / re-framing</a></li>
-<li class="toctree-l3"><a class="reference internal" href="Series.html#value-accessors">Value accessors</a></li>
-<li class="toctree-l3"><a class="reference internal" href="Series.html#attributes-and-underlying-data">Attributes and underlying data</a></li>
-<li class="toctree-l3"><a class="reference internal" href="Series.html#comparison-and-set-operations">Comparison and set operations</a></li>
-<li class="toctree-l3"><a class="reference internal" href="Series.html#conversion-reshaping-sorting">Conversion, reshaping, sorting</a></li>
-<li class="toctree-l3"><a class="reference internal" href="Series.html#function-application-aggregation-windowing">Function application, aggregation &amp; windowing</a></li>
-<li class="toctree-l3"><a class="reference internal" href="Series.html#computations-descriptive-stats">Computations &amp; descriptive stats</a></li>
+<li class="toctree-l2"><a class="reference internal" href="bach_reference_series_by_function.html">Reference by function</a><ul>
+<li class="toctree-l3"><a class="reference internal" href="bach_reference_series_by_function.html#creation-re-framing">Creation / re-framing</a></li>
+<li class="toctree-l3"><a class="reference internal" href="bach_reference_series_by_function.html#value-accessors">Value accessors</a></li>
+<li class="toctree-l3"><a class="reference internal" href="bach_reference_series_by_function.html#attributes-and-underlying-data">Attributes and underlying data</a></li>
+<li class="toctree-l3"><a class="reference internal" href="bach_reference_series_by_function.html#comparison-and-set-operations">Comparison and set operations</a></li>
+<li class="toctree-l3"><a class="reference internal" href="bach_reference_series_by_function.html#conversion-reshaping-sorting">Conversion, reshaping, sorting</a></li>
+<li class="toctree-l3"><a class="reference internal" href="bach_reference_series_by_function.html#function-application-aggregation-windowing">Function application, aggregation &amp; windowing</a></li>
+<li class="toctree-l3"><a class="reference internal" href="bach_reference_series_by_function.html#computations-descriptive-stats">Computations &amp; descriptive stats</a></li>
+</ul>
+</li>
+<li class="toctree-l2"><a class="reference internal" href="Series.html#usage">Usage</a><ul>
+<li class="toctree-l3"><a class="reference internal" href="Series.html#slicing-and-index-access">Slicing and index access</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series.html#database-access">Database access</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series.html#boolean-operations">Boolean Operations</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series.html#aggregations">Aggregations</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series.html#window-functions">Window Functions</a></li>
+<li class="toctree-l3"><a class="reference internal" href="Series.html#types">Types</a></li>
 </ul>
 </li>
 </ul>

--- a/docs/static/_modeling/bach_reference_dataframe.html
+++ b/docs/static/_modeling/bach_reference_dataframe.html
@@ -1,0 +1,22 @@
+<div>
+                
+  <section id="reference">
+<span id="bach-reference-dataframe"/><h1>Reference<a class="headerlink" href="#reference" title="Permalink to this headline">#</a></h1>
+<table class="autosummary longtable table autosummary">
+<colgroup>
+<col style="width: 10%"/>
+<col style="width: 90%"/>
+</colgroup>
+<tbody>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.html#bach.DataFrame" title="bach.DataFrame"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame</span></code></a>(engine,&#160;base_node,&#160;index,&#160;series,&#160;...)</p></td>
+<td><p>A mutable DataFrame representing tabular data in a database and enabling operations on that data.</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+
+
+              </div>
+              
+              
+              

--- a/docs/static/_modeling/bach_reference_dataframe_by_function.html
+++ b/docs/static/_modeling/bach_reference_dataframe_by_function.html
@@ -1,0 +1,310 @@
+<div>
+                
+  <section id="reference-by-function">
+<span id="bach-reference-dataframe-by-function"/><h1>Reference by function<a class="headerlink" href="#reference-by-function" title="Permalink to this headline">#</a></h1>
+<section id="creation">
+<h2>Creation<a class="headerlink" href="#creation" title="Permalink to this headline">#</a></h2>
+<table class="autosummary longtable table autosummary">
+<colgroup>
+<col style="width: 10%"/>
+<col style="width: 90%"/>
+</colgroup>
+<tbody>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.from_table.html#bach.DataFrame.from_table" title="bach.DataFrame.from_table"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.from_table</span></code></a>(engine,&#160;table_name,&#160;index)</p></td>
+<td><p>Instantiate a new DataFrame based on the content of an existing table in the database.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.from_model.html#bach.DataFrame.from_model" title="bach.DataFrame.from_model"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.from_model</span></code></a>(engine,&#160;model,&#160;index[,&#160;...])</p></td>
+<td><p>Instantiate a new DataFrame based on the result of the query defined in <cite>model</cite>.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.from_pandas.html#bach.DataFrame.from_pandas" title="bach.DataFrame.from_pandas"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.from_pandas</span></code></a>(engine,&#160;df,&#160;...[,&#160;...])</p></td>
+<td><p>Instantiate a new DataFrame based on the content of a Pandas DataFrame.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.copy.html#bach.DataFrame.copy" title="bach.DataFrame.copy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.copy</span></code></a>()</p></td>
+<td><p>Return a copy of this DataFrame.</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+<section id="value-accessors">
+<h2>Value accessors<a class="headerlink" href="#value-accessors" title="Permalink to this headline">#</a></h2>
+<table class="autosummary longtable table autosummary">
+<colgroup>
+<col style="width: 10%"/>
+<col style="width: 90%"/>
+</colgroup>
+<tbody>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.head.html#bach.DataFrame.head" title="bach.DataFrame.head"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.head</span></code></a>([n])</p></td>
+<td><p>Similar to <code class="xref py py-meth docutils literal notranslate"><span class="pre">to_pandas()</span></code> but only returns the first <cite>n</cite> rows.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.to_pandas.html#bach.DataFrame.to_pandas" title="bach.DataFrame.to_pandas"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.to_pandas</span></code></a>([limit])</p></td>
+<td><p>Run a SQL query representing the current state of this DataFrame against the database and return the resulting data as a Pandas DataFrame.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.values.html#bach.DataFrame.values" title="bach.DataFrame.values"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.values</span></code></a></p></td>
+<td><p>Return a Numpy representation of the DataFrame akin <code class="xref py py-attr docutils literal notranslate"><span class="pre">pandas.Dataframe.values</span></code></p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.loc.html#bach.DataFrame.loc" title="bach.DataFrame.loc"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.loc</span></code></a></p></td>
+<td><p>The <code class="docutils literal notranslate"><span class="pre">.loc</span></code> accessor offers different methods for label-based selection.</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+<section id="attributes-and-underlying-data">
+<h2>Attributes and underlying data<a class="headerlink" href="#attributes-and-underlying-data" title="Permalink to this headline">#</a></h2>
+<section id="axes">
+<h3>Axes<a class="headerlink" href="#axes" title="Permalink to this headline">#</a></h3>
+<table class="autosummary longtable table autosummary">
+<colgroup>
+<col style="width: 10%"/>
+<col style="width: 90%"/>
+</colgroup>
+<tbody>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.index.html#bach.DataFrame.index" title="bach.DataFrame.index"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.index</span></code></a></p></td>
+<td><p>Get the index dictionary <cite>{name: Series}</cite></p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.data.html#bach.DataFrame.data" title="bach.DataFrame.data"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.data</span></code></a></p></td>
+<td><p>Get the data dictionary <cite>{name: Series}</cite></p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.all_series.html#bach.DataFrame.all_series" title="bach.DataFrame.all_series"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.all_series</span></code></a></p></td>
+<td><p>Get all index and data Series in a dictionary <cite>{name: Series}</cite></p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.index_columns.html#bach.DataFrame.index_columns" title="bach.DataFrame.index_columns"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.index_columns</span></code></a></p></td>
+<td><p>Get all the index columns' names in a List</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.data_columns.html#bach.DataFrame.data_columns" title="bach.DataFrame.data_columns"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.data_columns</span></code></a></p></td>
+<td><p>Get all the data Series' names in a List</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.group_by.html#bach.DataFrame.group_by" title="bach.DataFrame.group_by"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.group_by</span></code></a></p></td>
+<td><p>Get this DataFrame's grouping, if any.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.order_by.html#bach.DataFrame.order_by" title="bach.DataFrame.order_by"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.order_by</span></code></a></p></td>
+<td><p>Get the current sort order, if any.</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+<section id="types">
+<h3>Types<a class="headerlink" href="#types" title="Permalink to this headline">#</a></h3>
+<table class="autosummary longtable table autosummary">
+<colgroup>
+<col style="width: 10%"/>
+<col style="width: 90%"/>
+</colgroup>
+<tbody>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.dtypes.html#bach.DataFrame.dtypes" title="bach.DataFrame.dtypes"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.dtypes</span></code></a></p></td>
+<td><p>Get the data Series' dtypes in a dictionary <cite>{name: dtype}</cite></p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.index_dtypes.html#bach.DataFrame.index_dtypes" title="bach.DataFrame.index_dtypes"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.index_dtypes</span></code></a></p></td>
+<td><p>Get the index Series' dtypes in a dictionary <cite>{name: dtype}</cite></p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.astype.html#bach.DataFrame.astype" title="bach.DataFrame.astype"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.astype</span></code></a>(dtype)</p></td>
+<td><p>Cast all or some of the data columns to a certain dtype.</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+<section id="sql-model">
+<h3>Sql Model<a class="headerlink" href="#sql-model" title="Permalink to this headline">#</a></h3>
+<table class="autosummary longtable table autosummary">
+<colgroup>
+<col style="width: 10%"/>
+<col style="width: 90%"/>
+</colgroup>
+<tbody>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.materialize.html#bach.DataFrame.materialize" title="bach.DataFrame.materialize"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.materialize</span></code></a>([node_name,&#160;inplace,&#160;...])</p></td>
+<td><p>Create a copy of this DataFrame with as base_node the current DataFrame's state.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.get_sample.html#bach.DataFrame.get_sample" title="bach.DataFrame.get_sample"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.get_sample</span></code></a>(table_name[,&#160;filter,&#160;...])</p></td>
+<td><p>Returns a DataFrame whose data is a sample of the current DataFrame object.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.get_unsampled.html#bach.DataFrame.get_unsampled" title="bach.DataFrame.get_unsampled"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.get_unsampled</span></code></a>()</p></td>
+<td><p>Return a copy of the current sampled DataFrame, that undoes calling <code class="xref py py-meth docutils literal notranslate"><span class="pre">get_sample()</span></code> earlier.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.view_sql.html#bach.DataFrame.view_sql" title="bach.DataFrame.view_sql"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.view_sql</span></code></a>([limit])</p></td>
+<td><p>Translate the current state of this DataFrame into a SQL query.</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+<section id="variables">
+<h3>Variables<a class="headerlink" href="#variables" title="Permalink to this headline">#</a></h3>
+<table class="autosummary longtable table autosummary">
+<colgroup>
+<col style="width: 10%"/>
+<col style="width: 90%"/>
+</colgroup>
+<tbody>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.create_variable.html#bach.DataFrame.create_variable" title="bach.DataFrame.create_variable"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.create_variable</span></code></a>(name,&#160;value,&#160;*[,&#160;...])</p></td>
+<td><p>Create a Series object that can be used as a variable, within the returned DataFrame.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.set_variable.html#bach.DataFrame.set_variable" title="bach.DataFrame.set_variable"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.set_variable</span></code></a>(name,&#160;value,&#160;*[,&#160;dtype])</p></td>
+<td><p>Return a copy of this DataFrame with the variable value updated.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.get_all_variable_usage.html#bach.DataFrame.get_all_variable_usage" title="bach.DataFrame.get_all_variable_usage"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.get_all_variable_usage</span></code></a>()</p></td>
+<td><p>Get all variables that influence the values of this DataFrame.</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+</section>
+<section id="reshaping-indexing-sorting-merging">
+<h2>Reshaping, indexing, sorting &amp; merging<a class="headerlink" href="#reshaping-indexing-sorting-merging" title="Permalink to this headline">#</a></h2>
+<table class="autosummary longtable table autosummary">
+<colgroup>
+<col style="width: 10%"/>
+<col style="width: 90%"/>
+</colgroup>
+<tbody>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.sort_index.html#bach.DataFrame.sort_index" title="bach.DataFrame.sort_index"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.sort_index</span></code></a>([level,&#160;ascending])</p></td>
+<td><p>Sort dataframe by index levels.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.sort_values.html#bach.DataFrame.sort_values" title="bach.DataFrame.sort_values"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.sort_values</span></code></a>(by[,&#160;ascending])</p></td>
+<td><p>Create a new DataFrame with the specified sorting order.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.rename.html#bach.DataFrame.rename" title="bach.DataFrame.rename"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.rename</span></code></a>([mapper,&#160;index,&#160;columns,&#160;...])</p></td>
+<td><p>Rename columns.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.drop.html#bach.DataFrame.drop" title="bach.DataFrame.drop"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.drop</span></code></a>([labels,&#160;index,&#160;columns,&#160;...])</p></td>
+<td><p>Drop columns from the DataFrame</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.drop_duplicates.html#bach.DataFrame.drop_duplicates" title="bach.DataFrame.drop_duplicates"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.drop_duplicates</span></code></a>([subset,&#160;keep,&#160;...])</p></td>
+<td><p>Return a dataframe with duplicated rows removed based on all series labels or a subset of labels.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.dropna.html#bach.DataFrame.dropna" title="bach.DataFrame.dropna"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.dropna</span></code></a>(*[,&#160;axis,&#160;how,&#160;thresh,&#160;subset])</p></td>
+<td><p>Removes rows with missing values (NaN, None and SQL NULL).</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.reset_index.html#bach.DataFrame.reset_index" title="bach.DataFrame.reset_index"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.reset_index</span></code></a>([level,&#160;drop])</p></td>
+<td><p>Drops the current index.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.set_index.html#bach.DataFrame.set_index" title="bach.DataFrame.set_index"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.set_index</span></code></a>(keys[,&#160;drop,&#160;append])</p></td>
+<td><p>Set this dataframe's index to the the index given in keys</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.merge.html#bach.DataFrame.merge" title="bach.DataFrame.merge"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.merge</span></code></a>(right[,&#160;how,&#160;on,&#160;left_on,&#160;...])</p></td>
+<td><p>Join the right Dataframe or Series on self.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.append.html#bach.DataFrame.append" title="bach.DataFrame.append"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.append</span></code></a>(other[,&#160;ignore_index,&#160;sort])</p></td>
+<td><p>Append rows of other dataframes to the the caller dataframe.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.fillna.html#bach.DataFrame.fillna" title="bach.DataFrame.fillna"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.fillna</span></code></a>(*[,&#160;value,&#160;method,&#160;axis,&#160;...])</p></td>
+<td><p>Fill any NULL value using a method or with a given value.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.ffill.html#bach.DataFrame.ffill" title="bach.DataFrame.ffill"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.ffill</span></code></a>([sort_by,&#160;ascending])</p></td>
+<td><p>Fill missing values by propagating the last non-nullable value in each series.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.bfill.html#bach.DataFrame.bfill" title="bach.DataFrame.bfill"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.bfill</span></code></a>([sort_by,&#160;ascending])</p></td>
+<td><p>Fill missing values by using the next non-nullable value in each series.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.stack.html#bach.DataFrame.stack" title="bach.DataFrame.stack"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.stack</span></code></a>([dropna])</p></td>
+<td><p>Stacks all data_columns into a single index series.</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+<section id="aggregation-windowing">
+<h2>Aggregation &amp; windowing<a class="headerlink" href="#aggregation-windowing" title="Permalink to this headline">#</a></h2>
+<table class="autosummary longtable table autosummary">
+<colgroup>
+<col style="width: 10%"/>
+<col style="width: 90%"/>
+</colgroup>
+<tbody>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.agg.html#bach.DataFrame.agg" title="bach.DataFrame.agg"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.agg</span></code></a>(func[,&#160;axis,&#160;numeric_only])</p></td>
+<td><p>Aggregate using one or more operations over the specified axis.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.aggregate.html#bach.DataFrame.aggregate" title="bach.DataFrame.aggregate"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.aggregate</span></code></a>(func[,&#160;axis,&#160;numeric_only])</p></td>
+<td><p>Alias for <code class="xref py py-meth docutils literal notranslate"><span class="pre">agg()</span></code></p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.groupby.html#bach.DataFrame.groupby" title="bach.DataFrame.groupby"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.groupby</span></code></a>([by])</p></td>
+<td><p>Group by any of the series currently in this DataDrame, both from index as well as data.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.rollup.html#bach.DataFrame.rollup" title="bach.DataFrame.rollup"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.rollup</span></code></a>(by)</p></td>
+<td><p>Group by and roll up over the column(s) <cite>by</cite>, replacing any current grouping.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.cube.html#bach.DataFrame.cube" title="bach.DataFrame.cube"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.cube</span></code></a>(by)</p></td>
+<td><p>Group by and cube over the column(s) <cite>by</cite>.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.window.html#bach.DataFrame.window" title="bach.DataFrame.window"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.window</span></code></a>(**frame_args)</p></td>
+<td><p>Create a window on the current dataframe grouping and its sorting.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.rolling.html#bach.DataFrame.rolling" title="bach.DataFrame.rolling"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.rolling</span></code></a>(window[,&#160;min_periods,&#160;...])</p></td>
+<td><p>A rolling window of size 'window', by default right aligned.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.expanding.html#bach.DataFrame.expanding" title="bach.DataFrame.expanding"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.expanding</span></code></a>([min_periods,&#160;center])</p></td>
+<td><p>Create an expanding window starting with the first row in the group, with at least <cite>min_period</cite> observations.</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+<section id="computations-descriptive-stats">
+<span id="dataframe-stats"/><h2>Computations &amp; descriptive stats<a class="headerlink" href="#computations-descriptive-stats" title="Permalink to this headline">#</a></h2>
+<section id="all-types">
+<h3>All types<a class="headerlink" href="#all-types" title="Permalink to this headline">#</a></h3>
+<table class="autosummary longtable table autosummary">
+<colgroup>
+<col style="width: 10%"/>
+<col style="width: 90%"/>
+</colgroup>
+<tbody>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.describe.html#bach.DataFrame.describe" title="bach.DataFrame.describe"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.describe</span></code></a>([percentiles,&#160;include,&#160;...])</p></td>
+<td><p>Returns descriptive statistics.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.count.html#bach.DataFrame.count" title="bach.DataFrame.count"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.count</span></code></a>([axis,&#160;level,&#160;numeric_only])</p></td>
+<td><p>Count all non-NULL values in each column.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.min.html#bach.DataFrame.min" title="bach.DataFrame.min"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.min</span></code></a>([axis,&#160;skipna,&#160;level,&#160;...])</p></td>
+<td><p>Returns the minimum of all values in each column.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.max.html#bach.DataFrame.max" title="bach.DataFrame.max"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.max</span></code></a>([axis,&#160;skipna,&#160;level,&#160;...])</p></td>
+<td><p>Returns the maximum of all values in each column.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.median.html#bach.DataFrame.median" title="bach.DataFrame.median"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.median</span></code></a>([axis,&#160;skipna,&#160;level,&#160;...])</p></td>
+<td><p>Returns the median of all values in each column.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.mode.html#bach.DataFrame.mode" title="bach.DataFrame.mode"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.mode</span></code></a>([axis,&#160;skipna,&#160;level,&#160;...])</p></td>
+<td><p>Returns the mode of all values in each column.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.nunique.html#bach.DataFrame.nunique" title="bach.DataFrame.nunique"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.nunique</span></code></a>([axis,&#160;skipna])</p></td>
+<td><p>Returns the number of unique values in each column.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.value_counts.html#bach.DataFrame.value_counts" title="bach.DataFrame.value_counts"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.value_counts</span></code></a>([subset,&#160;normalize,&#160;...])</p></td>
+<td><p>Returns a series containing counts of each unique row in the DataFrame</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+<section id="numeric">
+<h3>Numeric<a class="headerlink" href="#numeric" title="Permalink to this headline">#</a></h3>
+<table class="autosummary longtable table autosummary">
+<colgroup>
+<col style="width: 10%"/>
+<col style="width: 90%"/>
+</colgroup>
+<tbody>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.mean.html#bach.DataFrame.mean" title="bach.DataFrame.mean"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.mean</span></code></a>([axis,&#160;skipna,&#160;level,&#160;...])</p></td>
+<td><p>Returns the mean of all values in each column.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.quantile.html#bach.DataFrame.quantile" title="bach.DataFrame.quantile"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.quantile</span></code></a>([q,&#160;axis])</p></td>
+<td><p>Returns the quantile per numeric/timedelta column.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.sem.html#bach.DataFrame.sem" title="bach.DataFrame.sem"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.sem</span></code></a>([axis,&#160;skipna,&#160;level,&#160;ddof,&#160;...])</p></td>
+<td><p>Returns the unbiased standard error of the mean of each column.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.sum.html#bach.DataFrame.sum" title="bach.DataFrame.sum"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.sum</span></code></a>([axis,&#160;skipna,&#160;level,&#160;...])</p></td>
+<td><p>Returns the sum of all values in each column.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.std.html#bach.DataFrame.std" title="bach.DataFrame.std"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.std</span></code></a>([axis,&#160;skipna,&#160;level,&#160;ddof,&#160;...])</p></td>
+<td><p>Returns the sample standard deviation of each column.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="DataFrame/bach.DataFrame.var.html#bach.DataFrame.var" title="bach.DataFrame.var"><code class="xref py py-obj docutils literal notranslate"><span class="pre">DataFrame.var</span></code></a>([axis,&#160;skipna,&#160;level,&#160;ddof,&#160;...])</p></td>
+<td><p>Returns the unbiased variance of each column.</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+</section>
+</section>
+
+
+              </div>
+              
+              
+              

--- a/docs/static/_modeling/bach_reference_series.html
+++ b/docs/static/_modeling/bach_reference_series.html
@@ -1,0 +1,40 @@
+<div>
+                
+  <section id="reference">
+<span id="bach-reference-series"/><h1>Reference<a class="headerlink" href="#reference" title="Permalink to this headline">#</a></h1>
+<table class="autosummary longtable table autosummary">
+<colgroup>
+<col style="width: 10%"/>
+<col style="width: 90%"/>
+</colgroup>
+<tbody>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.html#bach.Series" title="bach.Series"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series</span></code></a>(engine,&#160;base_node,&#160;index,&#160;name,&#160;...)</p></td>
+<td><p>Series is an abstract class.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.SeriesBoolean.html#bach.SeriesBoolean" title="bach.SeriesBoolean"><code class="xref py py-obj docutils literal notranslate"><span class="pre">SeriesBoolean</span></code></a>(engine,&#160;base_node,&#160;index,&#160;...)</p></td>
+<td><p>A Series that represents the Boolean type and its specific operations</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.html#bach.SeriesAbstractNumeric" title="bach.SeriesAbstractNumeric"><code class="xref py py-obj docutils literal notranslate"><span class="pre">SeriesAbstractNumeric</span></code></a>(engine,&#160;base_node,&#160;...)</p></td>
+<td><p>A Series that represents the base numeric types and its specific operations</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.SeriesAbstractDateTime.html#bach.SeriesAbstractDateTime" title="bach.SeriesAbstractDateTime"><code class="xref py py-obj docutils literal notranslate"><span class="pre">SeriesAbstractDateTime</span></code></a>(engine,&#160;base_node,&#160;...)</p></td>
+<td><p>A Series that represents the generic date/time type and its specific operations.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.SeriesString.html#bach.SeriesString" title="bach.SeriesString"><code class="xref py py-obj docutils literal notranslate"><span class="pre">SeriesString</span></code></a>(engine,&#160;base_node,&#160;index,&#160;name,&#160;...)</p></td>
+<td><p>A Series that represents the string type and its specific operations</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.SeriesJsonb.html#bach.SeriesJsonb" title="bach.SeriesJsonb"><code class="xref py py-obj docutils literal notranslate"><span class="pre">SeriesJsonb</span></code></a>(engine,&#160;base_node,&#160;index,&#160;name,&#160;...)</p></td>
+<td><p>A Series that represents the postgres jsonb type and its specific operations.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.SeriesJson.html#bach.SeriesJson" title="bach.SeriesJson"><code class="xref py py-obj docutils literal notranslate"><span class="pre">SeriesJson</span></code></a>(engine,&#160;base_node,&#160;index,&#160;name,&#160;...)</p></td>
+<td><p>A Series that represents the json type.</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+
+
+              </div>
+              
+              
+              

--- a/docs/static/_modeling/bach_reference_series_by_function.html
+++ b/docs/static/_modeling/bach_reference_series_by_function.html
@@ -1,0 +1,315 @@
+<div>
+                
+  <section id="reference-by-function">
+<span id="bach-reference-series-by-function"/><h1>Reference by function<a class="headerlink" href="#reference-by-function" title="Permalink to this headline">#</a></h1>
+<section id="creation-re-framing">
+<h2>Creation / re-framing<a class="headerlink" href="#creation-re-framing" title="Permalink to this headline">#</a></h2>
+<table class="autosummary longtable table autosummary">
+<colgroup>
+<col style="width: 10%"/>
+<col style="width: 90%"/>
+</colgroup>
+<tbody>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.from_const.html#bach.Series.from_const" title="bach.Series.from_const"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.from_const</span></code></a>(base,&#160;value,&#160;name)</p></td>
+<td><p>Create an instance of this class, that represents a column with the given value.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.to_frame.html#bach.Series.to_frame" title="bach.Series.to_frame"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.to_frame</span></code></a>()</p></td>
+<td><p>Create a DataFrame with the index and data from this Series.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.copy.html#bach.Series.copy" title="bach.Series.copy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.copy</span></code></a>()</p></td>
+<td><p>Return a copy of this Series.</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+<section id="value-accessors">
+<h2>Value accessors<a class="headerlink" href="#value-accessors" title="Permalink to this headline">#</a></h2>
+<table class="autosummary longtable table autosummary">
+<colgroup>
+<col style="width: 10%"/>
+<col style="width: 90%"/>
+</colgroup>
+<tbody>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.head.html#bach.Series.head" title="bach.Series.head"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.head</span></code></a>([n])</p></td>
+<td><p>Get the first n rows from this Series as a pandas.Series.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.to_pandas.html#bach.Series.to_pandas" title="bach.Series.to_pandas"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.to_pandas</span></code></a>([limit])</p></td>
+<td><p>Get the data from this series as a pandas.Series :param limit: The limit to apply, either as a max amount of rows or a slice.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.array.html#bach.Series.array" title="bach.Series.array"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.array</span></code></a></p></td>
+<td><p>.array property accessor akin pandas.Series.array</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.values.html#bach.Series.values" title="bach.Series.values"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.values</span></code></a></p></td>
+<td><p>.values property accessor akin pandas.Series.values</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.value.html#bach.Series.value" title="bach.Series.value"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.value</span></code></a></p></td>
+<td><p>Retrieve the actual single value of this series.</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+<section id="attributes-and-underlying-data">
+<h2>Attributes and underlying data<a class="headerlink" href="#attributes-and-underlying-data" title="Permalink to this headline">#</a></h2>
+<section id="axes">
+<h3>Axes<a class="headerlink" href="#axes" title="Permalink to this headline">#</a></h3>
+<table class="autosummary longtable table autosummary">
+<colgroup>
+<col style="width: 10%"/>
+<col style="width: 90%"/>
+</colgroup>
+<tbody>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.name.html#bach.Series.name" title="bach.Series.name"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.name</span></code></a></p></td>
+<td><p>Get this Series' name</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.index.html#bach.Series.index" title="bach.Series.index"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.index</span></code></a></p></td>
+<td><p>Get this Series' index dictionary {name: Series}</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.group_by.html#bach.Series.group_by" title="bach.Series.group_by"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.group_by</span></code></a></p></td>
+<td><p>Get this Series' group_by, if any.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.sorted_ascending.html#bach.Series.sorted_ascending" title="bach.Series.sorted_ascending"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.sorted_ascending</span></code></a></p></td>
+<td><p>Get this Series' sorting by value.</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+<section id="types">
+<h3>Types<a class="headerlink" href="#types" title="Permalink to this headline">#</a></h3>
+<table class="autosummary longtable table autosummary">
+<colgroup>
+<col style="width: 10%"/>
+<col style="width: 90%"/>
+</colgroup>
+<tbody>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.dtype.html#bach.Series.dtype" title="bach.Series.dtype"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.dtype</span></code></a></p></td>
+<td><p>The dtype of this Series.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.astype.html#bach.Series.astype" title="bach.Series.astype"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.astype</span></code></a>(dtype)</p></td>
+<td><p>Convert this Series to another type.</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+<section id="sql-model">
+<h3>Sql Model<a class="headerlink" href="#sql-model" title="Permalink to this headline">#</a></h3>
+<table class="autosummary longtable table autosummary">
+<colgroup>
+<col style="width: 10%"/>
+<col style="width: 90%"/>
+</colgroup>
+<tbody>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.base_node.html#bach.Series.base_node" title="bach.Series.base_node"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.base_node</span></code></a></p></td>
+<td><p>Get this Series' base_node</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.view_sql.html#bach.Series.view_sql" title="bach.Series.view_sql"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.view_sql</span></code></a>()</p></td>
+<td><p/></td>
+</tr>
+</tbody>
+</table>
+</section>
+</section>
+<section id="comparison-and-set-operations">
+<h2>Comparison and set operations<a class="headerlink" href="#comparison-and-set-operations" title="Permalink to this headline">#</a></h2>
+<table class="autosummary longtable table autosummary">
+<colgroup>
+<col style="width: 10%"/>
+<col style="width: 90%"/>
+</colgroup>
+<tbody>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.all_values.html#bach.Series.all_values" title="bach.Series.all_values"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.all_values</span></code></a>()</p></td>
+<td><p>For every row in this Series, do multiple evaluations where _all_ sub-evaluations should be True</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.any_value.html#bach.Series.any_value" title="bach.Series.any_value"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.any_value</span></code></a>()</p></td>
+<td><p>For every row in this Series, do multiple evaluations where _any_ sub-evaluation should be True</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.exists.html#bach.Series.exists" title="bach.Series.exists"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.exists</span></code></a>()</p></td>
+<td><p>Boolean operation that returns True if there are one or more values in this Series</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.isin.html#bach.Series.isin" title="bach.Series.isin"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.isin</span></code></a>(other)</p></td>
+<td><p>Evaluate for every row in this series whether the value is contained in other</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.isnull.html#bach.Series.isnull" title="bach.Series.isnull"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.isnull</span></code></a>()</p></td>
+<td><p>Evaluate for every row in this series whether the value is missing or NULL.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.notnull.html#bach.Series.notnull" title="bach.Series.notnull"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.notnull</span></code></a>()</p></td>
+<td><p>Evaluate for every row in this series whether the value is not missing or NULL.</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+<section id="conversion-reshaping-sorting">
+<h2>Conversion, reshaping, sorting<a class="headerlink" href="#conversion-reshaping-sorting" title="Permalink to this headline">#</a></h2>
+<table class="autosummary longtable table autosummary">
+<colgroup>
+<col style="width: 10%"/>
+<col style="width: 90%"/>
+</colgroup>
+<tbody>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.sort_index.html#bach.Series.sort_index" title="bach.Series.sort_index"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.sort_index</span></code></a>(*[,&#160;ascending])</p></td>
+<td><p>Sort this Series by its index.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.sort_values.html#bach.Series.sort_values" title="bach.Series.sort_values"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.sort_values</span></code></a>(*[,&#160;ascending])</p></td>
+<td><p>Sort this Series by its values.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.fillna.html#bach.Series.fillna" title="bach.Series.fillna"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.fillna</span></code></a>(other)</p></td>
+<td><p>Fill any NULL value with the given constant or other compatible Series</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.append.html#bach.Series.append" title="bach.Series.append"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.append</span></code></a>(other[,&#160;ignore_index])</p></td>
+<td><p>Append rows of other series to the caller series.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.drop_duplicates.html#bach.Series.drop_duplicates" title="bach.Series.drop_duplicates"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.drop_duplicates</span></code></a>([keep])</p></td>
+<td><p>Return a series with duplicated rows removed.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.dropna.html#bach.Series.dropna" title="bach.Series.dropna"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.dropna</span></code></a>()</p></td>
+<td><p>Removes rows with missing values.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.unstack.html#bach.Series.unstack" title="bach.Series.unstack"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.unstack</span></code></a>([level,&#160;fill_value,&#160;aggregation])</p></td>
+<td><p>Pivot a level of the index labels.</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+<section id="function-application-aggregation-windowing">
+<h2>Function application, aggregation &amp; windowing<a class="headerlink" href="#function-application-aggregation-windowing" title="Permalink to this headline">#</a></h2>
+<table class="autosummary longtable table autosummary">
+<colgroup>
+<col style="width: 10%"/>
+<col style="width: 90%"/>
+</colgroup>
+<tbody>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.agg.html#bach.Series.agg" title="bach.Series.agg"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.agg</span></code></a>(func[,&#160;group_by])</p></td>
+<td><p>Apply one or more aggregation functions to this Series.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.aggregate.html#bach.Series.aggregate" title="bach.Series.aggregate"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.aggregate</span></code></a>(func[,&#160;group_by])</p></td>
+<td><p>Alias for <code class="xref py py-meth docutils literal notranslate"><span class="pre">agg()</span></code>.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.apply_func.html#bach.Series.apply_func" title="bach.Series.apply_func"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.apply_func</span></code></a>(func,&#160;*args,&#160;**kwargs)</p></td>
+<td><p>Apply the given functions to this Series.</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+<section id="computations-descriptive-stats">
+<h2>Computations &amp; descriptive stats<a class="headerlink" href="#computations-descriptive-stats" title="Permalink to this headline">#</a></h2>
+<section id="all-types">
+<h3>All types<a class="headerlink" href="#all-types" title="Permalink to this headline">#</a></h3>
+<table class="autosummary longtable table autosummary">
+<colgroup>
+<col style="width: 10%"/>
+<col style="width: 90%"/>
+</colgroup>
+<tbody>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.describe.html#bach.Series.describe" title="bach.Series.describe"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.describe</span></code></a>([percentiles,&#160;...])</p></td>
+<td><p>Returns descriptive statistics, it will vary based on what is provided</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.count.html#bach.Series.count" title="bach.Series.count"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.count</span></code></a>([partition,&#160;skipna])</p></td>
+<td><p>Returns the amount of rows in each partition or for all values if none is given.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.min.html#bach.Series.min" title="bach.Series.min"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.min</span></code></a>([partition,&#160;skipna])</p></td>
+<td><p>Returns the minimum value in each partition or for all values if none is given.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.max.html#bach.Series.max" title="bach.Series.max"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.max</span></code></a>([partition,&#160;skipna])</p></td>
+<td><p>Returns the maximum value in each partition or for all values if none is given.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.median.html#bach.Series.median" title="bach.Series.median"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.median</span></code></a>([partition,&#160;skipna])</p></td>
+<td><p>Returns the median in each partition or for all values if none is given.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.mode.html#bach.Series.mode" title="bach.Series.mode"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.mode</span></code></a>([partition,&#160;skipna])</p></td>
+<td><p>Returns the mode in each partition or for all values if none is given.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.nunique.html#bach.Series.nunique" title="bach.Series.nunique"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.nunique</span></code></a>([partition,&#160;skipna])</p></td>
+<td><p>Returns the amount of unique values in each partition or for all values if none is given.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.value_counts.html#bach.Series.value_counts" title="bach.Series.value_counts"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.value_counts</span></code></a>([normalize,&#160;sort,&#160;...])</p></td>
+<td><p>Returns a series containing counts per unique value</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+<section id="numeric">
+<h3>Numeric<a class="headerlink" href="#numeric" title="Permalink to this headline">#</a></h3>
+<table class="autosummary longtable table autosummary">
+<colgroup>
+<col style="width: 10%"/>
+<col style="width: 90%"/>
+</colgroup>
+<tbody>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.cut.html#bach.SeriesAbstractNumeric.cut" title="bach.SeriesAbstractNumeric.cut"><code class="xref py py-obj docutils literal notranslate"><span class="pre">SeriesAbstractNumeric.cut</span></code></a>(bins[,&#160;right])</p></td>
+<td><p>Segments values into bins.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.qcut.html#bach.SeriesAbstractNumeric.qcut" title="bach.SeriesAbstractNumeric.qcut"><code class="xref py py-obj docutils literal notranslate"><span class="pre">SeriesAbstractNumeric.qcut</span></code></a>(q)</p></td>
+<td><p>Segments values into equal-sized buckets based on rank or sample quantiles.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.mean.html#bach.SeriesAbstractNumeric.mean" title="bach.SeriesAbstractNumeric.mean"><code class="xref py py-obj docutils literal notranslate"><span class="pre">SeriesAbstractNumeric.mean</span></code></a>([partition,&#160;skipna])</p></td>
+<td><p>Get the mean/average of the input values.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.quantile.html#bach.SeriesAbstractNumeric.quantile" title="bach.SeriesAbstractNumeric.quantile"><code class="xref py py-obj docutils literal notranslate"><span class="pre">SeriesAbstractNumeric.quantile</span></code></a>([partition,&#160;q])</p></td>
+<td><p>When q is a float or len(q) == 1, the resultant series index will remain In case multiple quantiles are calculated, the resultant series index will have all calculated quantiles as index values.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.sem.html#bach.SeriesAbstractNumeric.sem" title="bach.SeriesAbstractNumeric.sem"><code class="xref py py-obj docutils literal notranslate"><span class="pre">SeriesAbstractNumeric.sem</span></code></a>([partition,&#160;...])</p></td>
+<td><p>Get the unbiased standard error of the mean.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.sum.html#bach.SeriesAbstractNumeric.sum" title="bach.SeriesAbstractNumeric.sum"><code class="xref py py-obj docutils literal notranslate"><span class="pre">SeriesAbstractNumeric.sum</span></code></a>([partition,&#160;...])</p></td>
+<td><p>Get the sum of the input values.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.std.html#bach.SeriesAbstractNumeric.std" title="bach.SeriesAbstractNumeric.std"><code class="xref py py-obj docutils literal notranslate"><span class="pre">SeriesAbstractNumeric.std</span></code></a>([partition,&#160;...])</p></td>
+<td><p>Get the sample standard deviation of the input values Normalized by N-1 by default.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.SeriesAbstractNumeric.var.html#bach.SeriesAbstractNumeric.var" title="bach.SeriesAbstractNumeric.var"><code class="xref py py-obj docutils literal notranslate"><span class="pre">SeriesAbstractNumeric.var</span></code></a>([partition,&#160;...])</p></td>
+<td><p>Get the sample variance of the input values (square of the sample standard deviation) Normalized by N-1 by default.</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+<section id="window">
+<h3>Window<a class="headerlink" href="#window" title="Permalink to this headline">#</a></h3>
+<table class="autosummary longtable table autosummary">
+<colgroup>
+<col style="width: 10%"/>
+<col style="width: 90%"/>
+</colgroup>
+<tbody>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.window_first_value.html#bach.Series.window_first_value" title="bach.Series.window_first_value"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.window_first_value</span></code></a>([window])</p></td>
+<td><p>Returns value evaluated at the row that is the first row of the window frame.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.window_lag.html#bach.Series.window_lag" title="bach.Series.window_lag"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.window_lag</span></code></a>([offset,&#160;default,&#160;window])</p></td>
+<td><p>Returns value evaluated at the row that is offset rows before the current row within the window</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.window_nth_value.html#bach.Series.window_nth_value" title="bach.Series.window_nth_value"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.window_nth_value</span></code></a>(n[,&#160;window])</p></td>
+<td><p>Returns value evaluated at the row that is the n'th row of the window frame.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.window_lead.html#bach.Series.window_lead" title="bach.Series.window_lead"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.window_lead</span></code></a>([offset,&#160;default,&#160;window])</p></td>
+<td><p>Returns value evaluated at the row that is offset rows after the current row within the window.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.window_last_value.html#bach.Series.window_last_value" title="bach.Series.window_last_value"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.window_last_value</span></code></a>([window])</p></td>
+<td><p>Returns value evaluated at the row that is the last row of the window frame.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.window_row_number.html#bach.Series.window_row_number" title="bach.Series.window_row_number"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.window_row_number</span></code></a>([window])</p></td>
+<td><p>Returns the number of the current row within its window, counting from 1.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.window_rank.html#bach.Series.window_rank" title="bach.Series.window_rank"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.window_rank</span></code></a>([window])</p></td>
+<td><p>Returns the rank of the current row, with gaps; that is, the row_number of the first row in its peer group.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.window_dense_rank.html#bach.Series.window_dense_rank" title="bach.Series.window_dense_rank"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.window_dense_rank</span></code></a>([window])</p></td>
+<td><p>Returns the rank of the current row, without gaps; this function effectively counts peer groups.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.window_percent_rank.html#bach.Series.window_percent_rank" title="bach.Series.window_percent_rank"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.window_percent_rank</span></code></a>([window])</p></td>
+<td><p>Returns the relative rank of the current row, that is (rank - 1) / (total partition rows - 1).</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="Series/bach.Series.window_ntile.html#bach.Series.window_ntile" title="bach.Series.window_ntile"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.window_ntile</span></code></a>([num_buckets,&#160;window])</p></td>
+<td><p>Returns an integer ranging from 1 to the argument value, dividing the partition as equally as possible.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="Series/bach.Series.window_cume_dist.html#bach.Series.window_cume_dist" title="bach.Series.window_cume_dist"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.window_cume_dist</span></code></a>([window])</p></td>
+<td><p>Returns the cumulative distribution, that is (number of partition rows preceding or peers with current row) / (total partition rows).</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+</section>
+</section>
+
+
+              </div>
+              
+              
+              

--- a/docs/static/_modeling/example_notebooks.html
+++ b/docs/static/_modeling/example_notebooks.html
@@ -7,6 +7,15 @@ also available as Jupyter notebooks from our <a class="reference external" href=
 instantiate the open model hub and create a Bach DataFrame with Objectiv data. The open
 model hub uses this DataFrame for its models. For a general introduction to Bach DataFrames, see the
 <a class="reference internal" href="bach.html#bach"><span class="std std-ref">Bach</span></a> docs or some basic examples to get started <a class="reference internal" href="bach_examples.html#bach-examples"><span class="std std-ref">here</span></a>.</p>
+<div class="toctree-wrapper hide-toctree-ul compound">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="modelhub_basics.html">Open model hub basics</a></li>
+<li class="toctree-l1"><a class="reference internal" href="product_analytics.html">Basic product analytics</a></li>
+<li class="toctree-l1"><a class="reference internal" href="open_taxonomy.html">Open taxonomy how-to</a></li>
+<li class="toctree-l1"><a class="reference internal" href="feature_engineering.html">Feature engineering with Bach</a></li>
+<li class="toctree-l1"><a class="reference internal" href="machine_learning.html">Bach and sklearn</a></li>
+</ul>
+</div>
 <section id="getting-started-with-objectiv">
 <span id="get-started-with-objectiv"/><h2>Getting started with Objectiv<a class="headerlink" href="#getting-started-with-objectiv" title="Permalink to this headline">#</a></h2>
 <p>Here we show how to instantiate the model hub and a Bach DataFrame with Objectiv data that can be used
@@ -32,18 +41,13 @@ ie. monthly or daily.</p>
 </div>
 <p>Take a look at one of the example notebooks below to see how you can analyze your data. Basic Bach
 introduction examples are <a class="reference internal" href="bach_examples.html#bach-examples"><span class="std std-ref">here</span></a> in the Bach docs.</p>
-</section>
-<section id="examples">
-<h2>Examples<a class="headerlink" href="#examples" title="Permalink to this headline">#</a></h2>
-<div class="toctree-wrapper compound">
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="modelhub_basics.html">Open model hub basics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="product_analytics.html">Basic product analytics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="open_taxonomy.html">Open taxonomy how-to</a></li>
-<li class="toctree-l1"><a class="reference internal" href="feature_engineering.html">Feature engineering with Bach</a></li>
-<li class="toctree-l1"><a class="reference internal" href="machine_learning.html">Bach and sklearn</a></li>
+<ul class="simple">
+<li><p><a class="reference internal" href="modelhub_basics.html#example-modelhub-basics"><span class="std std-ref">Open model hub basics</span></a></p></li>
+<li><p><a class="reference internal" href="product_analytics.html#example-product-analytics"><span class="std std-ref">Basic product analytics</span></a></p></li>
+<li><p><a class="reference internal" href="open_taxonomy.html#example-open-taxonomy"><span class="std std-ref">Open taxonomy how-to</span></a></p></li>
+<li><p><a class="reference internal" href="feature_engineering.html#example-feature-engineering"><span class="std std-ref">Feature engineering with Bach</span></a></p></li>
+<li><p><a class="reference internal" href="machine_learning.html#example-machine-learning"><span class="std std-ref">Bach and sklearn</span></a></p></li>
 </ul>
-</div>
 </section>
 </section>
 

--- a/docs/static/_modeling/feature_engineering.html
+++ b/docs/static/_modeling/feature_engineering.html
@@ -1,11 +1,12 @@
 <div>
                 
   <section id="feature-engineering-with-bach">
-<span id="feature-engineering"/><h1>Feature engineering with Bach<a class="headerlink" href="#feature-engineering-with-bach" title="Permalink to this headline">#</a></h1>
+<span id="example-feature-engineering"/><h1>Feature engineering with Bach<a class="headerlink" href="#feature-engineering-with-bach" title="Permalink to this headline">#</a></h1>
 <p>This example shows how Bach can be used for feature engineering. We&#8217;ll go through describing the data, finding
 outliers, transforming data and grouping and aggregating data so that a useful feature set is created that
 can be used for machine learning. We have a separate example available that goes into the details of how a
-data set prepared in Bach can be used for machine learning with sklearn <a class="reference internal" href="machine_learning.html#machine-learning"><span class="std std-ref">here</span></a>.</p>
+data set prepared in Bach can be used for machine learning with sklearn
+<a class="reference internal" href="machine_learning.html#example-machine-learning"><span class="std std-ref">here</span></a>.</p>
 <p>This example is also available in a <a class="reference external" href="https://github.com/objectiv/objectiv-analytics/blob/main/notebooks/feature_engineering.ipynb">notebook</a>
 to run on your own data or use our
 <a class="reference external" href="https://objectiv.io/docs/home/quickstart-guide/">quickstart</a> to try it out with demo data in 5 minutes.</p>

--- a/docs/static/_modeling/machine_learning.html
+++ b/docs/static/_modeling/machine_learning.html
@@ -1,7 +1,7 @@
 <div>
                 
   <section id="bach-and-sklearn">
-<span id="machine-learning"/><h1>Bach and sklearn<a class="headerlink" href="#bach-and-sklearn" title="Permalink to this headline">#</a></h1>
+<span id="example-machine-learning"/><h1>Bach and sklearn<a class="headerlink" href="#bach-and-sklearn" title="Permalink to this headline">#</a></h1>
 <p>With Objectiv you can do all your analysis and Machine Learning directly on the raw data in your SQL database.
 This example shows in the simplest way possible how you can use Objectiv to create a basic feature set and use
 sklearn to do machine learning on this data set. We also have an example that goes deeper into

--- a/docs/static/_modeling/modelhub_api_reference.html
+++ b/docs/static/_modeling/modelhub_api_reference.html
@@ -3,8 +3,6 @@
   <section id="open-model-hub-api-reference">
 <span id="modelhub-api-reference"/><h1>Open model hub API reference<a class="headerlink" href="#open-model-hub-api-reference" title="Permalink to this headline">#</a></h1>
 <p>This is the complete API reference of the model hub.</p>
-<section id="reference">
-<h2>Reference<a class="headerlink" href="#reference" title="Permalink to this headline">#</a></h2>
 <table class="autosummary longtable table autosummary">
 <colgroup>
 <col style="width: 10%"/>
@@ -22,7 +20,6 @@
 </tr>
 </tbody>
 </table>
-</section>
 </section>
 
 

--- a/docs/static/_modeling/modelhub_basics.html
+++ b/docs/static/_modeling/modelhub_basics.html
@@ -1,7 +1,7 @@
 <div>
                 
   <section id="open-model-hub-basics">
-<span id="modelhub-basics"/><h1>Open model hub basics<a class="headerlink" href="#open-model-hub-basics" title="Permalink to this headline">#</a></h1>
+<span id="example-modelhub-basics"/><h1>Open model hub basics<a class="headerlink" href="#open-model-hub-basics" title="Permalink to this headline">#</a></h1>
 <p>In this example, we briefly demonstrate how you can use pre-built models from the open model hub in
 conjunction with, <a class="reference internal" href="bach.html#bach"><span class="std std-ref">Bach</span></a>, our modeling library.</p>
 <p>This example uses real, unaltered data that was collected from <a class="reference external" href="https://objectiv.io">https://objectiv.io</a> with Objectiv&#8217;s Tracker. All models
@@ -17,7 +17,7 @@ to run on your own data or use our
 <p>The open model hub is a growing collection of open-source, free to use data models that you can take,
 combine and run for product analysis and exploration. It includes models for a wide range of typical product
 analytics use cases. The source is available for all models and you&#8217;re free to make any changes to them.</p>
-<p>The model hub has two main type of functions: <a class="reference internal" href="models.html#map-models"><span class="std std-ref">Mapping</span></a> and <a class="reference internal" href="models.html#aggregate-models"><span class="std std-ref">Aggregation</span></a>.</p>
+<p>The model hub has two main type of functions: <a class="reference internal" href="models_mapping.html#models-mapping"><span class="std std-ref">Mapping</span></a> and <a class="reference internal" href="models_aggregation.html#models-aggregation"><span class="std std-ref">Aggregation</span></a>.</p>
 <ul class="simple">
 <li><p><cite>map</cite> functions always return a series with the same shape and index as the DataFrame they are applied to.
 This ensures they can be added as a column to that DataFrame. <cite>map</cite> functions that return SeriesBoolean can

--- a/docs/static/_modeling/models.html
+++ b/docs/static/_modeling/models.html
@@ -10,8 +10,20 @@ be used with to filter the data.</p></li>
 <li><p><cite>aggregate</cite> fuctions return aggregated data in some form from the DataFrame. Can also be accessed with
 <cite>agg</cite>.</p></li>
 </ul>
-<section id="mapping">
-<span id="map-models"/><h2>Mapping<a class="headerlink" href="#mapping" title="Permalink to this headline">#</a></h2>
+<div class="toctree-wrapper hide-toctree-ul compound">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="models_mapping.html">Mapping</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="modelhub_api_reference/modelhub.Map.is_first_session.html">modelhub.Map.is_first_session</a></li>
+<li class="toctree-l2"><a class="reference internal" href="modelhub_api_reference/modelhub.Map.is_new_user.html">modelhub.Map.is_new_user</a></li>
+<li class="toctree-l2"><a class="reference internal" href="modelhub_api_reference/modelhub.Map.is_conversion_event.html">modelhub.Map.is_conversion_event</a></li>
+<li class="toctree-l2"><a class="reference internal" href="modelhub_api_reference/modelhub.Map.conversions_counter.html">modelhub.Map.conversions_counter</a></li>
+<li class="toctree-l2"><a class="reference internal" href="modelhub_api_reference/modelhub.Map.conversions_in_time.html">modelhub.Map.conversions_in_time</a></li>
+<li class="toctree-l2"><a class="reference internal" href="modelhub_api_reference/modelhub.Map.pre_conversion_hit_number.html">modelhub.Map.pre_conversion_hit_number</a></li>
+</ul>
+</li>
+</ul>
+</div>
+<p class="rubric">Mapping</p>
 <table class="autosummary longtable table autosummary">
 <colgroup>
 <col style="width: 10%"/>
@@ -38,9 +50,18 @@ be used with to filter the data.</p></li>
 </tr>
 </tbody>
 </table>
-</section>
-<section id="aggregation">
-<span id="aggregate-models"/><h2>Aggregation<a class="headerlink" href="#aggregation" title="Permalink to this headline">#</a></h2>
+<div class="toctree-wrapper hide-toctree-ul compound">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="models_aggregation.html">Aggregation</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="modelhub_api_reference/modelhub.Aggregate.unique_users.html">modelhub.Aggregate.unique_users</a></li>
+<li class="toctree-l2"><a class="reference internal" href="modelhub_api_reference/modelhub.Aggregate.unique_sessions.html">modelhub.Aggregate.unique_sessions</a></li>
+<li class="toctree-l2"><a class="reference internal" href="modelhub_api_reference/modelhub.Aggregate.session_duration.html">modelhub.Aggregate.session_duration</a></li>
+<li class="toctree-l2"><a class="reference internal" href="modelhub_api_reference/modelhub.Aggregate.frequency.html">modelhub.Aggregate.frequency</a></li>
+</ul>
+</li>
+</ul>
+</div>
+<p class="rubric">Aggregation</p>
 <table class="autosummary longtable table autosummary">
 <colgroup>
 <col style="width: 10%"/>
@@ -61,7 +82,6 @@ be used with to filter the data.</p></li>
 </tr>
 </tbody>
 </table>
-</section>
 </section>
 
 

--- a/docs/static/_modeling/models_aggregation.html
+++ b/docs/static/_modeling/models_aggregation.html
@@ -1,0 +1,31 @@
+<div>
+                
+  <section id="aggregation">
+<span id="models-aggregation"/><h1>Aggregation<a class="headerlink" href="#aggregation" title="Permalink to this headline">#</a></h1>
+<table class="autosummary longtable table autosummary">
+<colgroup>
+<col style="width: 10%"/>
+<col style="width: 90%"/>
+</colgroup>
+<tbody>
+<tr class="row-odd"><td><p><a class="reference internal" href="modelhub_api_reference/modelhub.Aggregate.unique_users.html#modelhub.Aggregate.unique_users" title="modelhub.Aggregate.unique_users"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Aggregate.unique_users</span></code></a>(data[,&#160;groupby])</p></td>
+<td><p>Calculate the unique users in the Objectiv <code class="docutils literal notranslate"><span class="pre">data</span></code>.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="modelhub_api_reference/modelhub.Aggregate.unique_sessions.html#modelhub.Aggregate.unique_sessions" title="modelhub.Aggregate.unique_sessions"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Aggregate.unique_sessions</span></code></a>(data[,&#160;groupby])</p></td>
+<td><p>Calculate the unique sessions in the Objectiv <code class="docutils literal notranslate"><span class="pre">data</span></code>.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="modelhub_api_reference/modelhub.Aggregate.session_duration.html#modelhub.Aggregate.session_duration" title="modelhub.Aggregate.session_duration"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Aggregate.session_duration</span></code></a>(data[,&#160;groupby,&#160;...])</p></td>
+<td><p>Calculate the average duration of sessions.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="modelhub_api_reference/modelhub.Aggregate.frequency.html#modelhub.Aggregate.frequency" title="modelhub.Aggregate.frequency"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Aggregate.frequency</span></code></a>(data)</p></td>
+<td><p>Calculate a frequency table for the number of users by number of sessions.</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+
+
+              </div>
+              
+              
+              

--- a/docs/static/_modeling/models_mapping.html
+++ b/docs/static/_modeling/models_mapping.html
@@ -1,0 +1,37 @@
+<div>
+                
+  <section id="mapping">
+<span id="models-mapping"/><h1>Mapping<a class="headerlink" href="#mapping" title="Permalink to this headline">#</a></h1>
+<table class="autosummary longtable table autosummary">
+<colgroup>
+<col style="width: 10%"/>
+<col style="width: 90%"/>
+</colgroup>
+<tbody>
+<tr class="row-odd"><td><p><a class="reference internal" href="modelhub_api_reference/modelhub.Map.is_first_session.html#modelhub.Map.is_first_session" title="modelhub.Map.is_first_session"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Map.is_first_session</span></code></a>(data)</p></td>
+<td><p>Labels all hits in a session True if that session is the first session of that user in the data.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="modelhub_api_reference/modelhub.Map.is_new_user.html#modelhub.Map.is_new_user" title="modelhub.Map.is_new_user"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Map.is_new_user</span></code></a>(data[,&#160;time_aggregation])</p></td>
+<td><p>Labels all hits True if the user is first seen in the period given <cite>time_aggregation</cite>.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="modelhub_api_reference/modelhub.Map.is_conversion_event.html#modelhub.Map.is_conversion_event" title="modelhub.Map.is_conversion_event"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Map.is_conversion_event</span></code></a>(data,&#160;name)</p></td>
+<td><p>Labels a hit True if it is a conversion event, all other hits are labeled False.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="modelhub_api_reference/modelhub.Map.conversions_counter.html#modelhub.Map.conversions_counter" title="modelhub.Map.conversions_counter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Map.conversions_counter</span></code></a>(data,&#160;name[,&#160;partition])</p></td>
+<td><p>Counts the total number of conversions given a partition (ie session_id or user_id).</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="modelhub_api_reference/modelhub.Map.conversions_in_time.html#modelhub.Map.conversions_in_time" title="modelhub.Map.conversions_in_time"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Map.conversions_in_time</span></code></a>(data,&#160;name[,&#160;partition])</p></td>
+<td><p>Counts the number of time a user is converted at a moment in time given a partition (ie 'session_id' or 'user_id').</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="modelhub_api_reference/modelhub.Map.pre_conversion_hit_number.html#modelhub.Map.pre_conversion_hit_number" title="modelhub.Map.pre_conversion_hit_number"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Map.pre_conversion_hit_number</span></code></a>(data,&#160;name[,&#160;...])</p></td>
+<td><p>Returns a count backwards from the first conversion, given the partition.</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+
+
+              </div>
+              
+              
+              

--- a/docs/static/_modeling/open_taxonomy.html
+++ b/docs/static/_modeling/open_taxonomy.html
@@ -1,7 +1,7 @@
 <div>
                 
   <section id="open-taxonomy-how-to">
-<h1>Open taxonomy how-to<a class="headerlink" href="#open-taxonomy-how-to" title="Permalink to this headline">#</a></h1>
+<span id="example-open-taxonomy"/><h1>Open taxonomy how-to<a class="headerlink" href="#open-taxonomy-how-to" title="Permalink to this headline">#</a></h1>
 <p>This example demonstrates what you can do with the Objectiv Bach modeling library and a dataset that was validated against the <a class="reference external" href="https://objectiv.io/docs/taxonomy/">open analytics taxonomy</a>.</p>
 <p>This example is also available in a <a class="reference external" href="https://github.com/objectiv/objectiv-analytics/blob/main/notebooks/open-taxonomy-how-to.ipynb">notebook</a>
 to run on your own data or use our
@@ -127,8 +127,8 @@ example is queried below:</p>
 <p>This concludes this demo.</p>
 <p>We&#8217;ve demonstrated a handful of the operations that Bach supports and hope you&#8217;ve gotten a taste of what Bach can do for your modeling workflow.</p>
 <p>The full Objectiv Bach API reference is available <a class="reference internal" href="bach_reference.html#bach-api-reference"><span class="std std-ref">here</span></a>.</p>
-<p>There is another example that focuses on using the <a class="reference internal" href="modelhub_basics.html#modelhub-basics"><span class="std std-ref">open model hub</span></a>, demonstrating
-how you can use the model hub and Bach to quickly answer common product analytics questions.</p>
+<p>There is another example that focuses on using the <a class="reference internal" href="modelhub_basics.html#example-modelhub-basics"><span class="std std-ref">open model hub</span></a>,
+demonstrating how you can use the model hub and Bach to quickly answer common product analytics questions.</p>
 </section>
 </section>
 

--- a/docs/static/_modeling/product_analytics.html
+++ b/docs/static/_modeling/product_analytics.html
@@ -1,7 +1,7 @@
 <div>
                 
   <section id="basic-product-analytics">
-<h1>Basic product analytics<a class="headerlink" href="#basic-product-analytics" title="Permalink to this headline">#</a></h1>
+<span id="example-product-analytics"/><h1>Basic product analytics<a class="headerlink" href="#basic-product-analytics" title="Permalink to this headline">#</a></h1>
 <p>This example shows how the open model hub can be used for basic product analysis.</p>
 <p>This example is also available in a <a class="reference external" href="https://github.com/objectiv/objectiv-analytics/blob/main/notebooks/basic-analysis.ipynb">notebook</a>
 to run on your own data or use our


### PR DESCRIPTION
This PR uses categories for the model hub restructure where applicable.

Noticeable other changes:
- No longer opens the first page under a category immediately; resulted in some strange behavior here and there, and is no longer really needed with the new category pages.
- Makes headings for the API references only a bit smaller.