### PR TITLE
Taxonomy core concepts page redirect to root

### DIFF
--- a/.htaccess-production
+++ b/.htaccess-production
@@ -154,6 +154,10 @@ RewriteRule ^.*?$ /docs/modeling/example-notebooks/product-analytics [L,R=301]
 RewriteCond %{REQUEST_URI} ^/(docs/modeling/user_intent)(\/?)$
 RewriteRule ^.*?$ /docs/modeling/example-notebooks/user-intent [L,R=301]
 
+# redirect old Taxonomy docs URLs
+# /docs/taxonomy/core_concepts -> /docs/taxonomy/
+RewriteCond %{REQUEST_URI} ^/(docs/taxonomy/core-concepts)(\/?)$
+RewriteRule ^.*?$ /docs/taxonomy/ [L,R=301]
 
 # set hsts header, to prevent client from returning to http
 Header set Strict-Transport-Security "max-age=31536000" env=HTTPS

--- a/.htaccess-staging
+++ b/.htaccess-staging
@@ -155,6 +155,10 @@ RewriteRule ^.*?$ /docs/modeling/example-notebooks/product-analytics [L,R=301]
 RewriteCond %{REQUEST_URI} ^/(docs/modeling/user_intent)(\/?)$
 RewriteRule ^.*?$ /docs/modeling/example-notebooks/user-intent [L,R=301]
 
+# redirect old Taxonomy docs URLs
+# /docs/taxonomy/core_concepts -> /docs/taxonomy/
+RewriteCond %{REQUEST_URI} ^/(docs/taxonomy/core-concepts)(\/?)$
+RewriteRule ^.*?$ /docs/taxonomy/ [L,R=301]
 
 # set hsts header, to prevent client from returning to http
 Header set Strict-Transport-Security "max-age=31536000" env=HTTPS

--- a/.htaccess-testing
+++ b/.htaccess-testing
@@ -154,6 +154,10 @@ RewriteRule ^.*?$ /docs/modeling/example-notebooks/product-analytics [L,R=301]
 RewriteCond %{REQUEST_URI} ^/(docs/modeling/user_intent)(\/?)$
 RewriteRule ^.*?$ /docs/modeling/example-notebooks/user-intent [L,R=301]
 
+# redirect old Taxonomy docs URLs
+# /docs/taxonomy/core_concepts -> /docs/taxonomy/
+RewriteCond %{REQUEST_URI} ^/(docs/taxonomy/core-concepts)(\/?)$
+RewriteRule ^.*?$ /docs/taxonomy/ [L,R=301]
 
 # set hsts header, to prevent client from returning to http
 Header set Strict-Transport-Security "max-age=31536000" env=HTTPS


### PR DESCRIPTION
Redirect the removed taxonomy 'core concepts' page (`docs/taxonomy/core-concepts`) to the root of the taxonomy docs (`docs/taxonomy/`).