### PR TITLE
Add GZIP compression

### DIFF
--- a/.htaccess-production
+++ b/.htaccess-production
@@ -1,3 +1,47 @@
+<IfModule mod_deflate.c>
+  # force deflate for mangled headers
+  # developer.yahoo.com/blogs/ydn/posts/2010/12/pushing-beyond-gzipping/
+  <IfModule mod_setenvif.c>
+    <IfModule mod_headers.c>
+      SetEnvIfNoCase ^(Accept-EncodXng|X-cept-Encoding|X{15}|~{15}|-{15})$ ^((gzip|deflate)\s*,?\s*)+|[X~-]{4,13}$ HAVE_Accept-Encoding
+      RequestHeader append Accept-Encoding "gzip,deflate" env=HAVE_Accept-Encoding
+    </IfModule>
+  </IfModule>
+
+  # HTML, TXT, CSS, JavaScript, JSON, XML, HTC:
+  <IfModule filter_module>
+    FilterDeclare   COMPRESS
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'text/html'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'text/css'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'text/plain'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'text/xml'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'text/x-component'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'application/javascript'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'application/json'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'application/xml'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'application/xhtml+xml'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'application/rss+xml'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'application/atom+xml'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'application/vnd.ms-fontobject'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'image/svg+xml'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'application/x-font-ttf'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'font/opentype'"
+    FilterChain     COMPRESS
+    FilterProtocol  COMPRESS  DEFLATE change=yes;byteranges=no
+  </IfModule>
+
+  <IfModule !mod_filter.c>
+    # Legacy versions of Apache
+    AddOutputFilterByType DEFLATE text/html text/plain text/css application/json
+    AddOutputFilterByType DEFLATE application/javascript
+    AddOutputFilterByType DEFLATE text/xml application/xml text/x-component
+    AddOutputFilterByType DEFLATE application/xhtml+xml application/rss+xml
+    AddOutputFilterByType DEFLATE application/atom+xml
+    AddOutputFilterByType DEFLATE image/svg+xml application/vnd.ms-fontobject
+    AddOutputFilterByType DEFLATE application/x-font-ttf font/opentype
+  </IfModule>
+</IfModule>
+
 # redirect to https
 RewriteEngine On
 RewriteCond %{HTTP_HOST} ^objectiv.io [NC]

--- a/.htaccess-production
+++ b/.htaccess-production
@@ -1,3 +1,4 @@
+# GZIP compression on TransIP: https://www.transip.nl/knowledgebase/artikel/366-gzip-gebruiken-in-wordpress/
 <IfModule mod_deflate.c>
   # force deflate for mangled headers
   # developer.yahoo.com/blogs/ydn/posts/2010/12/pushing-beyond-gzipping/

--- a/.htaccess-staging
+++ b/.htaccess-staging
@@ -1,3 +1,4 @@
+# GZIP compression on TransIP: https://www.transip.nl/knowledgebase/artikel/366-gzip-gebruiken-in-wordpress/
 <IfModule mod_deflate.c>
   # force deflate for mangled headers
   # developer.yahoo.com/blogs/ydn/posts/2010/12/pushing-beyond-gzipping/

--- a/.htaccess-staging
+++ b/.htaccess-staging
@@ -1,3 +1,48 @@
+<IfModule mod_deflate.c>
+  # force deflate for mangled headers
+  # developer.yahoo.com/blogs/ydn/posts/2010/12/pushing-beyond-gzipping/
+  <IfModule mod_setenvif.c>
+    <IfModule mod_headers.c>
+      SetEnvIfNoCase ^(Accept-EncodXng|X-cept-Encoding|X{15}|~{15}|-{15})$ ^((gzip|deflate)\s*,?\s*)+|[X~-]{4,13}$ HAVE_Accept-Encoding
+      RequestHeader append Accept-Encoding "gzip,deflate" env=HAVE_Accept-Encoding
+    </IfModule>
+  </IfModule>
+
+  # HTML, TXT, CSS, JavaScript, JSON, XML, HTC:
+  <IfModule filter_module>
+    FilterDeclare   COMPRESS
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'text/html'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'text/css'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'text/plain'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'text/xml'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'text/x-component'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'application/javascript'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'application/json'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'application/xml'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'application/xhtml+xml'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'application/rss+xml'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'application/atom+xml'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'application/vnd.ms-fontobject'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'image/svg+xml'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'application/x-font-ttf'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'font/opentype'"
+    FilterChain     COMPRESS
+    FilterProtocol  COMPRESS  DEFLATE change=yes;byteranges=no
+  </IfModule>
+
+  <IfModule !mod_filter.c>
+    # Legacy versions of Apache
+    AddOutputFilterByType DEFLATE text/html text/plain text/css application/json
+    AddOutputFilterByType DEFLATE application/javascript
+    AddOutputFilterByType DEFLATE text/xml application/xml text/x-component
+    AddOutputFilterByType DEFLATE application/xhtml+xml application/rss+xml
+    AddOutputFilterByType DEFLATE application/atom+xml
+    AddOutputFilterByType DEFLATE image/svg+xml application/vnd.ms-fontobject
+    AddOutputFilterByType DEFLATE application/x-font-ttf font/opentype
+  </IfModule>
+</IfModule>
+
+
 # redirect to https
 RewriteEngine On
 RewriteCond %{HTTP_HOST} ^staging.objectiv.io [NC]

--- a/.htaccess-testing
+++ b/.htaccess-testing
@@ -1,3 +1,4 @@
+# GZIP compression on TransIP: https://www.transip.nl/knowledgebase/artikel/366-gzip-gebruiken-in-wordpress/
 <IfModule mod_deflate.c>
   # force deflate for mangled headers
   # developer.yahoo.com/blogs/ydn/posts/2010/12/pushing-beyond-gzipping/

--- a/.htaccess-testing
+++ b/.htaccess-testing
@@ -1,3 +1,47 @@
+<IfModule mod_deflate.c>
+  # force deflate for mangled headers
+  # developer.yahoo.com/blogs/ydn/posts/2010/12/pushing-beyond-gzipping/
+  <IfModule mod_setenvif.c>
+    <IfModule mod_headers.c>
+      SetEnvIfNoCase ^(Accept-EncodXng|X-cept-Encoding|X{15}|~{15}|-{15})$ ^((gzip|deflate)\s*,?\s*)+|[X~-]{4,13}$ HAVE_Accept-Encoding
+      RequestHeader append Accept-Encoding "gzip,deflate" env=HAVE_Accept-Encoding
+    </IfModule>
+  </IfModule>
+
+  # HTML, TXT, CSS, JavaScript, JSON, XML, HTC:
+  <IfModule filter_module>
+    FilterDeclare   COMPRESS
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'text/html'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'text/css'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'text/plain'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'text/xml'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'text/x-component'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'application/javascript'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'application/json'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'application/xml'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'application/xhtml+xml'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'application/rss+xml'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'application/atom+xml'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'application/vnd.ms-fontobject'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'image/svg+xml'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'application/x-font-ttf'"
+FilterProvider COMPRESS DEFLATE "%{CONTENT_TYPE} = 'font/opentype'"
+    FilterChain     COMPRESS
+    FilterProtocol  COMPRESS  DEFLATE change=yes;byteranges=no
+  </IfModule>
+
+  <IfModule !mod_filter.c>
+    # Legacy versions of Apache
+    AddOutputFilterByType DEFLATE text/html text/plain text/css application/json
+    AddOutputFilterByType DEFLATE application/javascript
+    AddOutputFilterByType DEFLATE text/xml application/xml text/x-component
+    AddOutputFilterByType DEFLATE application/xhtml+xml application/rss+xml
+    AddOutputFilterByType DEFLATE application/atom+xml
+    AddOutputFilterByType DEFLATE image/svg+xml application/vnd.ms-fontobject
+    AddOutputFilterByType DEFLATE application/x-font-ttf font/opentype
+  </IfModule>
+</IfModule>
+
 # redirect to https
 RewriteEngine On
 RewriteCond %{HTTP_HOST} ^testing.objectiv.io [NC]


### PR DESCRIPTION
Enables GZIP compression for the site + docs. 

Tested on testing environment and is returning gzip encoding:
![gzip](https://user-images.githubusercontent.com/920184/168568477-f54a4b48-9d0f-4c7f-b3be-2dead42acb51.png)
t