### PR TITLE
Detect non-absolute URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,13 @@ provision the appropriate environment variables for SFTP, and then run:
 git pull && make build-docker-test-image build-docker-deploy-image
 
 # check image for any removed/changed URLs that may cause issues
+cd scripts
+virtualenv check_sitemaps
+source check_sitemaps/bin/activate
+pip install -r requirements.txt
+cd ../
 python3 scripts/check_urls.py --environment=testing
+deactivate
 
 # then, upload to testing via FTP
 docker run -e SFTP_URL \
@@ -77,7 +83,13 @@ provision the appropriate environment variables for SFTP, and then run:
 git pull && make build-docker-build-image build-docker-deploy-image
 
 # check image for any removed/changed URLs that may cause issues
+cd scripts
+virtualenv check_sitemaps
+source check_sitemaps/bin/activate
+pip install -r requirements.txt
+cd ../
 python3 scripts/check_urls.py --environment=staging
+deactivate
 
 # if URL checks are okay, upload to staging via FTP
 docker run -e SFTP_URL \

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ git pull && make build-docker-test-image build-docker-deploy-image
 
 # check image for any removed/changed URLs that may cause issues
 cd scripts
-virtualenv check_sitemaps
+# virtualenv check_sitemaps # only if not done yet
 source check_sitemaps/bin/activate
 pip install -r requirements.txt
 cd ../
@@ -84,7 +84,7 @@ git pull && make build-docker-build-image build-docker-deploy-image
 
 # check image for any removed/changed URLs that may cause issues
 cd scripts
-virtualenv check_sitemaps
+# virtualenv check_sitemaps # only if not done yet
 source check_sitemaps/bin/activate
 pip install -r requirements.txt
 cd ../

--- a/blog/2022-02-16 Location Stack.md
+++ b/blog/2022-02-16 Location Stack.md
@@ -67,7 +67,7 @@ Here is an example of the same event, but this time collected by Objectiv’s tr
    {
      "_type": "LinkContext",
      "id": "overview",
-     "href": "/docs/modeling/DataFrame""
+     "href": "https://objectiv.io/docs/modeling/DataFrame"
    }
  ]
 }

--- a/scripts/check_urls.py
+++ b/scripts/check_urls.py
@@ -41,8 +41,7 @@ def check_non_absolute_urls(path: str, extensions: List[str], urls: List[str]) -
                     matches = re.findall("(.*?)\/" + url, contents)
                     for match in matches:
                         before = match.strip()
-                        # non-absolute if: doesn't use `useBaseUrl()` or contains "https://" or Tracking code
-                        # could do more specific URL matching here, but sufficient for this purpose
+                        # non-absolute if: doesn't contain `useBaseUrl()`, "https://" or Tracking code
                         if (before.find("useBaseUrl") == -1 and before.find("https://") == -1 
                             and before.find("<Tracked") == -1):
                             non_abs_urls_found_in_files.append([before + url, filename])

--- a/scripts/check_urls.py
+++ b/scripts/check_urls.py
@@ -37,7 +37,8 @@ def check_non_absolute_urls(path: str, extensions: List[str], urls: List[str]) -
                 contents = f.read()
                 for url in urls:
                     # find all occurrences of the URL and determine if it's non-absolute
-                    matches = re.findall("(.*?)\/" + url, contents)
+                    matches = re.findall(f'(.*?)\/{url}', contents)
+
                     for match in matches:
                         before = match.strip()
                         # non-absolute if: doesn't contain `useBaseUrl()`, "https://" or Tracking code

--- a/scripts/check_urls.py
+++ b/scripts/check_urls.py
@@ -43,7 +43,7 @@ def check_non_absolute_urls(path: str, extensions: List[str], urls: List[str]) -
                         before = match.strip()
                         # non-absolute if: doesn't contain `useBaseUrl()`, "https://" or Tracking code
                         if (before.find("useBaseUrl") == -1 and before.find("https://") == -1
-                                and before.find("<Tracked") == -1):
+                                and before.find("http://") == -1 and before.find("<Tracked") == -1):
                             non_abs_urls_found_in_files.append([before + url, filename])
 
     return non_abs_urls_found_in_files


### PR DESCRIPTION
Our broken-link-checker cannot follow non-absolute URLs. This adds a check to the check_urls script for usage of non-absolute URLs in the website & blog.

This PR also updates:
- The README file to create a virtualenv for running the script. 
- A small error in a blog post, found accidentally by the script.