### PR TITLE
Various site improvements

### DIFF
--- a/docs/docs/tracking/react/api-reference/hooks/eventTrackers/useVisibilityTracker.md
+++ b/docs/docs/tracking/react/api-reference/hooks/eventTrackers/useVisibilityTracker.md
@@ -34,7 +34,7 @@ const trackVisibility = useVisibilityTracker();
 
 <Drawer
   onChange={(isOpen) => {
-    trackVisibility({ isVisibile: isOpen });
+    trackVisibility({ isVisible: isOpen });
   }}
 />
 ```

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -13,9 +13,9 @@ const lightCodeTheme = require('prism-react-renderer/themes/github');
 const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 
 const config = {
-  title: "Objectiv - Open-source product analytics, designed for data science",
+  title: "Objectiv - Open-source infrastructure for product analytics",
   titleDelimiter: '|',
-  tagline: 'Built to collect model-ready data straight out of the box. No tracking plans, data cleaning or transformations required. Just open your notebook and start modeling on your data right away with pandas-like operations that run on the full SQL dataset.', //meta description, and og:description
+  tagline: 'Collect rich, model-ready data and feed it straight into your data warehouse. Cut down delivery times of data projects with reusable & prebuilt models.', //meta description, and og:description
   url: envConfig.websiteUrl,
   baseUrl: envConfig.baseUrl,
   favicon: 'img/favicon/favicon.ico',

--- a/docs/src/theme/DocBreadcrumbs/index.tsx
+++ b/docs/src/theme/DocBreadcrumbs/index.tsx
@@ -15,6 +15,7 @@ import styles from './styles.module.css';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import { tagLink, makeIdFromString, tagNavigation } from '@objectiv/tracker-browser';
 
 // OBJECTIV
 import { useLocation } from "@docusaurus/router";
@@ -29,13 +30,22 @@ function BreadcrumbsItemLink({
   href?: string;
 }): JSX.Element {
   const className = clsx('breadcrumbs__link', styles.breadcrumbsItemLink);
+  // OBJECTIV
+  const getNodeText = node => {
+    if (['string', 'number'].includes(typeof node)) return node
+    if (node instanceof Array) return node.map(getNodeText).join('')
+    if (typeof node === 'object' && node) return getNodeText(node.props.children)
+  }
   return href ? (
-    <Link className={className} href={href}>
+    <Link
+      {...tagLink({ id: makeIdFromString(getNodeText(children) + "-" + href), href: href })}
+      className={className} href={href}>
       {children}
     </Link>
   ) : (
     <span className={className}>{children}</span>
   );
+  // END OBJECTIV
 }
 
 // TODO move to design system folder
@@ -97,6 +107,9 @@ export default function DocBreadcrumbs(): JSX.Element | null {
 
   return (
     <nav
+      // OBJECTIV
+      {...tagNavigation({ id: 'breadcrumbs' })}
+      // END OBJECTIV
       className={clsx(
         ThemeClassNames.docs.docBreadcrumbs,
         styles.breadcrumbsContainer,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -11,9 +11,9 @@ const slackJoinLink = '/join-slack';
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: "Objectiv - Open-source product analytics, designed for data science",
+  title: "Objectiv - Open-source infrastructure for product analytics",
   titleDelimiter: '|',
-  tagline: 'Built to collect model-ready data straight out of the box. No tracking plans, data cleaning or transformations required. Just open your notebook and start modeling on your data right away with pandas-like operations that run on the full SQL dataset.', //meta description, and og:description
+  tagline: 'Collect rich, model-ready data and feed it straight into your data warehouse. Cut down delivery times of data projects with reusable & prebuilt models.', //meta description, and og:description
   baseUrl: envConfig.baseUrl,
   url: envConfig.websiteUrl,
   favicon: 'img/favicon/favicon.ico',

--- a/src/components/before-after-image/index.tsx
+++ b/src/components/before-after-image/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useRef } from "react";
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import clsx from "clsx";
-import { TrackedDiv } from "@objectiv/tracker-react";
+import { TrackedDiv, TrackedButton } from "@objectiv/tracker-react";
 import styles from "./styles.module.css";
 
 // Handles using/setting state with an interval timer
@@ -60,20 +60,20 @@ export default function BeforeAfterImage({
       onMouseLeave={handleRunningChange}>
       <div className={clsx(styles.beforeAfterTabs, 
         tabColorsInverted && styles.beforeAfterTabsInverted)}>
-        <button 
+        <TrackedButton 
           id='before'
           className={clsx(styles.beforeAfterTab, 
             activeTab == 'before' ? styles.beforeAfterTabActive : styles.beforeAfterTabInactive)}
           onClick={toggleActiveTab}>
           BEFORE
-        </button>
-        <button 
+        </TrackedButton>
+        <TrackedButton 
           id='after'
           className={clsx(styles.beforeAfterTab, 
             activeTab == 'after' ? styles.beforeAfterTabActive : styles.beforeAfterTabInactive)}
           onClick={toggleActiveTab}>
           AFTER
-        </button>
+        </TrackedButton>
       </div>
       <div 
         className={clsx(styles.switch, 

--- a/src/components/star-us/index.tsx
+++ b/src/components/star-us/index.tsx
@@ -3,7 +3,7 @@ import clsx from "clsx";
 import styles from "./styles.module.css";
 import useBaseUrl from "@docusaurus/useBaseUrl";
 import { useScrollPosition } from '@docusaurus/theme-common';
-import { TrackedOverlayContext, useVisibilityTracker } from "@objectiv/tracker-react";
+import { PressableContextWrapper, TrackedOverlayContext, trackPressEvent } from "@objectiv/tracker-react";
 
 interface RefObject<T> {
   readonly current: T | null
@@ -42,22 +42,24 @@ function StarUsNotification(props, ref) {
   }
 
   return (
-    <TrackedOverlayContext 
-      Component='div' 
-      id='star-us-notification'
-      isVisible={starUsNotificationShown}
-      style={{opacity: 0}} 
-      onClick={closeNotification}
-      className={clsx(styles.starUsNotification, (starUsNotificationShown ? styles.starUsNotificationShow : null))}>
-      <div className={clsx(styles.starUsNotificationSticky)}>
-          <div className={clsx(styles.starUsNotificationStickyPointer)}>
-            <img src={useBaseUrl("img/icons/icon-caret-up.svg")} />
-          </div>
-          <div className={clsx(styles.starUsNotificationStickyContent)}>
-            <img src={useBaseUrl("img/icons/icon-emoticon-smiley-stars.svg")} /> Star us on Github!
-          </div>
-      </div>
-    </TrackedOverlayContext>
+    <PressableContextWrapper id={'star-us-notification'}>
+      <TrackedOverlayContext 
+        Component='div' 
+        id='star-us-notification-overlay'
+        isVisible={starUsNotificationShown}
+        style={{opacity: 0}} 
+        onClick={closeNotification}
+        className={clsx(styles.starUsNotification, (starUsNotificationShown ? styles.starUsNotificationShow : null))}>
+        <div className={clsx(styles.starUsNotificationSticky)}>
+            <div className={clsx(styles.starUsNotificationStickyPointer)}>
+              <img src={useBaseUrl("img/icons/icon-caret-up.svg")} />
+            </div>
+            <div className={clsx(styles.starUsNotificationStickyContent)}>
+              <img src={useBaseUrl("img/icons/icon-emoticon-smiley-stars.svg")} /> Star us on Github!
+            </div>
+        </div>
+      </TrackedOverlayContext>
+    </PressableContextWrapper>
   );
 }
 

--- a/src/components/star-us/index.tsx
+++ b/src/components/star-us/index.tsx
@@ -3,6 +3,7 @@ import clsx from "clsx";
 import styles from "./styles.module.css";
 import useBaseUrl from "@docusaurus/useBaseUrl";
 import { useScrollPosition } from '@docusaurus/theme-common';
+import { TrackedOverlayContext, useVisibilityTracker } from "@objectiv/tracker-react";
 
 interface RefObject<T> {
   readonly current: T | null
@@ -41,7 +42,10 @@ function StarUsNotification(props, ref) {
   }
 
   return (
-    <div 
+    <TrackedOverlayContext 
+      Component='div' 
+      id='star-us-notification'
+      isVisible={starUsNotificationShown}
       style={{opacity: 0}} 
       onClick={closeNotification}
       className={clsx(styles.starUsNotification, (starUsNotificationShown ? styles.starUsNotificationShow : null))}>
@@ -53,7 +57,7 @@ function StarUsNotification(props, ref) {
             <img src={useBaseUrl("img/icons/icon-emoticon-smiley-stars.svg")} /> Star us on Github!
           </div>
       </div>
-    </div>
+    </TrackedOverlayContext>
   );
 }
 

--- a/src/components/star-us/index.tsx
+++ b/src/components/star-us/index.tsx
@@ -3,7 +3,7 @@ import clsx from "clsx";
 import styles from "./styles.module.css";
 import useBaseUrl from "@docusaurus/useBaseUrl";
 import { useScrollPosition } from '@docusaurus/theme-common';
-import { PressableContextWrapper, TrackedOverlayContext, trackPressEvent } from "@objectiv/tracker-react";
+import { TrackedPressableContext, TrackedOverlayContext, trackPressEvent } from "@objectiv/tracker-react";
 
 interface RefObject<T> {
   readonly current: T | null
@@ -29,6 +29,8 @@ function StarUsNotification(props, ref) {
   useScrollPosition(
     ({scrollY}) => {
       if (!starUsNotificationClosed) {
+        console.log("scrollY:", scrollY);
+        console.log("starUsAnchorPosition:", starUsAnchorPosition);
         const scrollCheck = scrollY >= starUsAnchorPosition;
         setStarUsNotificationShown(scrollCheck);
       }
@@ -42,13 +44,15 @@ function StarUsNotification(props, ref) {
   }
 
   return (
-    <PressableContextWrapper id={'star-us-notification'}>
+    <TrackedPressableContext 
+      Component='div'  
+      id={'star-us-notification'}
+      onClick={closeNotification}>
       <TrackedOverlayContext 
         Component='div' 
         id='star-us-notification-overlay'
         isVisible={starUsNotificationShown}
         style={{opacity: 0}} 
-        onClick={closeNotification}
         className={clsx(styles.starUsNotification, (starUsNotificationShown ? styles.starUsNotificationShow : null))}>
         <div className={clsx(styles.starUsNotificationSticky)}>
             <div className={clsx(styles.starUsNotificationStickyPointer)}>
@@ -59,7 +63,7 @@ function StarUsNotification(props, ref) {
             </div>
         </div>
       </TrackedOverlayContext>
-    </PressableContextWrapper>
+    </TrackedPressableContext>
   );
 }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -15,6 +15,8 @@ import styles from './styles.module.css';
 export default function Home() {
   const context = useDocusaurusContext();
   const {tagline} = context.siteConfig;
+  
+  // reference for the 'star us' notification on top
   const starUsNotificationAnchorRef = useRef(null);
 
   return (
@@ -142,6 +144,8 @@ export default function Home() {
                   dataset. <br /> Share &amp; reuse any model and convert them to SQL with a single command." 
                 icon="icon-accelerate" />
 
+              <StarUsAnchor ref={starUsNotificationAnchorRef} />
+
               <div className={clsx(styles.modelingBeforeAfter)}>
                 <BeforeAfterImage 
                   id='modeling-workflow'
@@ -154,7 +158,6 @@ export default function Home() {
                   captionAfter='A typical modeling &amp; analysis workflow after using Objectiv' />
               </div>
 
-              <StarUsAnchor ref={starUsNotificationAnchorRef} />
 
               <div className={clsx(styles.modelingUSPs)}>
                 <div className={clsx(styles.valueRowLeft)}>


### PR DESCRIPTION
Updates metadata for the website to the latest title & description, and makes the 'star us' notification banner appear a little sooner.

Also adds some tracking improvements:
- [site] Track switching tabs between 'before' and 'after'.
- [site] Track 'star us' notification showing/hidden, and being closed via a click.
- [docs] Track breadcrumbs clicks.

Found a small error in the docs for `useVisibilityTracker`, updated it too.