### PR TITLE
Add stars count to homepage

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -79,8 +79,10 @@ const config = {
   customFields: {
     trackerApplicationId: envConfig.trackerApplicationId,
     trackerEndPoint: envConfig.trackerEndPoint,
+    trackerConsoleEnabled: envConfig.trackerConsoleEnabled === 'true',
     slackJoinLink: slackJoinLink,
-    trackerConsoleEnabled: envConfig.trackerConsoleEnabled === 'true'
+    gitHubSecretKey: "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",
+    gitHubRepo: "objectiv-analytics"
   },
 
   themeConfig:

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -81,7 +81,6 @@ const config = {
     trackerEndPoint: envConfig.trackerEndPoint,
     trackerConsoleEnabled: envConfig.trackerConsoleEnabled === 'true',
     slackJoinLink: slackJoinLink,
-    gitHubSecretKey: "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",
     gitHubRepo: "objectiv-analytics"
   },
 

--- a/package.json
+++ b/package.json
@@ -20,12 +20,14 @@
     "@mdx-js/react": "^1.6.22",
     "@objectiv/tracker-react": "^0.0.16",
     "@u-wave/react-vimeo": "^0.9.5",
+    "axios": "^0.27.2",
     "clsx": "^1.1.1",
     "emailjs-com": "^3.2.0",
     "react": "^17.0.2",
     "react-avatar": "^3.10.0",
     "react-dom": "^17.0.2",
     "react-hook-form": "^7.17.4",
+    "react-query": "^3.38.1",
     "react-twitter-embed": "^4.0.4"
   },
   "resolutions": {

--- a/src/components/github-stargazers/http-common.tsx
+++ b/src/components/github-stargazers/http-common.tsx
@@ -1,0 +1,11 @@
+import axios from "axios";
+
+const endpoint = "https://api.github.com"
+
+export default axios.create({
+  baseURL: endpoint,
+  method: "GET",
+  headers: {
+    accept: "application/vnd.github.v3+json"
+  }
+});

--- a/src/components/github-stargazers/index.tsx
+++ b/src/components/github-stargazers/index.tsx
@@ -28,9 +28,8 @@ function Stargazers(cta) {
 
   const [getStargazersCount, setStargazersCount] = useState(null);
 
-  const formatResponse = (res) => {
-    return res.stargazers_count.toLocaleString()
-    // return JSON.stringify(res, null, 2);
+  const formatResponse = (result) => {
+    return result.data.stargazers_count.toLocaleString();
   };
 
   const trackFailureEvent = useFailureEventTracker({
@@ -65,7 +64,7 @@ function Stargazers(cta) {
   );
 
   useEffect(() => {
-    if (isLoadingStargazers) setStargazersCount("..");
+    if (isLoadingStargazers) setStargazersCount("...");
   }, [isLoadingStargazers]);
 
   // load on mount

--- a/src/components/github-stargazers/index.tsx
+++ b/src/components/github-stargazers/index.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import clsx from "clsx";
+import styles from "./styles.module.css";
+import axios from "axios";
+import { QueryClient, QueryClientProvider, useQuery } from 'react-query'
+import { TrackedLink } from '../../trackedComponents/TrackedLink';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+const queryClient = new QueryClient();
+
+function Stargazers(cta) {
+  const { siteConfig } = useDocusaurusContext();
+  const { organizationName } = siteConfig;
+  const { gitHubRepo, gitHubSecretKey } = siteConfig.customFields;
+  const endpoint = "https://api.github.com/graphql";
+  const STARCOUNT_QUERY = `
+  query ($organization: String!, $repo: String!)  {
+    repository(owner: $organization, name: $repo) {
+      stargazers {
+        totalCount
+      }
+    }
+  }`;
+
+  const { data, isLoading, error } = useQuery("stars", () => {
+    return axios({
+      url: endpoint,
+      method: "POST",
+      headers: {
+        Authorization: `bearer ${gitHubSecretKey}`,
+        "Content-Type": "application/json"
+      },
+      data: {
+        query: STARCOUNT_QUERY,
+        variables: {
+          "organization": organizationName,
+          "repo": gitHubRepo
+        } 
+      }
+    }).then(response => response.data.data);
+  });
+
+  if (isLoading) return (<div>...</div>);
+  if (error) {
+    console.error(error);
+    // @ts-ignore: error type is not defined
+    return (<pre>{error.message}</pre>);
+  }
+
+  const count = data.repository.stargazers.totalCount.toLocaleString();
+
+  return (
+    <div className={clsx(styles.starsButtonsContainer)}>
+      <TrackedLink
+        to="https://github.com/objectiv/objectiv-analytics"
+        waitUntilTracked={true}
+        target="_self"
+        className={clsx("button", styles.ctaButton)}>
+        <span><img src={useBaseUrl("img/icons/icon-github-blue.svg")}  
+          alt={'Objectiv on GitHub'}/></span>
+        {cta.cta}
+      </TrackedLink>
+      <TrackedLink
+        to="https://github.com/objectiv/objectiv-analytics"
+        waitUntilTracked={true}
+        target="_self"
+        className={clsx("button", styles.ctaButton, styles.starCount)}>
+        {count}
+      </TrackedLink>
+    </div>
+  );
+}
+
+export default function GitHubStargazers(cta='GitHub') {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <Stargazers {...cta} />
+    </QueryClientProvider>
+  )
+}

--- a/src/components/github-stargazers/styles.module.css
+++ b/src/components/github-stargazers/styles.module.css
@@ -1,0 +1,70 @@
+.ctaButton {
+  height: 48px;
+  line-height: 28px;
+  padding: 10px 25px 10px 20px;
+  background: #FAFAFA;
+  border: none;
+  border-radius: 4px;
+  box-shadow: 0 1px 2px rgba(51, 51, 51, 0.25);
+  font-family: Roboto, serif;
+  font-size: 18px;
+  font-weight: normal;
+  margin: 10px 0;
+  transition: 0.5s;
+  color: black;
+}
+
+.ctaButton:hover {
+  background: #F7FDFF;
+  box-shadow: 1px 2px 3px rgba(51, 51, 51, 0.25);
+  color: #000;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.ctaButton span:nth-child(1) { /* the icon */
+  margin: 0 16px 0 0;
+  float: left;
+}
+
+.starsButtonsContainer {
+  display: inline-block;
+}
+
+.starCount {
+  position: relative !important;
+  margin-left: 0 !important;
+  background-color: #333 !important;
+  color: #fff;
+}
+.starCount:hover {
+  color: #fff;
+  background-color: rgb(70, 70, 70) !important;
+}
+
+.starCount::before, .starCount::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 0;
+  height: 0;
+  border-color: transparent;
+  border-style: solid;
+  display: inline-block;
+}
+
+.starCount::before {
+  left: -6px;
+  margin-top: -6px;
+  border-width: 6px 6px 6px 0;
+  border-right-color: #333;
+}
+
+.starCount::after {
+  left: -7px;
+  margin-top: -7px;
+  border-width: 7px 7px 7px 0;
+  z-index: -1;
+  border-right-color: #d4d4d4;
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,6 +3,7 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import clsx from 'clsx';
 import React, { useRef } from 'react';
+import GitHubStargazers from '../components/github-stargazers';
 import IconHeader from '../components/icon-header';
 import BeforeAfterImage from '../components/before-after-image';
 import VimeoPlayer from '../components/vimeo-player';
@@ -43,15 +44,6 @@ export default function Home() {
           </h2>
           <div className={clsx(styles.heroCtaButtons)}>
             <TrackedLink
-              to="https://github.com/objectiv/objectiv-analytics"
-              waitUntilTracked={true}
-              target="_self"
-              className={clsx("button", styles.ctaButton)}>
-              <span><img src={useBaseUrl("img/icons/icon-github-blue.svg")}  
-                alt={'Objectiv on GitHub'}/></span>
-              Star us on GitHub
-            </TrackedLink>
-            <TrackedLink
               to={useBaseUrl("/docs/home/quickstart-guide/", {absolute: true})}
               waitUntilTracked={true}
               target="_self"
@@ -60,6 +52,7 @@ export default function Home() {
                 alt={'Objectiv Quickstart Guide'}/></span>
               Spin up the Demo
             </TrackedLink>
+            <GitHubStargazers cta='Star us on GitHub' />
           </div>
         </div>
       </TrackedHeader>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -91,8 +91,8 @@ export default function Home() {
                   alt="The open analytics taxonomy" />
               </div>
               <div>
+                <h3>A taxonomy to ensure quality &amp; consistency</h3>
                 <p>
-                  <h3>A taxonomy to ensure quality &amp; consistency</h3>
                   Objectiv's tracker validates all incoming events against an&nbsp;
                   <TrackedLink
                     to={useBaseUrl("/docs/taxonomy/", {absolute: true})} 
@@ -112,8 +112,8 @@ export default function Home() {
 
             <div className={clsx(styles.valueRowLeft)}>
               <div>
+                <h3>Get the full context</h3>
                 <p>
-                  <h3>Get the full context</h3>
                   Objectiv's tracker captures the structure of your product's UI inside the dataset. 
                   Events contain the exact location where they were triggered in a hierarchical stack of 
                   locations.
@@ -165,8 +165,8 @@ export default function Home() {
             <div className={clsx(styles.modelingUSPs)}>
               <div className={clsx(styles.valueRowLeft)}>
                 <div>
+                  <h3>Pandas-like modeling on the full SQL dataset</h3>
                   <p>
-                    <h3>Pandas-like modeling on the full SQL dataset</h3>
                     The Objectiv Bach modeling library combines the scalability of SQL with the agility of 
                     Pandas.
                   </p>
@@ -195,8 +195,8 @@ export default function Home() {
                     alt="Take pre-built models off the shelf" />
                 </div>
                 <div>
+                  <h3>Take pre-built models off the shelf</h3>
                   <p>
-                    <h3>Take pre-built models off the shelf</h3>
                     Objectiv&nbsp;
                     <TrackedLink
                       to={useBaseUrl("/docs/modeling/example_notebooks/", {absolute: true})}
@@ -294,8 +294,8 @@ export default function Home() {
             <div className={clsx(styles.eliminateComplexityUSPs)}>
               <div className={clsx(styles.valueRowLeft)}>
                 <div>
+                  <h3>Convert models to SQL with a single command</h3>
                   <p>
-                    <h3>Convert models to SQL with a single command</h3>
                     On command, Objectiv converts your entire model to a production-ready SQL query, which 
                     you can directly use to feed into your tools and products.
                   </p>

--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -121,7 +121,7 @@
   height: 48px;
   line-height: 28px;
   padding: 10px 20px;
-  background: #FFFFFF;
+  background: #FAFAFA;
   border: none;
   border-radius: 4px;
   box-shadow: 0 1px 2px rgba(51, 51, 51, 0.25);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1122,7 +1122,7 @@
     core-js-pure "^3.20.2"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.17.8", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.17.8", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4":
   version "7.17.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
   integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
@@ -2468,6 +2468,11 @@ async@^2.6.2, async@^3.2.3:
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.3.tgz#ac53dafd3f4720ee9e8a160628f18ea91df196c9"
   integrity sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
+
 at-least-node@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
@@ -2491,6 +2496,14 @@ axios@^0.25.0:
   integrity sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==
   dependencies:
     follow-redirects "^1.14.7"
+
+axios@^0.27.2:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
+  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+  dependencies:
+    follow-redirects "^1.14.9"
+    form-data "^4.0.0"
 
 babel-loader@^8.2.4:
   version "8.2.4"
@@ -2574,6 +2587,11 @@ batch@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
   integrity sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=
+
+big-integer@^1.6.16:
+  version "1.6.51"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
+  integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
 
 big.js@^5.2.2:
   version "5.2.2"
@@ -2663,6 +2681,20 @@ braces@^3.0.2, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+broadcast-channel@^3.4.1:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-3.7.0.tgz#2dfa5c7b4289547ac3f6705f9c00af8723889937"
+  integrity sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    detect-node "^2.1.0"
+    js-sha3 "0.8.0"
+    microseconds "0.2.0"
+    nano-time "1.0.0"
+    oblivious-set "1.0.0"
+    rimraf "3.0.2"
+    unload "2.2.0"
 
 browserslist@^4.0.0, browserslist@^4.14.5, browserslist@^4.16.6, browserslist@^4.17.5, browserslist@^4.18.1, browserslist@^4.20.2:
   version "4.20.2"
@@ -2957,6 +2989,13 @@ combine-promises@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/combine-promises/-/combine-promises-1.1.0.tgz#72db90743c0ca7aab7d0d8d2052fd7b0f674de71"
   integrity sha512-ZI9jvcLDxqwaXEixOhArm3r7ReIivsXkpbyEWyeOhzz1QS0iSgBPnWvEqvIQtYyamGCYA88gFhmUrs9hrrQ0pg==
+
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
 
 comma-separated-tokens@^1.0.0:
   version "1.0.8"
@@ -3387,6 +3426,11 @@ del@^6.0.0:
     rimraf "^3.0.2"
     slash "^3.0.0"
 
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
 depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
@@ -3404,7 +3448,7 @@ detab@2.0.4:
   dependencies:
     repeat-string "^1.5.4"
 
-detect-node@^2.0.4:
+detect-node@^2.0.4, detect-node@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
@@ -3953,6 +3997,11 @@ follow-redirects@^1.0.0, follow-redirects@^1.14.7:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
   integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
 
+follow-redirects@^1.14.9:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.0.tgz#06441868281c86d0dda4ad8bdaead2d02dca89d4"
+  integrity sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==
+
 fork-ts-checker-webpack-plugin@^6.5.0:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.5.1.tgz#fd689e2d9de6ac76abb620909eea56438cd0f232"
@@ -3971,6 +4020,15 @@ fork-ts-checker-webpack-plugin@^6.5.0:
     schema-utils "2.7.0"
     semver "^7.3.2"
     tapable "^1.0.0"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 formdata-polyfill@^4.0.10:
   version "4.0.10"
@@ -4822,6 +4880,11 @@ joi@^17.6.0:
     "@sideway/formula" "^3.0.0"
     "@sideway/pinpoint" "^2.0.0"
 
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -5109,6 +5172,14 @@ markdown-escapes@^1.0.0:
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
   integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
 
+match-sorter@^6.0.2:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.3.1.tgz#98cc37fda756093424ddf3cbc62bfe9c75b92bda"
+  integrity sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
+
 md5@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/md5/-/md5-2.3.0.tgz#c3da9a6aae3a30b46b7b0c349b87b110dc3bda4f"
@@ -5201,6 +5272,11 @@ micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
+microseconds@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
+  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
+
 mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":
   version "1.52.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
@@ -5218,7 +5294,7 @@ mime-types@2.1.18:
   dependencies:
     mime-db "~1.33.0"
 
-mime-types@^2.1.27, mime-types@^2.1.31, mime-types@~2.1.17, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.12, mime-types@^2.1.27, mime-types@^2.1.31, mime-types@~2.1.17, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -5313,6 +5389,13 @@ multicast-dns@^7.2.4:
   dependencies:
     dns-packet "^5.2.2"
     thunky "^1.0.2"
+
+nano-time@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
+  integrity sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=
+  dependencies:
+    big-integer "^1.6.16"
 
 nanoid@^3.3.1:
   version "3.3.2"
@@ -5431,6 +5514,11 @@ object.assign@^4.1.0:
     define-properties "^1.1.3"
     has-symbols "^1.0.1"
     object-keys "^1.1.1"
+
+oblivious-set@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/oblivious-set/-/oblivious-set-1.0.0.tgz#c8316f2c2fb6ff7b11b6158db3234c49f733c566"
+  integrity sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==
 
 obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
@@ -6260,6 +6348,15 @@ react-loadable-ssr-addon-v5-slorber@^1.0.1:
   dependencies:
     "@babel/runtime" "^7.10.3"
 
+react-query@^3.38.1:
+  version "3.38.1"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.38.1.tgz#4892304dae7eca7fa0ab5c8ae3e9748f0fca2df9"
+  integrity sha512-CM9hsz6oib17hsBguGaMJr+a0swMzou2gvNHHjAusnXvkfTx6CTzx0Iwuplox1jI2j3WiY91BGrcIN6bp1n1Iw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    broadcast-channel "^3.4.1"
+    match-sorter "^6.0.2"
+
 react-router-config@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/react-router-config/-/react-router-config-5.1.1.tgz#0f4263d1a80c6b2dc7b9c1902c9526478194a988"
@@ -6510,6 +6607,11 @@ remark-squeeze-paragraphs@4.0.0:
   dependencies:
     mdast-squeeze-paragraphs "^4.0.0"
 
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=
+
 renderkid@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/renderkid/-/renderkid-3.0.0.tgz#5fd823e4d6951d37358ecc9a58b1f06836b6268a"
@@ -6577,7 +6679,7 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rimraf@^3.0.2:
+rimraf@3.0.2, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -7377,6 +7479,14 @@ universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+
+unload@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
+  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    detect-node "^2.0.4"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Shows the repo's stars count on the homepage, using GitHub's REST API. Using unauthenticated requests, which should be fine, as the rate limit is 60 per hour per IP address (based on the user's IP). If rate limit is exceeded or any other error occurs, the count is not shown at all.

Also fixes an unrelated warning about `<h3>` tags used within `<p>` tags.