### PR TITLE
Modeling docs: update user-intent notebook link to open model hub

### DIFF
--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.agg.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.agg.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-agg
 slug: /modeling/bach/api-reference/DataFrame/agg/
 title: agg

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.aggregate.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.aggregate.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-aggregate
 slug: /modeling/bach/api-reference/DataFrame/aggregate/
 title: aggregate

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.all_series.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.all_series.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-all-series
 slug: /modeling/bach/api-reference/DataFrame/all_series/
 title: all_series

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.append.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.append.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-append
 slug: /modeling/bach/api-reference/DataFrame/append/
 title: append

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.astype.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.astype.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-astype
 slug: /modeling/bach/api-reference/DataFrame/astype/
 title: astype

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.bfill.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.bfill.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-bfill
 slug: /modeling/bach/api-reference/DataFrame/bfill/
 title: bfill

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.copy.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.copy.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-copy
 slug: /modeling/bach/api-reference/DataFrame/copy/
 title: copy

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.count.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.count.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-count
 slug: /modeling/bach/api-reference/DataFrame/count/
 title: count

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.create_variable.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.create_variable.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-create-variable
 slug: /modeling/bach/api-reference/DataFrame/create_variable/
 title: create_variable

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.cube.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.cube.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-cube
 slug: /modeling/bach/api-reference/DataFrame/cube/
 title: cube

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.data.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.data.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-data
 slug: /modeling/bach/api-reference/DataFrame/data/
 title: data

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.data_columns.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.data_columns.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-data-columns
 slug: /modeling/bach/api-reference/DataFrame/data_columns/
 title: data_columns

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.describe.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.describe.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-describe
 slug: /modeling/bach/api-reference/DataFrame/describe/
 title: describe

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.drop.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.drop.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-drop
 slug: /modeling/bach/api-reference/DataFrame/drop/
 title: drop

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.drop_duplicates.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.drop_duplicates.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-drop-duplicates
 slug: /modeling/bach/api-reference/DataFrame/drop_duplicates/
 title: drop_duplicates

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.dropna.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.dropna.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-dropna
 slug: /modeling/bach/api-reference/DataFrame/dropna/
 title: dropna

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.dtypes.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.dtypes.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-dtypes
 slug: /modeling/bach/api-reference/DataFrame/dtypes/
 title: dtypes

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.expanding.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.expanding.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-expanding
 slug: /modeling/bach/api-reference/DataFrame/expanding/
 title: expanding

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.ffill.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.ffill.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-ffill
 slug: /modeling/bach/api-reference/DataFrame/ffill/
 title: ffill

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.fillna.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.fillna.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-fillna
 slug: /modeling/bach/api-reference/DataFrame/fillna/
 title: fillna

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.from_model.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.from_model.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-from-model
 slug: /modeling/bach/api-reference/DataFrame/from_model/
 title: from_model

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.from_pandas.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.from_pandas.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-from-pandas
 slug: /modeling/bach/api-reference/DataFrame/from_pandas/
 title: from_pandas

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.from_table.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.from_table.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-from-table
 slug: /modeling/bach/api-reference/DataFrame/from_table/
 title: from_table

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.get_all_variable_usage.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.get_all_variable_usage.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-get-all-variable-usage
 slug: /modeling/bach/api-reference/DataFrame/get_all_variable_usage/
 title: get_all_variable_usage

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.get_dummies.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.get_dummies.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-get-dummies
 slug: /modeling/bach/api-reference/DataFrame/get_dummies/
 title: get_dummies

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.get_sample.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.get_sample.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-get-sample
 slug: /modeling/bach/api-reference/DataFrame/get_sample/
 title: get_sample

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.get_unsampled.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.get_unsampled.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-get-unsampled
 slug: /modeling/bach/api-reference/DataFrame/get_unsampled/
 title: get_unsampled

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.group_by.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.group_by.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-group-by
 slug: /modeling/bach/api-reference/DataFrame/group_by/
 title: group_by

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.groupby.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.groupby.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-groupby
 slug: /modeling/bach/api-reference/DataFrame/groupby/
 title: groupby

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.head.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.head.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-head
 slug: /modeling/bach/api-reference/DataFrame/head/
 title: head

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.index.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.index.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-index
 slug: /modeling/bach/api-reference/DataFrame/index/
 title: index

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.index_columns.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.index_columns.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-index-columns
 slug: /modeling/bach/api-reference/DataFrame/index_columns/
 title: index_columns

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.index_dtypes.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.index_dtypes.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-index-dtypes
 slug: /modeling/bach/api-reference/DataFrame/index_dtypes/
 title: index_dtypes

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.is_materialized.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.is_materialized.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-is-materialized
 slug: /modeling/bach/api-reference/DataFrame/is_materialized/
 title: is_materialized

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.loc.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.loc.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-loc
 slug: /modeling/bach/api-reference/DataFrame/loc/
 title: loc

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.materialize.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.materialize.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-materialize
 slug: /modeling/bach/api-reference/DataFrame/materialize/
 title: materialize

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.max.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.max.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-max
 slug: /modeling/bach/api-reference/DataFrame/max/
 title: max

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame
 slug: /modeling/bach/api-reference/DataFrame/DataFrame/
 title: DataFrame

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.mean.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.mean.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-mean
 slug: /modeling/bach/api-reference/DataFrame/mean/
 title: mean

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.median.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.median.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-median
 slug: /modeling/bach/api-reference/DataFrame/median/
 title: median

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.merge.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.merge.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-merge
 slug: /modeling/bach/api-reference/DataFrame/merge/
 title: merge

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.min.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.min.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-min
 slug: /modeling/bach/api-reference/DataFrame/min/
 title: min

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.minmax_scale.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.minmax_scale.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-minmax-scale
 slug: /modeling/bach/api-reference/DataFrame/minmax_scale/
 title: minmax_scale

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.mode.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.mode.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-mode
 slug: /modeling/bach/api-reference/DataFrame/mode/
 title: mode

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.nunique.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.nunique.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-nunique
 slug: /modeling/bach/api-reference/DataFrame/nunique/
 title: nunique

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.order_by.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.order_by.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-order-by
 slug: /modeling/bach/api-reference/DataFrame/order_by/
 title: order_by

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.plot.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.plot.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-plot
 slug: /modeling/bach/api-reference/DataFrame/plot/
 title: plot

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.quantile.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.quantile.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-quantile
 slug: /modeling/bach/api-reference/DataFrame/quantile/
 title: quantile

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.rename.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.rename.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-rename
 slug: /modeling/bach/api-reference/DataFrame/rename/
 title: rename

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.reset_index.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.reset_index.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-reset-index
 slug: /modeling/bach/api-reference/DataFrame/reset_index/
 title: reset_index

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.rolling.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.rolling.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-rolling
 slug: /modeling/bach/api-reference/DataFrame/rolling/
 title: rolling

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.rollup.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.rollup.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-rollup
 slug: /modeling/bach/api-reference/DataFrame/rollup/
 title: rollup

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.round.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.round.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-round
 slug: /modeling/bach/api-reference/DataFrame/round/
 title: round

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.savepoints.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.savepoints.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-savepoints
 slug: /modeling/bach/api-reference/DataFrame/savepoints/
 title: savepoints

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.scale.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.scale.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-scale
 slug: /modeling/bach/api-reference/DataFrame/scale/
 title: scale

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.sem.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.sem.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-sem
 slug: /modeling/bach/api-reference/DataFrame/sem/
 title: sem

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.set_index.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.set_index.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-set-index
 slug: /modeling/bach/api-reference/DataFrame/set_index/
 title: set_index

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.set_savepoint.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.set_savepoint.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-set-savepoint
 slug: /modeling/bach/api-reference/DataFrame/set_savepoint/
 title: set_savepoint

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.set_variable.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.set_variable.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-set-variable
 slug: /modeling/bach/api-reference/DataFrame/set_variable/
 title: set_variable

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.sort_index.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.sort_index.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-sort-index
 slug: /modeling/bach/api-reference/DataFrame/sort_index/
 title: sort_index

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.sort_values.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.sort_values.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-sort-values
 slug: /modeling/bach/api-reference/DataFrame/sort_values/
 title: sort_values

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.stack.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.stack.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-stack
 slug: /modeling/bach/api-reference/DataFrame/stack/
 title: stack

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.std.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.std.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-std
 slug: /modeling/bach/api-reference/DataFrame/std/
 title: std

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.std_pop.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.std_pop.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-std-pop
 slug: /modeling/bach/api-reference/DataFrame/std_pop/
 title: std_pop

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.sum.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.sum.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-sum
 slug: /modeling/bach/api-reference/DataFrame/sum/
 title: sum

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.to_numpy.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.to_numpy.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-to-numpy
 slug: /modeling/bach/api-reference/DataFrame/to_numpy/
 title: to_numpy

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.to_pandas.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.to_pandas.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-to-pandas
 slug: /modeling/bach/api-reference/DataFrame/to_pandas/
 title: to_pandas

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.unstack.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.unstack.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-unstack
 slug: /modeling/bach/api-reference/DataFrame/unstack/
 title: unstack

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.value_counts.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.value_counts.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-value-counts
 slug: /modeling/bach/api-reference/DataFrame/value_counts/
 title: value_counts

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.var.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.var.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-var
 slug: /modeling/bach/api-reference/DataFrame/var/
 title: var

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.variables.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.variables.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-variables
 slug: /modeling/bach/api-reference/DataFrame/variables/
 title: variables

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.view_sql.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.view_sql.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-view-sql
 slug: /modeling/bach/api-reference/DataFrame/view_sql/
 title: view_sql

--- a/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.window.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/bach.DataFrame.window.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-bach-data-frame-window
 slug: /modeling/bach/api-reference/DataFrame/window/
 title: window

--- a/docs/docs/modeling/bach/api-reference/DataFrame/index.mdx
+++ b/docs/docs/modeling/bach/api-reference/DataFrame/index.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-data-frame-index
 slug: /modeling/bach/api-reference/DataFrame/
 title: DataFrame

--- a/docs/docs/modeling/bach/api-reference/Series/AbstractDateTime/bach.SeriesAbstractDateTime.dt.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/AbstractDateTime/bach.SeriesAbstractDateTime.dt.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-abstract-date-time-bach-series-abstract-date-time-dt
 slug: /modeling/bach/api-reference/Series/AbstractDateTime/dt/
 title: dt

--- a/docs/docs/modeling/bach/api-reference/Series/AbstractDateTime/index.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/AbstractDateTime/index.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-abstract-date-time-index
 slug: /modeling/bach/api-reference/Series/AbstractDateTime/
 title: AbstractDateTime

--- a/docs/docs/modeling/bach/api-reference/Series/AbstractNumeric/bach.SeriesAbstractNumeric.cut.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/AbstractNumeric/bach.SeriesAbstractNumeric.cut.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-abstract-numeric-bach-series-abstract-numeric-cut
 slug: /modeling/bach/api-reference/Series/AbstractNumeric/cut/
 title: cut

--- a/docs/docs/modeling/bach/api-reference/Series/AbstractNumeric/bach.SeriesAbstractNumeric.mean.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/AbstractNumeric/bach.SeriesAbstractNumeric.mean.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-abstract-numeric-bach-series-abstract-numeric-mean
 slug: /modeling/bach/api-reference/Series/AbstractNumeric/mean/
 title: mean

--- a/docs/docs/modeling/bach/api-reference/Series/AbstractNumeric/bach.SeriesAbstractNumeric.minmax_scale.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/AbstractNumeric/bach.SeriesAbstractNumeric.minmax_scale.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-abstract-numeric-bach-series-abstract-numeric-minmax-scale
 slug: /modeling/bach/api-reference/Series/AbstractNumeric/minmax_scale/
 title: minmax_scale

--- a/docs/docs/modeling/bach/api-reference/Series/AbstractNumeric/bach.SeriesAbstractNumeric.qcut.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/AbstractNumeric/bach.SeriesAbstractNumeric.qcut.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-abstract-numeric-bach-series-abstract-numeric-qcut
 slug: /modeling/bach/api-reference/Series/AbstractNumeric/qcut/
 title: qcut

--- a/docs/docs/modeling/bach/api-reference/Series/AbstractNumeric/bach.SeriesAbstractNumeric.quantile.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/AbstractNumeric/bach.SeriesAbstractNumeric.quantile.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-abstract-numeric-bach-series-abstract-numeric-quantile
 slug: /modeling/bach/api-reference/Series/AbstractNumeric/quantile/
 title: quantile

--- a/docs/docs/modeling/bach/api-reference/Series/AbstractNumeric/bach.SeriesAbstractNumeric.round.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/AbstractNumeric/bach.SeriesAbstractNumeric.round.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-abstract-numeric-bach-series-abstract-numeric-round
 slug: /modeling/bach/api-reference/Series/AbstractNumeric/round/
 title: round

--- a/docs/docs/modeling/bach/api-reference/Series/AbstractNumeric/bach.SeriesAbstractNumeric.scale.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/AbstractNumeric/bach.SeriesAbstractNumeric.scale.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-abstract-numeric-bach-series-abstract-numeric-scale
 slug: /modeling/bach/api-reference/Series/AbstractNumeric/scale/
 title: scale

--- a/docs/docs/modeling/bach/api-reference/Series/AbstractNumeric/bach.SeriesAbstractNumeric.sem.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/AbstractNumeric/bach.SeriesAbstractNumeric.sem.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-abstract-numeric-bach-series-abstract-numeric-sem
 slug: /modeling/bach/api-reference/Series/AbstractNumeric/sem/
 title: sem

--- a/docs/docs/modeling/bach/api-reference/Series/AbstractNumeric/bach.SeriesAbstractNumeric.std.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/AbstractNumeric/bach.SeriesAbstractNumeric.std.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-abstract-numeric-bach-series-abstract-numeric-std
 slug: /modeling/bach/api-reference/Series/AbstractNumeric/std/
 title: std

--- a/docs/docs/modeling/bach/api-reference/Series/AbstractNumeric/bach.SeriesAbstractNumeric.sum.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/AbstractNumeric/bach.SeriesAbstractNumeric.sum.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-abstract-numeric-bach-series-abstract-numeric-sum
 slug: /modeling/bach/api-reference/Series/AbstractNumeric/sum/
 title: sum

--- a/docs/docs/modeling/bach/api-reference/Series/AbstractNumeric/bach.SeriesAbstractNumeric.var.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/AbstractNumeric/bach.SeriesAbstractNumeric.var.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-abstract-numeric-bach-series-abstract-numeric-var
 slug: /modeling/bach/api-reference/Series/AbstractNumeric/var/
 title: var

--- a/docs/docs/modeling/bach/api-reference/Series/AbstractNumeric/index.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/AbstractNumeric/index.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-abstract-numeric-index
 slug: /modeling/bach/api-reference/Series/AbstractNumeric/
 title: AbstractNumeric

--- a/docs/docs/modeling/bach/api-reference/Series/Boolean/bach.SeriesBoolean.max.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/Boolean/bach.SeriesBoolean.max.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-boolean-bach-series-boolean-max
 slug: /modeling/bach/api-reference/Series/Boolean/max/
 title: max

--- a/docs/docs/modeling/bach/api-reference/Series/Boolean/bach.SeriesBoolean.min.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/Boolean/bach.SeriesBoolean.min.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-boolean-bach-series-boolean-min
 slug: /modeling/bach/api-reference/Series/Boolean/min/
 title: min

--- a/docs/docs/modeling/bach/api-reference/Series/Boolean/index.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/Boolean/index.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-boolean-index
 slug: /modeling/bach/api-reference/Series/Boolean/
 title: Boolean

--- a/docs/docs/modeling/bach/api-reference/Series/Json/index.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/Json/index.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-json-index
 slug: /modeling/bach/api-reference/Series/Json/
 title: Json

--- a/docs/docs/modeling/bach/api-reference/Series/Jsonb/bach.SeriesJsonb.json.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/Jsonb/bach.SeriesJsonb.json.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-jsonb-bach-series-jsonb-json
 slug: /modeling/bach/api-reference/Series/Jsonb/json/
 title: json

--- a/docs/docs/modeling/bach/api-reference/Series/Jsonb/index.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/Jsonb/index.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-jsonb-index
 slug: /modeling/bach/api-reference/Series/Jsonb/
 title: Jsonb

--- a/docs/docs/modeling/bach/api-reference/Series/String/bach.SeriesString.get_dummies.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/String/bach.SeriesString.get_dummies.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-string-bach-series-string-get-dummies
 slug: /modeling/bach/api-reference/Series/String/get_dummies/
 title: get_dummies

--- a/docs/docs/modeling/bach/api-reference/Series/String/bach.SeriesString.str.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/String/bach.SeriesString.str.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-string-bach-series-string-str
 slug: /modeling/bach/api-reference/Series/String/str/
 title: str

--- a/docs/docs/modeling/bach/api-reference/Series/String/index.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/String/index.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-string-index
 slug: /modeling/bach/api-reference/Series/String/
 title: String

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.agg.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.agg.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-agg
 slug: /modeling/bach/api-reference/Series/agg/
 title: agg

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.aggregate.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.aggregate.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-aggregate
 slug: /modeling/bach/api-reference/Series/aggregate/
 title: aggregate

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.all_values.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.all_values.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-all-values
 slug: /modeling/bach/api-reference/Series/all_values/
 title: all_values

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.any_value.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.any_value.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-any-value
 slug: /modeling/bach/api-reference/Series/any_value/
 title: any_value

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.append.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.append.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-append
 slug: /modeling/bach/api-reference/Series/append/
 title: append

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.apply_func.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.apply_func.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-apply-func
 slug: /modeling/bach/api-reference/Series/apply_func/
 title: apply_func

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.array.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.array.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-array
 slug: /modeling/bach/api-reference/Series/array/
 title: array

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.astype.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.astype.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-astype
 slug: /modeling/bach/api-reference/Series/astype/
 title: astype

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.base_node.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.base_node.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-base-node
 slug: /modeling/bach/api-reference/Series/base_node/
 title: base_node

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.copy.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.copy.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-copy
 slug: /modeling/bach/api-reference/Series/copy/
 title: copy

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.count.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.count.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-count
 slug: /modeling/bach/api-reference/Series/count/
 title: count

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.describe.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.describe.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-describe
 slug: /modeling/bach/api-reference/Series/describe/
 title: describe

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.drop_duplicates.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.drop_duplicates.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-drop-duplicates
 slug: /modeling/bach/api-reference/Series/drop_duplicates/
 title: drop_duplicates

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.dropna.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.dropna.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-dropna
 slug: /modeling/bach/api-reference/Series/dropna/
 title: dropna

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.dtype.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.dtype.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-dtype
 slug: /modeling/bach/api-reference/Series/dtype/
 title: dtype

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.exists.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.exists.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-exists
 slug: /modeling/bach/api-reference/Series/exists/
 title: exists

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.fillna.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.fillna.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-fillna
 slug: /modeling/bach/api-reference/Series/fillna/
 title: fillna

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.from_value.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.from_value.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-from-value
 slug: /modeling/bach/api-reference/Series/from_value/
 title: from_value

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.get_db_dtype.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.get_db_dtype.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-get-db-dtype
 slug: /modeling/bach/api-reference/Series/get_db_dtype/
 title: get_db_dtype

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.group_by.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.group_by.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-group-by
 slug: /modeling/bach/api-reference/Series/group_by/
 title: group_by

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.head.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.head.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-head
 slug: /modeling/bach/api-reference/Series/head/
 title: head

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.index.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.index.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-index
 slug: /modeling/bach/api-reference/Series/index/
 title: index

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.index_sorting.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.index_sorting.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-index-sorting
 slug: /modeling/bach/api-reference/Series/index_sorting/
 title: index_sorting

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.isin.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.isin.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-isin
 slug: /modeling/bach/api-reference/Series/isin/
 title: isin

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.isnull.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.isnull.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-isnull
 slug: /modeling/bach/api-reference/Series/isnull/
 title: isnull

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.max.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.max.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-max
 slug: /modeling/bach/api-reference/Series/max/
 title: max

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series
 slug: /modeling/bach/api-reference/Series/Series/
 title: Series

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.median.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.median.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-median
 slug: /modeling/bach/api-reference/Series/median/
 title: median

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.min.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.min.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-min
 slug: /modeling/bach/api-reference/Series/min/
 title: min

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.mode.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.mode.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-mode
 slug: /modeling/bach/api-reference/Series/mode/
 title: mode

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.name.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.name.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-name
 slug: /modeling/bach/api-reference/Series/name/
 title: name

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.notnull.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.notnull.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-notnull
 slug: /modeling/bach/api-reference/Series/notnull/
 title: notnull

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.nunique.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.nunique.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-nunique
 slug: /modeling/bach/api-reference/Series/nunique/
 title: nunique

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.sort_index.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.sort_index.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-sort-index
 slug: /modeling/bach/api-reference/Series/sort_index/
 title: sort_index

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.sort_values.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.sort_values.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-sort-values
 slug: /modeling/bach/api-reference/Series/sort_values/
 title: sort_values

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.sorted_ascending.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.sorted_ascending.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-sorted-ascending
 slug: /modeling/bach/api-reference/Series/sorted_ascending/
 title: sorted_ascending

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.to_frame.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.to_frame.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-to-frame
 slug: /modeling/bach/api-reference/Series/to_frame/
 title: to_frame

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.to_numpy.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.to_numpy.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-to-numpy
 slug: /modeling/bach/api-reference/Series/to_numpy/
 title: to_numpy

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.to_pandas.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.to_pandas.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-to-pandas
 slug: /modeling/bach/api-reference/Series/to_pandas/
 title: to_pandas

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.unique.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.unique.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-unique
 slug: /modeling/bach/api-reference/Series/unique/
 title: unique

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.unstack.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.unstack.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-unstack
 slug: /modeling/bach/api-reference/Series/unstack/
 title: unstack

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.value.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.value.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-value
 slug: /modeling/bach/api-reference/Series/value/
 title: value

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.value_counts.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.value_counts.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-value-counts
 slug: /modeling/bach/api-reference/Series/value_counts/
 title: value_counts

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.view_sql.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.view_sql.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-view-sql
 slug: /modeling/bach/api-reference/Series/view_sql/
 title: view_sql

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.window_cume_dist.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.window_cume_dist.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-window-cume-dist
 slug: /modeling/bach/api-reference/Series/window_cume_dist/
 title: window_cume_dist

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.window_dense_rank.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.window_dense_rank.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-window-dense-rank
 slug: /modeling/bach/api-reference/Series/window_dense_rank/
 title: window_dense_rank

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.window_first_value.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.window_first_value.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-window-first-value
 slug: /modeling/bach/api-reference/Series/window_first_value/
 title: window_first_value

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.window_lag.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.window_lag.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-window-lag
 slug: /modeling/bach/api-reference/Series/window_lag/
 title: window_lag

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.window_last_value.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.window_last_value.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-window-last-value
 slug: /modeling/bach/api-reference/Series/window_last_value/
 title: window_last_value

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.window_lead.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.window_lead.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-window-lead
 slug: /modeling/bach/api-reference/Series/window_lead/
 title: window_lead

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.window_nth_value.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.window_nth_value.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-window-nth-value
 slug: /modeling/bach/api-reference/Series/window_nth_value/
 title: window_nth_value

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.window_ntile.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.window_ntile.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-window-ntile
 slug: /modeling/bach/api-reference/Series/window_ntile/
 title: window_ntile

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.window_percent_rank.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.window_percent_rank.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-window-percent-rank
 slug: /modeling/bach/api-reference/Series/window_percent_rank/
 title: window_percent_rank

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.window_rank.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.window_rank.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-window-rank
 slug: /modeling/bach/api-reference/Series/window_rank/
 title: window_rank

--- a/docs/docs/modeling/bach/api-reference/Series/bach.Series.window_row_number.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/bach.Series.window_row_number.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-bach-series-window-row-number
 slug: /modeling/bach/api-reference/Series/window_row_number/
 title: window_row_number

--- a/docs/docs/modeling/bach/api-reference/Series/index.mdx
+++ b/docs/docs/modeling/bach/api-reference/Series/index.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-series-index
 slug: /modeling/bach/api-reference/Series/
 title: Series

--- a/docs/docs/modeling/bach/api-reference/index.mdx
+++ b/docs/docs/modeling/bach/api-reference/index.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-api-reference-index
 sidebar_position: 5
 slug: /modeling/bach/api-reference/

--- a/docs/docs/modeling/bach/core-concepts.mdx
+++ b/docs/docs/modeling/bach/core-concepts.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-core-concepts
 sidebar_position: 3
 slug: /modeling/bach/core-concepts/

--- a/docs/docs/modeling/bach/examples.mdx
+++ b/docs/docs/modeling/bach/examples.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-examples
 sidebar_position: 4
 slug: /modeling/bach/examples/

--- a/docs/docs/modeling/bach/index.mdx
+++ b/docs/docs/modeling/bach/index.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-index
 sidebar_position: 3
 slug: /modeling/bach/

--- a/docs/docs/modeling/bach/what-is-bach.mdx
+++ b/docs/docs/modeling/bach/what-is-bach.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: bach-what-is-bach
 sidebar_position: 2
 slug: /modeling/bach/what-is-bach/

--- a/docs/docs/modeling/example-notebooks/feature-engineering.mdx
+++ b/docs/docs/modeling/example-notebooks/feature-engineering.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: example-notebooks-feature-engineering
 sidebar_position: 4
 slug: /modeling/example-notebooks/feature-engineering/

--- a/docs/docs/modeling/example-notebooks/index.mdx
+++ b/docs/docs/modeling/example-notebooks/index.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: example-notebooks-index
 sidebar_position: 4
 slug: /modeling/example-notebooks/

--- a/docs/docs/modeling/example-notebooks/machine-learning.mdx
+++ b/docs/docs/modeling/example-notebooks/machine-learning.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: example-notebooks-machine-learning
 sidebar_position: 1
 slug: /modeling/example-notebooks/machine-learning/

--- a/docs/docs/modeling/example-notebooks/modelhub-basics.mdx
+++ b/docs/docs/modeling/example-notebooks/modelhub-basics.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: example-notebooks-modelhub-basics
 sidebar_position: 5
 slug: /modeling/example-notebooks/modelhub-basics/

--- a/docs/docs/modeling/example-notebooks/open-taxonomy.mdx
+++ b/docs/docs/modeling/example-notebooks/open-taxonomy.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: example-notebooks-open-taxonomy
 sidebar_position: 6
 slug: /modeling/example-notebooks/open-taxonomy/

--- a/docs/docs/modeling/example-notebooks/product-analytics.mdx
+++ b/docs/docs/modeling/example-notebooks/product-analytics.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: example-notebooks-product-analytics
 sidebar_position: 2
 slug: /modeling/example-notebooks/product-analytics/

--- a/docs/docs/modeling/example-notebooks/user-intent.mdx
+++ b/docs/docs/modeling/example-notebooks/user-intent.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: example-notebooks-user-intent
 sidebar_position: 3
 slug: /modeling/example-notebooks/user-intent/
@@ -48,7 +47,7 @@ modelhub.aggregate.unique_users(df, groupby=['application', 'root_location']).he
 
 ## Exploring session duration
 
-The average `session_duration` model from the [open model hub](/docs/modeling/) is another good pointer to explore first for user intent.
+The average `session_duration` model from the [open model hub](/docs/modeling/open-model-hub/) is another good pointer to explore first for user intent.
 
 ```python
 modelhub.aggregate.session_duration(df, groupby=['application', 'root_location']).sort_index().head()

--- a/docs/docs/modeling/index.mdx
+++ b/docs/docs/modeling/index.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: index
 sidebar_position: 1
 slug: /modeling/

--- a/docs/docs/modeling/open-model-hub/api-reference/ModelHub/index.mdx
+++ b/docs/docs/modeling/open-model-hub/api-reference/ModelHub/index.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-api-reference-model-hub-index
 slug: /modeling/open-model-hub/api-reference/ModelHub/
 title: ModelHub

--- a/docs/docs/modeling/open-model-hub/api-reference/ModelHub/modelhub.ModelHub.add_conversion_event.mdx
+++ b/docs/docs/modeling/open-model-hub/api-reference/ModelHub/modelhub.ModelHub.add_conversion_event.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-api-reference-model-hub-modelhub-model-hub-add-conversion-event
 slug: /modeling/open-model-hub/api-reference/ModelHub/add_conversion_event/
 title: add_conversion_event

--- a/docs/docs/modeling/open-model-hub/api-reference/ModelHub/modelhub.ModelHub.agg.mdx
+++ b/docs/docs/modeling/open-model-hub/api-reference/ModelHub/modelhub.ModelHub.agg.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-api-reference-model-hub-modelhub-model-hub-agg
 slug: /modeling/open-model-hub/api-reference/ModelHub/agg/
 title: agg

--- a/docs/docs/modeling/open-model-hub/api-reference/ModelHub/modelhub.ModelHub.aggregate.mdx
+++ b/docs/docs/modeling/open-model-hub/api-reference/ModelHub/modelhub.ModelHub.aggregate.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-api-reference-model-hub-modelhub-model-hub-aggregate
 slug: /modeling/open-model-hub/api-reference/ModelHub/aggregate/
 title: aggregate

--- a/docs/docs/modeling/open-model-hub/api-reference/ModelHub/modelhub.ModelHub.conversion_events.mdx
+++ b/docs/docs/modeling/open-model-hub/api-reference/ModelHub/modelhub.ModelHub.conversion_events.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-api-reference-model-hub-modelhub-model-hub-conversion-events
 slug: /modeling/open-model-hub/api-reference/ModelHub/conversion_events/
 title: conversion_events

--- a/docs/docs/modeling/open-model-hub/api-reference/ModelHub/modelhub.ModelHub.get_objectiv_dataframe.mdx
+++ b/docs/docs/modeling/open-model-hub/api-reference/ModelHub/modelhub.ModelHub.get_objectiv_dataframe.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-api-reference-model-hub-modelhub-model-hub-get-objectiv-dataframe
 slug: /modeling/open-model-hub/api-reference/ModelHub/get_objectiv_dataframe/
 title: get_objectiv_dataframe

--- a/docs/docs/modeling/open-model-hub/api-reference/ModelHub/modelhub.ModelHub.map.mdx
+++ b/docs/docs/modeling/open-model-hub/api-reference/ModelHub/modelhub.ModelHub.map.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-api-reference-model-hub-modelhub-model-hub-map
 slug: /modeling/open-model-hub/api-reference/ModelHub/map/
 title: map

--- a/docs/docs/modeling/open-model-hub/api-reference/ModelHub/modelhub.ModelHub.mdx
+++ b/docs/docs/modeling/open-model-hub/api-reference/ModelHub/modelhub.ModelHub.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-api-reference-model-hub-modelhub-model-hub
 slug: /modeling/open-model-hub/api-reference/ModelHub/ModelHub/
 title: ModelHub

--- a/docs/docs/modeling/open-model-hub/api-reference/ModelHub/modelhub.ModelHub.time_agg.mdx
+++ b/docs/docs/modeling/open-model-hub/api-reference/ModelHub/modelhub.ModelHub.time_agg.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-api-reference-model-hub-modelhub-model-hub-time-agg
 slug: /modeling/open-model-hub/api-reference/ModelHub/time_agg/
 title: time_agg

--- a/docs/docs/modeling/open-model-hub/api-reference/ModelHub/modelhub.ModelHub.time_aggregation.mdx
+++ b/docs/docs/modeling/open-model-hub/api-reference/ModelHub/modelhub.ModelHub.time_aggregation.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-api-reference-model-hub-modelhub-model-hub-time-aggregation
 slug: /modeling/open-model-hub/api-reference/ModelHub/time_aggregation/
 title: time_aggregation

--- a/docs/docs/modeling/open-model-hub/api-reference/ModelHub/modelhub.ModelHub.to_metabase.mdx
+++ b/docs/docs/modeling/open-model-hub/api-reference/ModelHub/modelhub.ModelHub.to_metabase.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-api-reference-model-hub-modelhub-model-hub-to-metabase
 slug: /modeling/open-model-hub/api-reference/ModelHub/to_metabase/
 title: to_metabase

--- a/docs/docs/modeling/open-model-hub/api-reference/SeriesGlobalContexts/index.mdx
+++ b/docs/docs/modeling/open-model-hub/api-reference/SeriesGlobalContexts/index.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-api-reference-series-global-contexts-index
 slug: /modeling/open-model-hub/api-reference/SeriesGlobalContexts/
 title: SeriesGlobalContexts

--- a/docs/docs/modeling/open-model-hub/api-reference/SeriesGlobalContexts/modelhub.SeriesGlobalContexts.gc.mdx
+++ b/docs/docs/modeling/open-model-hub/api-reference/SeriesGlobalContexts/modelhub.SeriesGlobalContexts.gc.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-api-reference-series-global-contexts-modelhub-series-global-contexts-gc
 slug: /modeling/open-model-hub/api-reference/SeriesGlobalContexts/gc/
 title: gc

--- a/docs/docs/modeling/open-model-hub/api-reference/SeriesGlobalContexts/modelhub.SeriesGlobalContexts.global_contexts.mdx
+++ b/docs/docs/modeling/open-model-hub/api-reference/SeriesGlobalContexts/modelhub.SeriesGlobalContexts.global_contexts.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-api-reference-series-global-contexts-modelhub-series-global-contexts-global-contexts
 slug: /modeling/open-model-hub/api-reference/SeriesGlobalContexts/global_contexts/
 title: global_contexts

--- a/docs/docs/modeling/open-model-hub/api-reference/SeriesGlobalContexts/modelhub.SeriesGlobalContexts.mdx
+++ b/docs/docs/modeling/open-model-hub/api-reference/SeriesGlobalContexts/modelhub.SeriesGlobalContexts.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-api-reference-series-global-contexts-modelhub-series-global-contexts
 slug: /modeling/open-model-hub/api-reference/SeriesGlobalContexts/SeriesGlobalContexts/
 title: SeriesGlobalContexts

--- a/docs/docs/modeling/open-model-hub/api-reference/SeriesGlobalContexts/modelhub.SeriesGlobalContexts.obj.mdx
+++ b/docs/docs/modeling/open-model-hub/api-reference/SeriesGlobalContexts/modelhub.SeriesGlobalContexts.obj.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-api-reference-series-global-contexts-modelhub-series-global-contexts-obj
 slug: /modeling/open-model-hub/api-reference/SeriesGlobalContexts/obj/
 title: obj

--- a/docs/docs/modeling/open-model-hub/api-reference/SeriesGlobalContexts/modelhub.SeriesGlobalContexts.objectiv.mdx
+++ b/docs/docs/modeling/open-model-hub/api-reference/SeriesGlobalContexts/modelhub.SeriesGlobalContexts.objectiv.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-api-reference-series-global-contexts-modelhub-series-global-contexts-objectiv
 slug: /modeling/open-model-hub/api-reference/SeriesGlobalContexts/objectiv/
 title: objectiv

--- a/docs/docs/modeling/open-model-hub/api-reference/SeriesLocationStack/index.mdx
+++ b/docs/docs/modeling/open-model-hub/api-reference/SeriesLocationStack/index.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-api-reference-series-location-stack-index
 slug: /modeling/open-model-hub/api-reference/SeriesLocationStack/
 title: SeriesLocationStack

--- a/docs/docs/modeling/open-model-hub/api-reference/SeriesLocationStack/modelhub.SeriesLocationStack.location_stack.mdx
+++ b/docs/docs/modeling/open-model-hub/api-reference/SeriesLocationStack/modelhub.SeriesLocationStack.location_stack.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-api-reference-series-location-stack-modelhub-series-location-stack-location-stack
 slug: /modeling/open-model-hub/api-reference/SeriesLocationStack/location_stack/
 title: location_stack

--- a/docs/docs/modeling/open-model-hub/api-reference/SeriesLocationStack/modelhub.SeriesLocationStack.ls.mdx
+++ b/docs/docs/modeling/open-model-hub/api-reference/SeriesLocationStack/modelhub.SeriesLocationStack.ls.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-api-reference-series-location-stack-modelhub-series-location-stack-ls
 slug: /modeling/open-model-hub/api-reference/SeriesLocationStack/ls/
 title: ls

--- a/docs/docs/modeling/open-model-hub/api-reference/SeriesLocationStack/modelhub.SeriesLocationStack.mdx
+++ b/docs/docs/modeling/open-model-hub/api-reference/SeriesLocationStack/modelhub.SeriesLocationStack.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-api-reference-series-location-stack-modelhub-series-location-stack
 slug: /modeling/open-model-hub/api-reference/SeriesLocationStack/SeriesLocationStack/
 title: SeriesLocationStack

--- a/docs/docs/modeling/open-model-hub/api-reference/SeriesLocationStack/modelhub.SeriesLocationStack.obj.mdx
+++ b/docs/docs/modeling/open-model-hub/api-reference/SeriesLocationStack/modelhub.SeriesLocationStack.obj.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-api-reference-series-location-stack-modelhub-series-location-stack-obj
 slug: /modeling/open-model-hub/api-reference/SeriesLocationStack/obj/
 title: obj

--- a/docs/docs/modeling/open-model-hub/api-reference/SeriesLocationStack/modelhub.SeriesLocationStack.objectiv.mdx
+++ b/docs/docs/modeling/open-model-hub/api-reference/SeriesLocationStack/modelhub.SeriesLocationStack.objectiv.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-api-reference-series-location-stack-modelhub-series-location-stack-objectiv
 slug: /modeling/open-model-hub/api-reference/SeriesLocationStack/objectiv/
 title: objectiv

--- a/docs/docs/modeling/open-model-hub/api-reference/index.mdx
+++ b/docs/docs/modeling/open-model-hub/api-reference/index.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-api-reference-index
 sidebar_position: 3
 slug: /modeling/open-model-hub/api-reference/

--- a/docs/docs/modeling/open-model-hub/index.mdx
+++ b/docs/docs/modeling/open-model-hub/index.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-index
 sidebar_position: 2
 slug: /modeling/open-model-hub/

--- a/docs/docs/modeling/open-model-hub/models/Aggregate/index.mdx
+++ b/docs/docs/modeling/open-model-hub/models/Aggregate/index.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-models-aggregate-index
 slug: /modeling/open-model-hub/models/Aggregate/
 title: Aggregate

--- a/docs/docs/modeling/open-model-hub/models/Aggregate/modelhub.Aggregate.frequency.mdx
+++ b/docs/docs/modeling/open-model-hub/models/Aggregate/modelhub.Aggregate.frequency.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-models-aggregate-modelhub-aggregate-frequency
 slug: /modeling/open-model-hub/models/Aggregate/frequency/
 title: frequency

--- a/docs/docs/modeling/open-model-hub/models/Aggregate/modelhub.Aggregate.session_duration.mdx
+++ b/docs/docs/modeling/open-model-hub/models/Aggregate/modelhub.Aggregate.session_duration.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-models-aggregate-modelhub-aggregate-session-duration
 slug: /modeling/open-model-hub/models/Aggregate/session_duration/
 title: session_duration

--- a/docs/docs/modeling/open-model-hub/models/Aggregate/modelhub.Aggregate.unique_sessions.mdx
+++ b/docs/docs/modeling/open-model-hub/models/Aggregate/modelhub.Aggregate.unique_sessions.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-models-aggregate-modelhub-aggregate-unique-sessions
 slug: /modeling/open-model-hub/models/Aggregate/unique_sessions/
 title: unique_sessions

--- a/docs/docs/modeling/open-model-hub/models/Aggregate/modelhub.Aggregate.unique_users.mdx
+++ b/docs/docs/modeling/open-model-hub/models/Aggregate/modelhub.Aggregate.unique_users.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-models-aggregate-modelhub-aggregate-unique-users
 slug: /modeling/open-model-hub/models/Aggregate/unique_users/
 title: unique_users

--- a/docs/docs/modeling/open-model-hub/models/Map/index.mdx
+++ b/docs/docs/modeling/open-model-hub/models/Map/index.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-models-map-index
 slug: /modeling/open-model-hub/models/Map/
 title: Map

--- a/docs/docs/modeling/open-model-hub/models/Map/modelhub.Map.conversions_counter.mdx
+++ b/docs/docs/modeling/open-model-hub/models/Map/modelhub.Map.conversions_counter.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-models-map-modelhub-map-conversions-counter
 slug: /modeling/open-model-hub/models/Map/conversions_counter/
 title: conversions_counter

--- a/docs/docs/modeling/open-model-hub/models/Map/modelhub.Map.conversions_in_time.mdx
+++ b/docs/docs/modeling/open-model-hub/models/Map/modelhub.Map.conversions_in_time.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-models-map-modelhub-map-conversions-in-time
 slug: /modeling/open-model-hub/models/Map/conversions_in_time/
 title: conversions_in_time

--- a/docs/docs/modeling/open-model-hub/models/Map/modelhub.Map.is_conversion_event.mdx
+++ b/docs/docs/modeling/open-model-hub/models/Map/modelhub.Map.is_conversion_event.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-models-map-modelhub-map-is-conversion-event
 slug: /modeling/open-model-hub/models/Map/is_conversion_event/
 title: is_conversion_event

--- a/docs/docs/modeling/open-model-hub/models/Map/modelhub.Map.is_first_session.mdx
+++ b/docs/docs/modeling/open-model-hub/models/Map/modelhub.Map.is_first_session.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-models-map-modelhub-map-is-first-session
 slug: /modeling/open-model-hub/models/Map/is_first_session/
 title: is_first_session

--- a/docs/docs/modeling/open-model-hub/models/Map/modelhub.Map.is_new_user.mdx
+++ b/docs/docs/modeling/open-model-hub/models/Map/modelhub.Map.is_new_user.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-models-map-modelhub-map-is-new-user
 slug: /modeling/open-model-hub/models/Map/is_new_user/
 title: is_new_user

--- a/docs/docs/modeling/open-model-hub/models/Map/modelhub.Map.pre_conversion_hit_number.mdx
+++ b/docs/docs/modeling/open-model-hub/models/Map/modelhub.Map.pre_conversion_hit_number.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-models-map-modelhub-map-pre-conversion-hit-number
 slug: /modeling/open-model-hub/models/Map/pre_conversion_hit_number/
 title: pre_conversion_hit_number

--- a/docs/docs/modeling/open-model-hub/models/index.mdx
+++ b/docs/docs/modeling/open-model-hub/models/index.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-models-index
 sidebar_position: 2
 slug: /modeling/open-model-hub/models/

--- a/docs/docs/modeling/open-model-hub/version-check.mdx
+++ b/docs/docs/modeling/open-model-hub/version-check.mdx
@@ -1,5 +1,4 @@
 ---
-date: '2022-05-12T08:00:13.746Z'
 id: open-model-hub-version-check
 sidebar_position: 5
 slug: /modeling/open-model-hub/version-check/


### PR DESCRIPTION
Also removes the 'date' frontmatter, as it meant all MDX files were updated every time we ran the builder.