### PR TITLE
Improve SEO for site & docs

### DIFF
--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -1,7 +1,8 @@
 ---
 sidebar_position: 1
 slug: /
-title: Introduction
+title: ""
+description: Objectiv is open-source infrastructure for product analytics. Collect rich, model-ready data and feed it straight into your data warehouse. Cut down delivery times of data projects with reusable &amp; prebuilt models.
 ---
 
 # 
@@ -11,22 +12,19 @@ import Mermaid from '@theme/Mermaid';
 
 ![Objectiv Logo](/img/logo-objectiv-large.svg "Objectiv Logo")
 
-## Welcome to the official Objectiv documentation
-Objectiv is a complete, self-hosted product analytics stack designed for
-data science without gruntwork.
+## Objectiv Documentation
+Objectiv is open-source infrastructure for product analytics. Highlights:
+
+* Collect [model-ready user behavior data](/tracking/core-concepts/overview.md) and feed it straight into 
+  your data warehouse.
+* Use [pandas-like operations](/modeling/intro.mdx) and [pre-built models](/modeling/models.mdx) that run on 
+  the full SQL dataset.
+* Instantly convert models to SQL to feed all data consumers from a single source of truth.
+
+Check out [objectiv.io](https://www.objectiv.io) to learn more.
 
 <img src={useBaseUrl('/img/objectiv-stack.svg')} alt="The Objectiv Stack"/>
 
-It includes everything you need to answer your product analytics questions with speed and precision.
-Straight from your notebook on the full, raw dataset. No cleaning, transformations or tracking plans required.
-
-### Highlights
-* Collect [model-ready data](/tracking/core-concepts/overview.md) that doesn't require cleaning and transformation
-* Ensure compatibility with many models by validating against an [open analytics taxonomy](/taxonomy/introduction.md)
-* Build reusable models with [Pandas-like modeling](/modeling/intro.mdx) that runs on the full dataset
-* Chain together custom & [pre-built models](/modeling/models.mdx) to answer in-depth questions quickly
-
-Check out [objectiv.io](https://www.objectiv.io) to learn more.
 
 ## Getting Started
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -13,9 +13,9 @@ const lightCodeTheme = require('prism-react-renderer/themes/github');
 const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 
 const config = {
-  title: "Objectiv - Open-source infrastructure for product analytics",
+  title: "Documentation",
   titleDelimiter: '|',
-  tagline: 'Collect rich, model-ready data and feed it straight into your data warehouse. Cut down delivery times of data projects with reusable & prebuilt models.', //meta description, and og:description
+  tagline: 'Objectiv is open-source infrastructure for product analytics. Collect rich, model-ready data and feed it straight into your data warehouse. Cut down delivery times of data projects with reusable &amp; prebuilt models.', //meta description, and og:description
   url: envConfig.websiteUrl,
   baseUrl: envConfig.baseUrl,
   favicon: 'img/favicon/favicon.ico',

--- a/docs/src/theme/Layout/index.tsx
+++ b/docs/src/theme/Layout/index.tsx
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import clsx from 'clsx';
+import ErrorBoundary from '@docusaurus/ErrorBoundary';
+import SkipToContent from '@theme/SkipToContent';
+import AnnouncementBar from '@theme/AnnouncementBar';
+import Navbar from '@theme/Navbar';
+import Footer from '@theme/Footer';
+import LayoutProviders from '@theme/LayoutProviders';
+import LayoutHead from '@theme/LayoutHead';
+import type {Props} from '@theme/Layout';
+import {ThemeClassNames, useKeyboardNavigation} from '@docusaurus/theme-common';
+import ErrorPageContent from '@theme/ErrorPageContent';
+import './styles.css';
+
+export default function Layout(props: Props): JSX.Element {
+  const {children, noFooter, wrapperClassName, pageClassName} = props;
+
+  useKeyboardNavigation();
+
+  return (
+    <LayoutProviders>
+      <LayoutHead {...props} />
+
+      <Navbar />
+
+      <main
+        className={clsx(
+          ThemeClassNames.wrapper.main,
+          wrapperClassName,
+          pageClassName,
+        )}>
+        <ErrorBoundary fallback={ErrorPageContent}>{children}</ErrorBoundary>
+      </main>
+
+      {!noFooter && <Footer />}
+    </LayoutProviders>
+  );
+}

--- a/docs/src/theme/Layout/styles.css
+++ b/docs/src/theme/Layout/styles.css
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+html,
+body {
+  height: 100%;
+}
+
+#__docusaurus {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.main-wrapper {
+  flex: 1 0 auto;
+}
+
+/* Docusaurus-specific utility classes */
+
+.docusaurus-mt-lg {
+  margin-top: 3rem;
+}

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -13,7 +13,7 @@ const slackJoinLink = '/join-slack';
 const config = {
   title: "Objectiv - Open-source infrastructure for product analytics",
   titleDelimiter: '|',
-  tagline: 'Collect rich, model-ready data and feed it straight into your data warehouse. Cut down delivery times of data projects with reusable & prebuilt models.', //meta description, and og:description
+  tagline: 'Collect rich, model-ready data and feed it straight into your data warehouse. Cut down delivery times of data projects with reusable &amp; prebuilt models.', //meta description, and og:description
   baseUrl: envConfig.baseUrl,
   url: envConfig.websiteUrl,
   favicon: 'img/favicon/favicon.ico',

--- a/src/components/star-us/index.tsx
+++ b/src/components/star-us/index.tsx
@@ -29,8 +29,6 @@ function StarUsNotification(props, ref) {
   useScrollPosition(
     ({scrollY}) => {
       if (!starUsNotificationClosed) {
-        console.log("scrollY:", scrollY);
-        console.log("starUsAnchorPosition:", starUsAnchorPosition);
         const scrollCheck = scrollY >= starUsAnchorPosition;
         setStarUsNotificationShown(scrollCheck);
       }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,7 +8,7 @@ import BeforeAfterImage from '../components/before-after-image';
 import VimeoPlayer from '../components/vimeo-player';
 import AnimatedGif from '../components/animated-gif';
 import StarUsNotification, { StarUsAnchor } from '../components/star-us';
-import { TrackedDiv } from "@objectiv/tracker-react";
+import { TrackedDiv, TrackedHeader } from "@objectiv/tracker-react";
 import { TrackedLink } from '../trackedComponents/TrackedLink';
 import styles from './styles.module.css';
 
@@ -20,403 +20,400 @@ export default function Home() {
   const starUsNotificationAnchorRef = useRef(null);
 
   return (
-    <div>
-      <Layout
-        title=''
-        description={tagline}>
+    <Layout
+      title=''
+      description={tagline}>
 
-        <StarUsNotification innerRef={starUsNotificationAnchorRef} />
-        
-        <TrackedDiv 
-          id={'hero'} 
-          className={clsx('hero hero--primary', styles.heroBanner)}>
-          <div className={clsx('container', styles.heroContainer)}>
-            <img
-              className={clsx(styles.heroImage)}
-              src={useBaseUrl("img/objectiv-rainbow-pipeline.svg")}
-              alt="Product Analytics Pipeline" />
-            <h1 className={clsx(styles.heroTitle)}>
-              Open-source infrastructure <br />
-              for product analytics
-            </h1>
-            <p className={clsx(styles.heroSubTitle)}>
+      <StarUsNotification innerRef={starUsNotificationAnchorRef} />
+      
+      <TrackedHeader 
+        id={'hero'} 
+        className={clsx('hero hero--primary', styles.heroBanner)}>
+        <div className={clsx('container', styles.heroContainer)}>
+          <img
+            className={clsx(styles.heroImage)}
+            src={useBaseUrl("img/objectiv-rainbow-pipeline.svg")}
+            alt="Product Analytics Pipeline" />
+          <h1 className={clsx(styles.heroTitle)}>
+            Open-source infrastructure <br />
+            for product analytics
+          </h1>
+          <h2 className={clsx(styles.heroSubTitle)}>
             Collect rich, model-ready data and feed it straight into your data warehouse. <br />
             Cut down delivery times of data projects with reusable &amp; prebuilt models.
-            </p>
-            <TrackedLink
-              to="https://github.com/objectiv/objectiv-analytics"
-              waitUntilTracked={true}
-              target="_self"
-              className={clsx("button", styles.ctaButton)}>
-              <span><img src={useBaseUrl("img/icons/icon-github-blue.svg")}  
-                alt={'Objectiv on GitHub'}/></span>
-              Star us on GitHub
-            </TrackedLink>
-          </div>
-        </TrackedDiv>
+          </h2>
+          <TrackedLink
+            to="https://github.com/objectiv/objectiv-analytics"
+            waitUntilTracked={true}
+            target="_self"
+            className={clsx("button", styles.ctaButton)}>
+            <span><img src={useBaseUrl("img/icons/icon-github-blue.svg")}  
+              alt={'Objectiv on GitHub'}/></span>
+            Star us on GitHub
+          </TrackedLink>
+        </div>
+      </TrackedHeader>
 
-        <main className={clsx(styles.bodyLarge)}>
+      <main className={clsx(styles.bodyLarge)}>
 
-          <div className={clsx(styles.pageSection, styles.pageSectionDarkGrey)}>
-            <TrackedDiv 
-              id={'capture-data'} 
-              className={clsx("container", styles.contentContainer, styles.stackCaptureData)}>
+        <div className={clsx(styles.pageSection, styles.pageSectionDarkGrey)}>
+          <TrackedDiv 
+            id={'capture-data'} 
+            className={clsx("container", styles.contentContainer, styles.stackCaptureData)}>
 
-              <IconHeader 
-                title="Capture user behavior in detail and feed it <br />straight into the heart of your 
-                  analytics stack" 
-                subTitle="Eliminate stack complexity with a tracker that feeds validated user behavior data 
-                  <br /> straight into your warehouse. No cleaning, transformations or tracking plans 
-                  required." 
-                icon="icon-diamond-yellow" />
+            <IconHeader 
+              title="Capture user behavior in detail and feed it <br />straight into the heart of your 
+                analytics stack" 
+              subTitle="Eliminate stack complexity with a tracker that feeds validated user behavior data 
+                <br /> straight into your warehouse. No cleaning, transformations or tracking plans 
+                required." 
+              icon="icon-diamond-yellow" />
 
-              <div className={clsx(styles.stackCaptureDataBeforeAfter)}>
-                <BeforeAfterImage 
-                  id='data-capture-workflow'
-                  beforeImageUrl='img/stack-capture-before.svg'
-                  afterImageUrl='img/stack-capture-after.svg'
-                  beforeImageMobileUrl='img/stack-capture-before-vertical.svg'
-                  afterImageMobileUrl='img/stack-capture-after-vertical.svg'
-                  captionBefore='A typical data collection workflow before using Objectiv'
-                  captionAfter='A typical data collection workflow after using Objectiv' />
+            <div className={clsx(styles.stackCaptureDataBeforeAfter)}>
+              <BeforeAfterImage 
+                id='data-capture-workflow'
+                beforeImageUrl='img/stack-capture-before.svg'
+                afterImageUrl='img/stack-capture-after.svg'
+                beforeImageMobileUrl='img/stack-capture-before-vertical.svg'
+                afterImageMobileUrl='img/stack-capture-after-vertical.svg'
+                captionBefore='A typical data collection workflow before using Objectiv'
+                captionAfter='A typical data collection workflow after using Objectiv' />
+            </div>
+
+            <div className={clsx(styles.valueRowRight)}>
+              <div>
+                <img
+                  src={useBaseUrl("img/solution-taxonomy-dark.svg")}
+                  alt="The open analytics taxonomy" />
+              </div>
+              <div>
+                <p>
+                  <strong>A taxonomy for model-ready data</strong> <br />
+                  Objectiv's tracker validates all incoming events against an&nbsp;
+                  <TrackedLink
+                    to={useBaseUrl("/docs/taxonomy/")}
+                    waitUntilTracked={true}
+                    target="_self">
+                    open analytics taxonomy
+                  </TrackedLink>. This ensures it is well-structured, clean and ready for modeling.
+                </p>
+                <p>It describes classes for common user interactions and their contexts. A tracking plan 
+                  is no longer needed as the requirements for effective analysis are carried by the 
+                  design of the taxonomy.</p>
+                <img
+                  src={useBaseUrl("img/value-squeaky-clean-model-ready-data.svg")}
+                  alt="The result: squeaky clean model-ready data" />                      
+              </div>
+            </div>
+
+            <div className={clsx(styles.valueRowLeft)}>
+              <div>
+                <p>
+                  <strong>Get the full context</strong><br />
+                  Objectiv's tracker captures the structure of your product's UI inside the dataset. 
+                  Events contain the exact location where they were triggered in a hierarchical stack of 
+                  locations.
+                </p>
+                <p>
+                  This not only makes events easily identifiable, it also enables data slicing on a very 
+                  granular level without doing a ton of manual mapping first.
+                </p>
+                <img
+                  src={useBaseUrl("img/value-fine-grained-slicing-control.svg")}
+                  alt="Fine-grained slicing control" />
+              </div>
+              <div>
+                <img
+                  src={useBaseUrl("img/value-better-data-event-dark.svg")}
+                  alt="Objectiv Event example" />
+              </div>  
+            </div>
+
+          </TrackedDiv>
+        </div>
+
+        <div className={clsx(styles.pageSection, styles.pageSectionLightGrey)}>
+          <TrackedDiv 
+              id={'modeling'} 
+              className={clsx("container", styles.contentContainer, styles.modeling)}>
+
+            <IconHeader 
+              title="Cut down delivery times of data projects <br /> with reusable &amp; pre-built models" 
+              subTitle="Take granular control over your data with pre-built models that run on the full 
+                dataset. <br /> Share &amp; reuse any model and convert them to SQL with a single command." 
+              icon="icon-accelerate" />
+
+            <StarUsAnchor ref={starUsNotificationAnchorRef} />
+
+            <div className={clsx(styles.modelingBeforeAfter)}>
+              <BeforeAfterImage 
+                id='modeling-workflow'
+                beforeImageUrl='img/modeling-before.svg'
+                afterImageUrl='img/modeling-after.svg'
+                beforeImageMobileUrl='img/modeling-before-vertical.svg'
+                afterImageMobileUrl='img/modeling-after-vertical.svg'
+                tabColorsInverted={true}
+                captionBefore='A typical modeling &amp; analysis workflow before using Objectiv'
+                captionAfter='A typical modeling &amp; analysis workflow after using Objectiv' />
+            </div>
+
+
+            <div className={clsx(styles.modelingUSPs)}>
+              <div className={clsx(styles.valueRowLeft)}>
+                <div>
+                  <p>
+                    <strong>Pandas-like modeling on the full SQL dataset</strong> <br />
+                    The Objectiv Bach modeling library combines the scalability of SQL with the agility of 
+                    Pandas.
+                  </p>
+                  <p>
+                    You can build models using dataframes and pandas-like operations and run them on the 
+                    full dataset as SQL. If you know Pandas, you'll feel right at home.
+                  </p>
+                </div>
+                <div>
+                  <img
+                    src={useBaseUrl("img/value-pandas-like-operations-on-full-dataset.svg")}
+                    alt="Pandas-like operations on the full dataset" />
+                </div>
+              </div>
+
+              <div className={clsx(styles.valueRowFull)}>
+                <AnimatedGif
+                  url={useBaseUrl("img/examples/example-call-models-in-model-hub.gif")}
+                  alt='Example animation of how to call models from the model hub' />
               </div>
 
               <div className={clsx(styles.valueRowRight)}>
                 <div>
                   <img
-                    src={useBaseUrl("img/solution-taxonomy-dark.svg")}
-                    alt="The open analytics taxonomy" />
+                    src={useBaseUrl("img/value-reusable-models.svg")}
+                    alt="Take pre-built models off the shelf" />
                 </div>
                 <div>
                   <p>
-                    <strong>A taxonomy for model-ready data</strong> <br />
-                    Objectiv's tracker validates all incoming events against an&nbsp;
-                    <TrackedLink
-                      to={useBaseUrl("/docs/taxonomy/")}
-                      waitUntilTracked={true}
-                      target="_self">
-                      open analytics taxonomy
-                    </TrackedLink>. This ensures it is well-structured, clean and ready for modeling.
+                    <strong>Take pre-built models off the shelf</strong> <br />
+                    Objectiv includes pre-built models for a wide range of product analytics use cases. You 
+                    can chain them together to answer common product analytics questions quickly.
                   </p>
-                  <p>It describes classes for common user interactions and their contexts. A tracking plan 
-                    is no longer needed as the requirements for effective analysis are carried by the 
-                    design of the taxonomy.</p>
-                  <img
-                    src={useBaseUrl("img/value-squeaky-clean-model-ready-data.svg")}
-                    alt="The result: squeaky clean model-ready data" />                      
+                  <p>You're free to customize them (or build your own) for specific in-depth analyses.</p>
                 </div>
               </div>
 
-              <div className={clsx(styles.valueRowLeft)}>
-                <div>
-                  <p>
-                    <strong>Get the full context</strong><br />
-                    Objectiv's tracker captures the structure of your product's UI inside the dataset. 
-                    Events contain the exact location where they were triggered in a hierarchical stack of 
-                    locations.
-                  </p>
-                  <p>
-                    This not only makes events easily identifiable, it also enables data slicing on a very 
-                    granular level without doing a ton of manual mapping first.
-                  </p>
-                  <img
-                    src={useBaseUrl("img/value-fine-grained-slicing-control.svg")}
-                    alt="Fine-grained slicing control" />
-                </div>
-                <div>
-                  <img
-                    src={useBaseUrl("img/value-better-data-event-dark.svg")}
-                    alt="Objectiv Event example" />
-                </div>  
-              </div>
-
-            </TrackedDiv>
-          </div>
-
-          <div className={clsx(styles.pageSection, styles.pageSectionLightGrey)}>
-            <TrackedDiv 
-                id={'modeling'} 
-                className={clsx("container", styles.contentContainer, styles.modeling)}>
-
-              <IconHeader 
-                title="Cut down delivery times of data projects <br /> with reusable &amp; pre-built models" 
-                subTitle="Take granular control over your data with pre-built models that run on the full 
-                  dataset. <br /> Share &amp; reuse any model and convert them to SQL with a single command." 
-                icon="icon-accelerate" />
-
-              <StarUsAnchor ref={starUsNotificationAnchorRef} />
-
-              <div className={clsx(styles.modelingBeforeAfter)}>
-                <BeforeAfterImage 
-                  id='modeling-workflow'
-                  beforeImageUrl='img/modeling-before.svg'
-                  afterImageUrl='img/modeling-after.svg'
-                  beforeImageMobileUrl='img/modeling-before-vertical.svg'
-                  afterImageMobileUrl='img/modeling-after-vertical.svg'
-                  tabColorsInverted={true}
-                  captionBefore='A typical modeling &amp; analysis workflow before using Objectiv'
-                  captionAfter='A typical modeling &amp; analysis workflow after using Objectiv' />
-              </div>
-
-
-              <div className={clsx(styles.modelingUSPs)}>
-                <div className={clsx(styles.valueRowLeft)}>
-                  <div>
-                    <p>
-                      <strong>Pandas-like modeling on the full SQL dataset</strong> <br />
-                      The Objectiv Bach modeling library combines the scalability of SQL with the agility of 
-                      Pandas.
-                    </p>
-                    <p>
-                      You can build models using dataframes and pandas-like operations and run them on the 
-                      full dataset as SQL. If you know Pandas, you'll feel right at home.
-                    </p>
-                  </div>
-                  <div>
-                    <img
-                      src={useBaseUrl("img/value-pandas-like-operations-on-full-dataset.svg")}
-                      alt="Pandas-like operations on the full dataset" />
-                  </div>
-                </div>
-
-                <div className={clsx(styles.valueRowFull)}>
-                  <AnimatedGif
-                    url={useBaseUrl("img/examples/example-call-models-in-model-hub.gif")}
-                    alt='Example animation of how to call models from the model hub' />
-                </div>
-
-                <div className={clsx(styles.valueRowRight)}>
-                  <div>
-                    <img
-                      src={useBaseUrl("img/value-reusable-models.svg")}
-                      alt="Take pre-built models off the shelf" />
-                  </div>
-                  <div>
-                    <p>
-                      <strong>Take pre-built models off the shelf</strong> <br />
-                      Objectiv includes pre-built models for a wide range of product analytics use cases. You 
-                      can chain them together to answer common product analytics questions quickly.
-                    </p>
-                    <p>You're free to customize them (or build your own) for specific in-depth analyses.</p>
-                  </div>
-                </div>
-
-                <div className={clsx(styles.bachIntroVideo)}>
-                  <img
-                    className={clsx(styles.objectivIn2Minutes)}
-                    src={useBaseUrl("img/bach-in-2-minutes.svg")}
-                    alt="Objectiv Bach for Data Scientists - 2 minutes" />
-                  <div className={clsx(styles.video)}>
-                    <VimeoPlayer id="2-minute-video" videoId="670857141" />
-                  </div>
-                </div>
-
-                <div className={clsx(styles.twoColumnItems)}>
-                  <div className={clsx(styles.twoColumnItem)}>
-                    <div className={clsx(styles.twoColumnIcon)}>
-                      <img
-                        src={useBaseUrl("img/icons/icon-recycling.svg")}
-                        alt="Reuse" />
-                    </div>
-                    <div>
-                      <strong>Reuse anyone's models</strong><br />
-                      High data consistency means models and datasets are intercompatible and can be shared 
-                      and reused.
-                    </div>
-                  </div>
-                  <div className={clsx(styles.twoColumnItem)}>
-                    <div className={clsx(styles.twoColumnIcon)}>
-                      <img
-                        src={useBaseUrl("img/icons/icon-pandas-compatible.svg")}
-                        alt="Pandas logo" />
-                    </div>
-                    <div>
-                      <strong>Pandas compatible</strong><br />
-                      Pandas compatibility enables you to tap into the rich ecosystem Pandas is well-known 
-                      for, including all ML libraries.
-                    </div>
-                  </div>
-                </div>
-                <div className={clsx(styles.twoColumnItems)}>
-                  <div className={clsx(styles.twoColumnItem)}>
-                    <div className={clsx(styles.twoColumnIcon)}>
-                      <img
-                        src={useBaseUrl("img/icons/icon-taxonomy-sitemap.svg")}
-                        alt="Bach" />
-                    </div>
-                    <div>
-                      <strong>Works with the open taxonomy</strong><br />
-                      Bach includes operations that are specifically designed to effectively work with 
-                      datasets that embrace the&nbsp;
-                      <TrackedLink
-                        to={useBaseUrl("/docs/taxonomy/", {absolute: true})}
-                        waitUntilTracked={true}
-                        target="_self">
-                        open analytics taxonomy
-                      </TrackedLink>.
-                    </div>
-                  </div>
-                  <div className={clsx(styles.twoColumnItem)}>
-                    <div className={clsx(styles.twoColumnIcon)}>
-                      <img
-                        src={useBaseUrl("img/icons/icon-brain.svg")}
-                        alt="Brain" />
-                    </div>
-                    <div>
-                      <strong>Optimized for machine learning</strong><br />
-                      A number of built-in optimizations for popular libraries, like scikit-learn, will 
-                      enable you to incorporate ML into your analyses faster.
-                    </div>
-                  </div>
-                </div> 
-              </div>
-
-            </TrackedDiv>
-          </div>
-
-          <div className={clsx(styles.pageSection)}>
-            <TrackedDiv 
-                id={'eliminate-complexity'} 
-                className={clsx("container", styles.contentContainer, styles.eliminateComplexity)}>
-              <IconHeader 
-                title="Make your notebook the headquarters <br /> of your analytics operations" 
-                subTitle="Run &amp; control your entire product analytics workflow from a notebook." 
-                icon="icon-jupyter-notebook-in-browser" />
-              <div className={clsx(styles.eliminateComplexityUSPs)}>
-                <div className={clsx(styles.valueRowLeft)}>
-                  <div>
-                    <p>
-                      <strong>Convert models to SQL with a single command</strong><br />
-                      On command, Objectiv converts your entire model to a production-ready SQL query, which 
-                      you can directly use to feed into your tools and products.
-                    </p>
-                    <p>
-                      Combine this with the fact that raw Objectiv data is model-ready straight from the 
-                      tracker, and you have a very efficient workflow that enables you to experiment freely 
-                      without the typical overhead.
-                    </p>
-                    <p>
-                      As a result, you can adapt to changing product questions much faster and keep all your 
-                      product analytics projects in one place.
-                    </p>
-                  </div>
-                  <div>
-                    <img
-                      src={useBaseUrl("img/value-notebook-as-headquarters.svg")}
-                      alt="The notebook as your headquarters" />
-                  </div>  
-                </div>
-                <div className={clsx(styles.valueRowFull)}>
-                  <AnimatedGif
-                    url={useBaseUrl("img/examples/example-output-to-metabase.gif")}
-                    alt='Example animation of output to Metabase' />
-                </div>
-                <div className={clsx(styles.combineExport)}>
-                  <img
-                    src={useBaseUrl("img/value-combine-export.svg")}
-                    className={clsx(styles.valueCombineExportHorizontal)}
-                    alt="Combine or export in several ways" />
-                  <img
-                    src={useBaseUrl("img/value-combine-export-vertical.svg")}
-                    className={clsx(styles.valueCombineExportVertical)}
-                    alt="Combine or export in several ways" />
-                  <p>To simplify sharing insights with other team members, Objectiv comes with <br />
-                  built-in integration for the open-source BI platform <strong>Metabase</strong>.</p>
+              <div className={clsx(styles.bachIntroVideo)}>
+                <img
+                  className={clsx(styles.objectivIn2Minutes)}
+                  src={useBaseUrl("img/bach-in-2-minutes.svg")}
+                  alt="Objectiv Bach for Data Scientists - 2 minutes" />
+                <div className={clsx(styles.video)}>
+                  <VimeoPlayer id="2-minute-video" videoId="670857141" />
                 </div>
               </div>
-
-            </TrackedDiv>
-          </div>
-
-          <div className={clsx(styles.pageSection, styles.pageSectionDarkGrey)}>
-            <TrackedDiv 
-              id={'the-stack-quickstart'} 
-              className={clsx("container", styles.contentContainer, styles.theProduct, styles.quickStart)}>
-
-              <IconHeader 
-                title="What's in the box?" 
-                subTitle="Objectiv is self-hosted. It includes what you need to answer common product 
-                analytics <br /> questions fast and accurately, while providing a solid foundation for 
-                advanced modeling." />
-
-              <img 
-                src={useBaseUrl("img/the-stack.svg")} 
-                className={clsx(styles.theStack)}
-                alt="The Objectiv stack" />
-              <img 
-                src={useBaseUrl("img/the-stack-horizontal-vertical.svg")} 
-                className={clsx(styles.theStackHorizontalVertical)}
-                alt="The Objectiv stack" />
-              <img 
-                src={useBaseUrl("img/the-stack-vertical.svg")} 
-                className={clsx(styles.theStackVertical)}
-                alt="The Objectiv stack" />
 
               <div className={clsx(styles.twoColumnItems)}>
                 <div className={clsx(styles.twoColumnItem)}>
                   <div className={clsx(styles.twoColumnIcon)}>
                     <img
-                      src={useBaseUrl("img/icons/icon-postgresql.png")}
-                      alt="PostgreSQL" />
+                      src={useBaseUrl("img/icons/icon-recycling.svg")}
+                      alt="Reuse" />
                   </div>
                   <div>
-                    <strong>PostgreSQL support</strong><br />
-                    Run it locally or in the cloud for reliable event handling.
+                    <strong>Reuse anyone's models</strong><br />
+                    High data consistency means models and datasets are intercompatible and can be shared 
+                    and reused.
                   </div>
                 </div>
                 <div className={clsx(styles.twoColumnItem)}>
                   <div className={clsx(styles.twoColumnIcon)}>
                     <img
-                      src={useBaseUrl("img/icons/icon-bigquery-snowplow.png")}
-                      alt="BigQuery through Snowplow" />
+                      src={useBaseUrl("img/icons/icon-pandas-compatible.svg")}
+                      alt="Pandas logo" />
                   </div>
                   <div>
-                    <strong>BigQuery support</strong><br />
-                    Plugs into your Snowplow backend for event handling at scale with BigQuery.<br />
-                    <img src={useBaseUrl("img/coming-soon.svg")} 
-                      className={clsx(styles.stackBQComingSoon)}
-                      alt="Coming soon" />
+                    <strong>Pandas compatible</strong><br />
+                    Pandas compatibility enables you to tap into the rich ecosystem Pandas is well-known 
+                    for, including all ML libraries.
                   </div>
                 </div>
               </div>
+              <div className={clsx(styles.twoColumnItems)}>
+                <div className={clsx(styles.twoColumnItem)}>
+                  <div className={clsx(styles.twoColumnIcon)}>
+                    <img
+                      src={useBaseUrl("img/icons/icon-taxonomy-sitemap.svg")}
+                      alt="Bach" />
+                  </div>
+                  <div>
+                    <strong>Works with the open taxonomy</strong><br />
+                    Bach includes operations that are specifically designed to effectively work with 
+                    datasets that embrace the&nbsp;
+                    <TrackedLink
+                      to={useBaseUrl("/docs/taxonomy/", {absolute: true})}
+                      waitUntilTracked={true}
+                      target="_self">
+                      open analytics taxonomy
+                    </TrackedLink>.
+                  </div>
+                </div>
+                <div className={clsx(styles.twoColumnItem)}>
+                  <div className={clsx(styles.twoColumnIcon)}>
+                    <img
+                      src={useBaseUrl("img/icons/icon-brain.svg")}
+                      alt="Brain" />
+                  </div>
+                  <div>
+                    <strong>Optimized for machine learning</strong><br />
+                    A number of built-in optimizations for popular libraries, like scikit-learn, will 
+                    enable you to incorporate ML into your analyses faster.
+                  </div>
+                </div>
+              </div> 
+            </div>
 
-              <h2>Try the Objectiv local demo</h2>
-              <p>Follow the Quickstart Guide to run a fully functional Objectiv setup locally.</p>
-              <TrackedLink
-                to={useBaseUrl("/docs/home/quickstart-guide/", {absolute: true})}
-                waitUntilTracked={true}
-                target="_self"
-                className={clsx("button", styles.ctaButton)}>
-                <span><img src={useBaseUrl("img/icons/icon-docs-blue.svg")}  
-                  alt={'Objectiv Quickstart Guide'}/></span>
-                Objectiv Quickstart Guide
-              </TrackedLink>
-              <img 
-                src={useBaseUrl("img/solution-takes-less-than-5-minutes-white.svg")} 
-                className={clsx(styles.takesLessThan5Minutes)}
-                alt="Takes less than 5 minutes" />
+          </TrackedDiv>
+        </div>
 
-            </TrackedDiv>
-          </div>
+        <div className={clsx(styles.pageSection)}>
+          <TrackedDiv 
+              id={'eliminate-complexity'} 
+              className={clsx("container", styles.contentContainer, styles.eliminateComplexity)}>
+            <IconHeader 
+              title="Make your notebook the headquarters <br /> of your analytics operations" 
+              subTitle="Run &amp; control your entire product analytics workflow from a notebook." 
+              icon="icon-jupyter-notebook-in-browser" />
+            <div className={clsx(styles.eliminateComplexityUSPs)}>
+              <div className={clsx(styles.valueRowLeft)}>
+                <div>
+                  <p>
+                    <strong>Convert models to SQL with a single command</strong><br />
+                    On command, Objectiv converts your entire model to a production-ready SQL query, which 
+                    you can directly use to feed into your tools and products.
+                  </p>
+                  <p>
+                    Combine this with the fact that raw Objectiv data is model-ready straight from the 
+                    tracker, and you have a very efficient workflow that enables you to experiment freely 
+                    without the typical overhead.
+                  </p>
+                  <p>
+                    As a result, you can adapt to changing product questions much faster and keep all your 
+                    product analytics projects in one place.
+                  </p>
+                </div>
+                <div>
+                  <img
+                    src={useBaseUrl("img/value-notebook-as-headquarters.svg")}
+                    alt="The notebook as your headquarters" />
+                </div>  
+              </div>
+              <div className={clsx(styles.valueRowFull)}>
+                <AnimatedGif
+                  url={useBaseUrl("img/examples/example-output-to-metabase.gif")}
+                  alt='Example animation of output to Metabase' />
+              </div>
+              <div className={clsx(styles.combineExport)}>
+                <img
+                  src={useBaseUrl("img/value-combine-export.svg")}
+                  className={clsx(styles.valueCombineExportHorizontal)}
+                  alt="Combine or export in several ways" />
+                <img
+                  src={useBaseUrl("img/value-combine-export-vertical.svg")}
+                  className={clsx(styles.valueCombineExportVertical)}
+                  alt="Combine or export in several ways" />
+                <p>To simplify sharing insights with other team members, Objectiv comes with <br />
+                built-in integration for the open-source BI platform <strong>Metabase</strong>.</p>
+              </div>
+            </div>
 
-          <footer className={clsx(styles.slackFooter)}>
-            <TrackedDiv id={'slack'} className={clsx("container", styles.contentContainer)}>
+          </TrackedDiv>
+        </div>
 
-              <h3>Objectiv is open-source and we're building it in public.</h3>
-              <p>Have opinions on where we should take this or want to stay in the loop?</p>
-              <TrackedLink
-                to="/join-slack"
-                className={clsx("button", styles.ctaButton)}>
-                <span><img src={useBaseUrl("img/icons/icon-slack.svg")}  alt={'Join us on Slack'}/></span>
-                Join us on Slack
-              </TrackedLink>
+        <div className={clsx(styles.pageSection, styles.pageSectionDarkGrey)}>
+          <TrackedDiv 
+            id={'the-stack-quickstart'} 
+            className={clsx("container", styles.contentContainer, styles.theProduct, styles.quickStart)}>
 
-            </TrackedDiv>
-          </footer>
+            <IconHeader 
+              title="What's in the box?" 
+              subTitle="Objectiv is self-hosted. It includes what you need to answer common product 
+              analytics <br /> questions fast and accurately, while providing a solid foundation for 
+              advanced modeling." />
 
-        </main>
-      </Layout>
+            <img 
+              src={useBaseUrl("img/the-stack.svg")} 
+              className={clsx(styles.theStack)}
+              alt="The Objectiv stack" />
+            <img 
+              src={useBaseUrl("img/the-stack-horizontal-vertical.svg")} 
+              className={clsx(styles.theStackHorizontalVertical)}
+              alt="The Objectiv stack" />
+            <img 
+              src={useBaseUrl("img/the-stack-vertical.svg")} 
+              className={clsx(styles.theStackVertical)}
+              alt="The Objectiv stack" />
 
-    </div>
+            <div className={clsx(styles.twoColumnItems)}>
+              <div className={clsx(styles.twoColumnItem)}>
+                <div className={clsx(styles.twoColumnIcon)}>
+                  <img
+                    src={useBaseUrl("img/icons/icon-postgresql.png")}
+                    alt="PostgreSQL" />
+                </div>
+                <div>
+                  <strong>PostgreSQL support</strong><br />
+                  Run it locally or in the cloud for reliable event handling.
+                </div>
+              </div>
+              <div className={clsx(styles.twoColumnItem)}>
+                <div className={clsx(styles.twoColumnIcon)}>
+                  <img
+                    src={useBaseUrl("img/icons/icon-bigquery-snowplow.png")}
+                    alt="BigQuery through Snowplow" />
+                </div>
+                <div>
+                  <strong>BigQuery support</strong><br />
+                  Plugs into your Snowplow backend for event handling at scale with BigQuery.<br />
+                  <img src={useBaseUrl("img/coming-soon.svg")} 
+                    className={clsx(styles.stackBQComingSoon)}
+                    alt="Coming soon" />
+                </div>
+              </div>
+            </div>
+
+            <h2>Try the Objectiv local demo</h2>
+            <p>Follow the Quickstart Guide to run a fully functional Objectiv setup locally.</p>
+            <TrackedLink
+              to={useBaseUrl("/docs/home/quickstart-guide/", {absolute: true})}
+              waitUntilTracked={true}
+              target="_self"
+              className={clsx("button", styles.ctaButton)}>
+              <span><img src={useBaseUrl("img/icons/icon-docs-blue.svg")}  
+                alt={'Objectiv Quickstart Guide'}/></span>
+              Objectiv Quickstart Guide
+            </TrackedLink>
+            <img 
+              src={useBaseUrl("img/solution-takes-less-than-5-minutes-white.svg")} 
+              className={clsx(styles.takesLessThan5Minutes)}
+              alt="Takes less than 5 minutes" />
+
+          </TrackedDiv>
+        </div>
+
+        <footer className={clsx(styles.slackFooter)}>
+          <TrackedDiv id={'slack'} className={clsx("container", styles.contentContainer)}>
+
+            <h3>Objectiv is open-source and we're building it in public.</h3>
+            <p>Have opinions on where we should take this or want to stay in the loop?</p>
+            <TrackedLink
+              to="/join-slack"
+              className={clsx("button", styles.ctaButton)}>
+              <span><img src={useBaseUrl("img/icons/icon-slack.svg")}  alt={'Join us on Slack'}/></span>
+              Join us on Slack
+            </TrackedLink>
+
+          </TrackedDiv>
+        </footer>
+
+      </main>
+    </Layout>
   );
 }

--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -205,6 +205,7 @@
 
 .heroSubTitle {
   font-size: 18px;
+  font-weight: normal;
   line-height: 150%;
   margin: 30px 0 35px 0;
   color: #333;

--- a/src/theme/Layout/index.tsx
+++ b/src/theme/Layout/index.tsx
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import clsx from 'clsx';
+import ErrorBoundary from '@docusaurus/ErrorBoundary';
+import SkipToContent from '@theme/SkipToContent';
+import AnnouncementBar from '@theme/AnnouncementBar';
+import Navbar from '@theme/Navbar';
+import Footer from '@theme/Footer';
+import LayoutProviders from '@theme/LayoutProviders';
+import LayoutHead from '@theme/LayoutHead';
+import type {Props} from '@theme/Layout';
+import {ThemeClassNames, useKeyboardNavigation} from '@docusaurus/theme-common';
+import ErrorPageContent from '@theme/ErrorPageContent';
+import './styles.css';
+
+export default function Layout(props: Props): JSX.Element {
+  const {children, noFooter, wrapperClassName, pageClassName} = props;
+
+  useKeyboardNavigation();
+
+  return (
+    <LayoutProviders>
+      <LayoutHead {...props} />
+
+      <Navbar />
+
+      <main
+        className={clsx(
+          ThemeClassNames.wrapper.main,
+          wrapperClassName,
+          pageClassName,
+        )}>
+        <ErrorBoundary fallback={ErrorPageContent}>{children}</ErrorBoundary>
+      </main>
+
+      {!noFooter && <Footer />}
+    </LayoutProviders>
+  );
+}

--- a/src/theme/Layout/styles.css
+++ b/src/theme/Layout/styles.css
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+html,
+body {
+  height: 100%;
+}
+
+#__docusaurus {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.main-wrapper {
+  flex: 1 0 auto;
+}
+
+/* Docusaurus-specific utility classes */
+
+.docusaurus-mt-lg {
+  margin-top: 3rem;
+}


### PR DESCRIPTION
Site:
- Fixed meta description tag; can't contain ampersands.
- Swizzled the Layout component to remove unnecessary elements, and change the main div to a <main> element.
- Changed the header to a `<header>` element instead of a `<div>`.
- Changed the subtitle to an `<h2>` element instead of a `<p>`.

Docs:
- Fixed meta description tag; can't contain ampersands.
- Swizzled the Layout component to remove unnecessary elements, and change the main div to a <main> element.
- Main docs page (the introduction) now has title 'Documentation", as it will be index under "Objectiv [...]" anyway, and a description that explains what Objectiv is, instead of "Objectiv documentation logo" as a title and the "Welcome ..." text as a description.
- Also reworked the content on the main docs page to be more inline with the latest repo README.