### PR TITLE
Move stars counters into button

### DIFF
--- a/src/components/github-stargazers/index.tsx
+++ b/src/components/github-stargazers/index.tsx
@@ -75,24 +75,22 @@ function Stargazers(cta) {
   return (
     <div className={clsx(styles.starsButtonsContainer)}>
       <TrackedLink
+        id={'star-us'}
         to="https://github.com/objectiv/objectiv-analytics"
         waitUntilTracked={true}
         target="_self"
-        className={clsx("button", styles.ctaButton)}>
-        <span><img src={useBaseUrl("img/icons/icon-github-blue.svg")}  
-          alt={'Objectiv on GitHub'}/></span>
-        {cta.cta}
+        className={clsx("button", styles.starsButton)}>
+          <div className={clsx(styles.starsButtonContent)}>
+            <span><img src={useBaseUrl("img/icons/icon-github-blue.svg")}  
+              alt={'Objectiv on GitHub'}/></span>
+            {cta.cta}
+          </div>
+          {getStargazersCount && (
+            <div className={clsx(styles.starCount)}>
+              {getStargazersCount}
+            </div>
+          )}
       </TrackedLink>
-      {getStargazersCount && (
-        <TrackedLink
-          to="https://github.com/objectiv/objectiv-analytics"
-          waitUntilTracked={true}
-          target="_self"
-          id={'starCount'}
-          className={clsx("button", styles.ctaButton, styles.starCount)}>
-            {getStargazersCount}
-        </TrackedLink>
-      )}
     </div>
   );
 }

--- a/src/components/github-stargazers/styles.module.css
+++ b/src/components/github-stargazers/styles.module.css
@@ -1,7 +1,11 @@
-.ctaButton {
+.starsButtonsContainer {
+  display: inline-block;
+}
+
+.starsButton {
   height: 48px;
   line-height: 28px;
-  padding: 10px 25px 10px 20px;
+  padding: 0;
   background: #FAFAFA;
   border: none;
   border-radius: 4px;
@@ -14,7 +18,7 @@
   color: black;
 }
 
-.ctaButton:hover {
+.starsButton:hover {
   background: #F7FDFF;
   box-shadow: 1px 2px 3px rgba(51, 51, 51, 0.25);
   color: #000;
@@ -22,49 +26,21 @@
   text-decoration: none;
 }
 
-.ctaButton span:nth-child(1) { /* the icon */
+.starsButtonContent {
+  display: inline-block;
+  padding: 10px 20px 10px 20px;
+}
+
+.starsButtonContent span:nth-child(1) { /* the icon */
   margin: 0 16px 0 0;
   float: left;
 }
 
-.starsButtonsContainer {
-  display: inline-block;
-}
-
 .starCount {
-  position: relative !important;
-  margin-left: 0 !important;
-  background-color: #333 !important;
-  color: #fff;
-}
-.starCount:hover {
-  color: #fff;
-  background-color: rgb(70, 70, 70) !important;
-}
-
-.starCount::before, .starCount::after {
-  content: "";
-  position: absolute;
-  top: 50%;
-  left: 0;
-  width: 0;
-  height: 0;
-  border-color: transparent;
-  border-style: solid;
   display: inline-block;
-}
-
-.starCount::before {
-  left: -6px;
-  margin-top: -6px;
-  border-width: 6px 6px 6px 0;
-  border-right-color: #333;
-}
-
-.starCount::after {
-  left: -7px;
-  margin-top: -7px;
-  border-width: 7px 7px 7px 0;
-  z-index: -1;
-  border-right-color: #d4d4d4;
+  padding: 10px 16px 10px 16px;
+  margin: 0 0 0 -6px;
+  background-color: #EEEEEE;
+  color: #333333;
+  font-weight: bold;
 }

--- a/src/components/github-stargazers/styles.module.css
+++ b/src/components/github-stargazers/styles.module.css
@@ -19,7 +19,6 @@
 }
 
 .starsButton:hover {
-  background: #F7FDFF;
   box-shadow: 1px 2px 3px rgba(51, 51, 51, 0.25);
   color: #000;
   cursor: pointer;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -199,7 +199,7 @@ export default function Home() {
                   <p>
                     Objectiv&nbsp;
                     <TrackedLink
-                      to={useBaseUrl("/docs/modeling/example-notebooks/", {absolute: true})}
+                      to={useBaseUrl("/docs/modeling/open-model-hub/", {absolute: true})}
                       waitUntilTracked={true}
                       target="_self">
                       includes pre-built models

--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -133,7 +133,6 @@
 }
 
 .ctaButton:hover {
-  background: #F7FDFF;
   box-shadow: 1px 2px 3px rgba(51, 51, 51, 0.25);
   color: #000;
   cursor: pointer;


### PR DESCRIPTION
Moves the stars counter into the button, instead of next to it. Now looks like this:

![image](https://user-images.githubusercontent.com/920184/168304094-332e6660-179d-439b-965e-ef68a52f011e.png)
