### PR TITLE
Adds three additional parameters to the marketing context

### DIFF
--- a/docs/docs/taxonomy/reference/global-contexts/MarketingContext.md
+++ b/docs/docs/taxonomy/reference/global-contexts/MarketingContext.md
@@ -26,7 +26,10 @@ import Mermaid from '@theme/Mermaid';
 | **medium**    | string      | Advertising or marketing medium: cpc, banner, email newsletter, etc.
 | **campaign**    | string      | Campaign name, slogan, promo code, etc.
 | **term**    | string      | _[optional]_ Search keywords. 
-| **content**    | string      | _[optional]_ To differentiate similar content, or links within the same ad. 
+| **content**    | string      | _[optional]_ To differentiate similar content, or links within the same ad.
+| **source_platform** | string | _[optional]_ Identifies the platform where the marketing activity was undertaken.
+| **creative_format** | string | _[optional]_ Identifies the creative used (e.g., skyscraper, banner, etc).
+| **marketing_tactic** | string | _[optional]_ Identifies the marketing tactic used (e.g., onboarding, retention, acquisition etc).
 
 :::info setting of the properties
 The backend will automatically set all the properties based on the UTM parameters in the PathContext.


### PR DESCRIPTION
This adds some new UTM parameters to the marketing context (added by Google in March 2022).

From this very small contribution I'm hoping to learn some new things about this interesting project.

1) How are these contexts versioned? (Is the plan to stick with schemaver or diverge?) and how does this behaviour work with trackers?
2) From a schema change how can we easily propagate the benefits of this downstream (trackers where required, as well as potentially data models)?