### PR TITLE
Custom search metadata component

### DIFF
--- a/docs/src/components/custom-search-metadata/index.tsx
+++ b/docs/src/components/custom-search-metadata/index.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import Head from '@docusaurus/Head';
+
+type CustomSearchMetadataProps = {
+  type: string, // can be used for grouping search results in the future
+  platform: string // can be used for filtering on the platform type (e.g. 'React') in the future
+}
+
+export default function CustomSearchMetadata({ type, platform }: CustomSearchMetadataProps) {
+  return (
+    <Head>
+      {type && <meta name="docsearch:type" content={type} />}
+      {platform && <meta name="docsearch:platform" content={platform} />}
+    </Head>
+  );
+}


### PR DESCRIPTION
Adds ability to add custom search metadata to doc pages. Will experiment with this on Algolia search later.