### PR TITLE
Check URLs added/removed in the objectiv.io repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ provision the appropriate environment variables for SFTP, and then run:
 # pull any changes, and build the deployable docker images for both website and docs for testing only.
 git pull && make build-docker-test-image build-docker-deploy-image
 
+# check image for any removed/changed URLs that may cause issues
+python3 scripts/check_urls.py --environment=testing
+
 # then, upload to testing via FTP
 docker run -e SFTP_URL \
     -e SFTP_USERNAME \
@@ -73,9 +76,8 @@ provision the appropriate environment variables for SFTP, and then run:
 # pull any changes, and build the deployable docker images for both website and docs for staging & production.
 git pull && make build-docker-build-image build-docker-deploy-image
 
-# second, compare the sitemap on production to the sitemap in the image, to double-check any URL changes; if 
-# you don't have `blessings` & `lxml` installed yet, do `sudo apt-get install python3-blessings python3-lxml`
-./docker/build/diff-sitemaps.sh
+# check image for any removed/changed URLs that may cause issues
+python3 scripts/check_urls.py --environment=staging
 
 # if URL checks are okay, upload to staging via FTP
 docker run -e SFTP_URL \

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,27 @@
+# Objectiv Website & Documentation Scripts
+
+Scripts to check website & docs.
+
+## Setup
+To set up the environment:
+
+```bash
+virtualenv check_sitemaps
+source check_sitemaps/bin/activate
+pip install -r requirements.txt
+```
+
+## Check URLs
+
+Check a website/docs Docker image for URLs that are added/removed compared to production and local repos.
+
+To run:
+
+```bash
+python3 scripts/check_urls.py
+```
+
+Optional parameters:
+- `--environment`: the image's environment, e.g. `--environment=testing`
+- `--docker-image`: the docker image to scan, e.g. `--docker-image=objectiv/website-deploy`
+- `--tag`: the docker image tag, e.g. `--tag=20220101`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,7 +15,7 @@ pip install -r requirements.txt
 
 Check a website/docs Docker image for URLs that are added/removed compared to production and local repos.
 
-To run:
+To run (from root of repo):
 
 ```bash
 python3 scripts/check_urls.py

--- a/scripts/check_urls.py
+++ b/scripts/check_urls.py
@@ -18,12 +18,6 @@ FQDN_PATHS = ['/', '/docs/']  # list of paths on domain to get sitemap from
 SITEMAP = 'sitemap.xml'  # name of sitemap file
 EXTENSIONS_TO_SCAN = ['md', 'html', 'rst', 'ipynb']  # file extensions to scan for URLs
 
-parser = argparse.ArgumentParser()
-parser.add_argument("--environment", default='production', help="the image's environment, e.g. 'testing'")
-parser.add_argument("--docker-image", default='objectiv/website-deploy', help="the docker image to scan")
-parser.add_argument("--tag", default=datetime.datetime.now().strftime('%Y%m%d'), help="the docker image tag")
-args = parser.parse_args()
-
 
 def has_extension(filename: str, extensions: List[str]) -> bool:
     """Check whether a file has one of the specified extensions
@@ -71,7 +65,6 @@ def check_urls_from_files(path: str, extensions: List[str], urls: List[str]) -> 
             urls_found_in_files += check_urls_in_file(fn, urls)
 
     return urls_found_in_files
-    # return {fn: check_urls_in_file(fn, urls) for fn in glob.glob(path, recursive=True) if has_extension(fn, extensions)}
 
 
 def compare_urls(source: List[str], target: List[str]) -> List[str]:
@@ -160,6 +153,15 @@ def main() -> int:
     * URLs that are used externally
     * TODO: tracker validation
     """
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--environment", default='production', 
+                        help="the image's environment, e.g. 'testing'")
+    parser.add_argument("--docker-image", default='objectiv/website-deploy', 
+                        help="the docker image to scan")
+    parser.add_argument("--tag", default=datetime.datetime.now().strftime('%Y%m%d'), 
+                        help="the docker image tag")
+    args = parser.parse_args()
 
     term = Terminal()
 

--- a/scripts/check_urls.py
+++ b/scripts/check_urls.py
@@ -147,6 +147,7 @@ def main() -> int:
     Check URLs removed & added in a docker image against what's used:
     * On production (website/docs sitemaps)
     * In local repositories (objectiv.io and objectiv-analytics)
+    * URLs that are used externally
     * TODO: tracker validation
     """
 

--- a/scripts/check_urls.py
+++ b/scripts/check_urls.py
@@ -1,0 +1,204 @@
+"""
+Copyright 2022 Objectiv B.V.
+"""
+import datetime
+import sys
+import argparse
+import requests
+import xml.etree.ElementTree as ElementTree
+from typing import List, Dict
+import glob
+import urllib.parse
+from blessings import Terminal
+from subprocess import check_output
+
+# Basic configuration
+FQDN = 'https://objectiv.io' # domain to get sitemaps from
+FQDN_PATHS = ['/', '/docs/'] # list of paths on domain to get sitemap from
+SITEMAP = 'sitemap.xml' # name of sitemap file
+EXTENSIONS_TO_SCAN = ['md', 'html', 'rst', 'ipynb'] # file extensions to scan for URLs
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--environment", default='production', help="the image's environment, e.g. 'testing'")
+parser.add_argument("--docker-image", default='objectiv/website-deploy', help="the docker image to scan")
+parser.add_argument("--tag", default=datetime.datetime.now().strftime('%Y%m%d'), help="the docker image tag")
+args = parser.parse_args()
+
+def has_extension(filename: str, extensions: List[str]) -> bool:
+    """Check whether a file has one of the specified extensions
+
+    :param filename: The file to check
+    :param extensions: The file extensions it should have, e.g. ['.md', .ipynb']
+
+    :return: True if the extension of the filename is in the list of specified allowed extensions
+    """
+    extension = filename.split('.')[-1]
+    return extension in extensions
+
+def check_urls_in_file(filename: str, urls: List[str]) -> List[str]:
+    """Get any occurance of the specified URLs in the specified file
+
+    :param filename: The file to scan
+    :param urls: The URLs to find in the file
+
+    :return: List of URLs found and in which file, e.g. [['https://test.com', '/source/hello.md']]
+    """
+    found = []
+    with open(filename) as f:
+        contents = f.read()
+
+        for url in urls:
+            if contents.find(url) != -1:
+                found.append([url, filename])
+    return found
+
+def check_urls_from_files(path: str, extensions: List[str], urls: List[str]) -> Dict[str,str]:
+    """Find any occurence of the URLs in the specified path and file types, e.g. in a repo
+
+    :param path: The path to scan
+    :param extensions: The file extensions to scan, e.g. ['.md', .ipynb']
+    :param urls: The URLs to find in the files
+
+    :return: List of URLs found and in which file, e.g. [['https://test.com', '/source/hello.md']]
+    """
+
+    urls_found_in_files = []
+    for fn in glob.glob(path, recursive=True):
+        if has_extension(fn, extensions):
+            urls_found_in_files += check_urls_in_file(fn, urls)
+
+    return urls_found_in_files
+    # return {fn: check_urls_in_file(fn, urls) for fn in glob.glob(path, recursive=True) if has_extension(fn, extensions)}
+
+def compare_urls(source: List[str], target: List[str]) -> List[str]:
+    """Get the URLs not found in source vs target
+
+    :param source: The source to compare
+    :param target: The target to compare to
+
+    :return: List of URLs missing in source, compared to target
+    """
+    return [u for u in source if u not in target]
+
+def get_base_url(url: str) -> str:
+    """Get the base URL from a URL (e.g. 'https://objectiv.io' from 'https://objectiv.io/about')
+
+    :param url: The URL to get the base from
+
+    :return: the base URL
+    """
+
+    parsed_url = urllib.parse.urlparse(url)
+    return f'{parsed_url.scheme}://{parsed_url.netloc}'
+
+def make_canonical(url: str, base_url: str = None) -> str:
+    """Canonicalize a URL
+
+    :param url: The URL to make canonical
+    :param base_url: The base URL (e.g. 'https://staging.objectiv.io') to replace
+
+    :return: a canonicalized URL in which the base URL is stripped
+    """
+
+    if not base_url:
+        base_url = get_base_url(url)
+    return url.replace(base_url, '')
+
+def get_urls_from_sitemap(sitemap: str) -> List:
+    """Get all the URLs from a sitemap (in text)
+
+    :param sitemap: The sitemap (in text) containing the URLs to extract
+
+    :return: A list of URLs fetched from the sitemap
+    """
+    doc = ElementTree.fromstring(sitemap)
+    for url in doc.findall('.//{http://www.sitemaps.org/schemas/sitemap/0.9}loc'):
+        yield url.text
+
+def get_urls_from_docker_image(env: str, path: str, image: str, tag: str = 'latest') -> List[str]:
+    """Get all the URLs from a file at the specified Docker image
+
+    :param env: The image environment, e.g. 'docker' or 'testing'
+    :param path: The path to the sitemap in the image (without the filename of the sitemap itself)
+    :param image: The image name
+    :param tag: The tag of the iamge
+
+    :return: A list of URLs fetched from the sitemap
+    """
+    sitemap_path = f'/services{path}build-{env}/{SITEMAP}'
+    print(f'Fetching URLs from sitemap in image {image}:{tag}{sitemap_path}')
+    sitemap = check_output(['docker', 'run', '--rm', f'{image}:{tag}', f'cat',  f'{sitemap_path}'])
+
+    return get_urls_from_sitemap(sitemap.decode('utf-8'))
+
+def get_urls_from_url(url: str) -> List:
+    """Get all the URLs from a file at the specified URL (i.e. a sitemap)
+
+    :param url: The URL to the file containing the URLs to extract
+
+    :return: A list of URLs fetched from the file at the specified URL
+    """
+    print(f'Fetching URLs from sitemap at {url}')
+    r = requests.get(url)
+    return get_urls_from_sitemap(r.text)
+
+def main() -> int:
+    """
+    Check URLs removed & added in a docker image against what's used:
+    * On production (website/docs sitemaps)
+    * In local repositories (objectiv.io and objectiv-analytics)
+    * TODO: tracker validation
+    """
+
+    term = Terminal()
+
+    # first get the URLs from the production domain's sitemap
+    prod_urls = []
+    for path in FQDN_PATHS:
+        prod_urls += get_urls_from_url(f'{FQDN}{path}{SITEMAP}')
+    prod_urls = [make_canonical(u, FQDN) for u in prod_urls]
+
+    # second, get the URLs from the image's sitemap
+    docker_urls = []
+    env = args.environment
+    image=args.docker_image
+    tag=args.tag
+    for path in FQDN_PATHS:
+        docker_urls += get_urls_from_docker_image(env, path=path, image=image, tag=tag)
+    docker_urls = [make_canonical(u) for u in docker_urls]
+
+    # third, compare the retrieved URLs from the docker image with the ones on production, and vice versa
+    removed_urls = compare_urls(prod_urls, docker_urls) # missing URLs prod vs image (i.e. will break)
+    added_urls = compare_urls(docker_urls, prod_urls) # missing URLs image vs prod (i.e. are new)
+
+    exitcode = 0
+    if removed_urls:
+        # these are missing URLs, i.e. they exist on prod, but not in the docker image
+        for url in removed_urls:
+            print(term.bold_red(f'Removed URL compared to production sitemap: ({url})'))
+        exitcode += 1
+
+    if added_urls:
+        # these are new URLs, i.e. the exist in the image, but not yet on production
+        for url in added_urls:
+            print(term.yellow(f'New URL compared to production sitemap: {url}'))
+        exitcode += 1
+
+    # fourth, check all removed+added URLs against the objectiv.io repository (i.e. the docs or site)
+    urls_to_check = removed_urls + added_urls
+    urls_in_use = check_urls_from_files('**', EXTENSIONS_TO_SCAN, urls_to_check)
+    urls_in_use += check_urls_from_files('../objectiv-analytics/**', EXTENSIONS_TO_SCAN, urls_to_check)
+
+    if urls_in_use:
+        for hit in urls_in_use:
+            url = hit[0]
+            file = hit[1]
+            print(term.blue(f'{file} uses URL: {url}'))
+        exitcode += 1
+
+    # TODO: check all removed+added URLs against the ones used in tracker validation
+    
+    return exitcode
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_urls.py
+++ b/scripts/check_urls.py
@@ -13,16 +13,17 @@ from blessings import Terminal
 from subprocess import check_output
 
 # Basic configuration
-FQDN = 'https://objectiv.io' # domain to get sitemaps from
-FQDN_PATHS = ['/', '/docs/'] # list of paths on domain to get sitemap from
-SITEMAP = 'sitemap.xml' # name of sitemap file
-EXTENSIONS_TO_SCAN = ['md', 'html', 'rst', 'ipynb'] # file extensions to scan for URLs
+FQDN = 'https://objectiv.io'  # domain to get sitemaps from
+FQDN_PATHS = ['/', '/docs/']  # list of paths on domain to get sitemap from
+SITEMAP = 'sitemap.xml'  # name of sitemap file
+EXTENSIONS_TO_SCAN = ['md', 'html', 'rst', 'ipynb']  # file extensions to scan for URLs
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--environment", default='production', help="the image's environment, e.g. 'testing'")
 parser.add_argument("--docker-image", default='objectiv/website-deploy', help="the docker image to scan")
 parser.add_argument("--tag", default=datetime.datetime.now().strftime('%Y%m%d'), help="the docker image tag")
 args = parser.parse_args()
+
 
 def has_extension(filename: str, extensions: List[str]) -> bool:
     """Check whether a file has one of the specified extensions
@@ -34,6 +35,7 @@ def has_extension(filename: str, extensions: List[str]) -> bool:
     """
     extension = filename.split('.')[-1]
     return extension in extensions
+
 
 def check_urls_in_file(filename: str, urls: List[str]) -> List[str]:
     """Get any occurance of the specified URLs in the specified file
@@ -51,6 +53,7 @@ def check_urls_in_file(filename: str, urls: List[str]) -> List[str]:
             if contents.find(url) != -1:
                 found.append([url, filename])
     return found
+
 
 def check_urls_from_files(path: str, extensions: List[str], urls: List[str]) -> Dict[str,str]:
     """Find any occurence of the URLs in the specified path and file types, e.g. in a repo
@@ -70,6 +73,7 @@ def check_urls_from_files(path: str, extensions: List[str], urls: List[str]) -> 
     return urls_found_in_files
     # return {fn: check_urls_in_file(fn, urls) for fn in glob.glob(path, recursive=True) if has_extension(fn, extensions)}
 
+
 def compare_urls(source: List[str], target: List[str]) -> List[str]:
     """Get the URLs not found in source vs target
 
@@ -79,6 +83,7 @@ def compare_urls(source: List[str], target: List[str]) -> List[str]:
     :return: List of URLs missing in source, compared to target
     """
     return [u for u in source if u not in target]
+
 
 def get_base_url(url: str) -> str:
     """Get the base URL from a URL (e.g. 'https://objectiv.io' from 'https://objectiv.io/about')
@@ -90,6 +95,7 @@ def get_base_url(url: str) -> str:
 
     parsed_url = urllib.parse.urlparse(url)
     return f'{parsed_url.scheme}://{parsed_url.netloc}'
+
 
 def make_canonical(url: str, base_url: str = None) -> str:
     """Canonicalize a URL
@@ -104,6 +110,7 @@ def make_canonical(url: str, base_url: str = None) -> str:
         base_url = get_base_url(url)
     return url.replace(base_url, '')
 
+
 def get_urls_from_sitemap(sitemap: str) -> List:
     """Get all the URLs from a sitemap (in text)
 
@@ -114,6 +121,7 @@ def get_urls_from_sitemap(sitemap: str) -> List:
     doc = ElementTree.fromstring(sitemap)
     for url in doc.findall('.//{http://www.sitemaps.org/schemas/sitemap/0.9}loc'):
         yield url.text
+
 
 def get_urls_from_docker_image(env: str, path: str, image: str, tag: str = 'latest') -> List[str]:
     """Get all the URLs from a file at the specified Docker image
@@ -131,6 +139,7 @@ def get_urls_from_docker_image(env: str, path: str, image: str, tag: str = 'late
 
     return get_urls_from_sitemap(sitemap.decode('utf-8'))
 
+
 def get_urls_from_url(url: str) -> List:
     """Get all the URLs from a file at the specified URL (i.e. a sitemap)
 
@@ -141,6 +150,7 @@ def get_urls_from_url(url: str) -> List:
     print(f'Fetching URLs from sitemap at {url}')
     r = requests.get(url)
     return get_urls_from_sitemap(r.text)
+
 
 def main() -> int:
     """
@@ -162,8 +172,8 @@ def main() -> int:
     # second, get the URLs from the image's sitemap
     docker_urls = []
     env = args.environment
-    image=args.docker_image
-    tag=args.tag
+    image = args.docker_image
+    tag = args.tag
     for path in FQDN_PATHS:
         docker_urls += get_urls_from_docker_image(env, path=path, image=image, tag=tag)
     docker_urls = [make_canonical(u) for u in docker_urls]
@@ -200,6 +210,7 @@ def main() -> int:
     # TODO: check all removed+added URLs against the ones used in tracker validation
     
     return exitcode
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/check_urls.py
+++ b/scripts/check_urls.py
@@ -31,7 +31,7 @@ def has_extension(filename: str, extensions: List[str]) -> bool:
     return extension in extensions
 
 
-def check_urls_in_file(filename: str, urls: List[str]) -> List[str]:
+def check_urls_in_file(filename: str, urls: List[str]) -> List[List[str]]:
     """Get any occurance of the specified URLs in the specified file
 
     :param filename: The file to scan
@@ -49,11 +49,11 @@ def check_urls_in_file(filename: str, urls: List[str]) -> List[str]:
     return found
 
 
-def check_urls_from_files(path: str, extensions: List[str], urls: List[str]) -> Dict[str,str]:
+def check_urls_from_files(path: str, extensions: List[str], urls: List[str]) -> List[List[str]]:
     """Find any occurence of the URLs in the specified path and file types, e.g. in a repo
 
     :param path: The path to scan
-    :param extensions: The file extensions to scan, e.g. ['.md', .ipynb']
+    :param extensions: The file extensions to scan, e.g. ['md', 'ipynb']
     :param urls: The URLs to find in the files
 
     :return: List of URLs found and in which file, e.g. [['https://test.com', '/source/hello.md']]

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,4 @@
+lxml
+blessings
+requests
+urllib3

--- a/scripts/urls_in_use.md
+++ b/scripts/urls_in_use.md
@@ -1,0 +1,9 @@
+The following URLs are in use externally, and should not be removed:
+- https://objectiv.io/docs/home/quickstart-guide
+- https://objectiv.io/docs/modeling/
+- https://objectiv.io/blog/meet-objectiv/ (e.g. by https://www.emerce.nl/nieuws/utrechts-objectivio-opensource-productanalytics)
+- https://objectiv.io/blog/location-stack/
+- https://objectiv.io/blog/release-0.0.13-marketing-context/
+- https://objectiv.io/blog/release-0.0.14-bach-date-time-operations/
+- https://objectiv.io/blog/release-0.0.15-core-tracker-validation/
+- https://objectiv.io/blog/release-0.0.16-example-notebooks-for-open-model-hub/


### PR DESCRIPTION
Adds a script to check URLs added/removed in an image built for the objectiv.io repo. Checks are performed against:

* Production (website + docs sitemaps).
* Local repositories (objectiv.io and objectiv-analytics).
* Known URLs that are used externally.

In the near future we'd like to extend this to also check the URLs used in the tracker's validation.

Example output where the URL to the quickstart is changed from `/docs/home/quickstart-guide` to `/docs/home/quickstart-guide2` for testing purposes:

![image](https://user-images.githubusercontent.com/920184/161549741-f86438cc-20de-4462-89f9-58ebd0075cbd.png)
