### PR TITLE
Fix tracking warning on empty `PaginatorNavLink` title

### DIFF
--- a/docs/src/theme/PaginatorNavLink/index.tsx
+++ b/docs/src/theme/PaginatorNavLink/index.tsx
@@ -20,7 +20,7 @@ export default function PaginatorNavLink(props: Props): JSX.Element {
       className="pagination-nav__link" 
       to={permalink}
       // OBJECTIV
-      {...tagLink({ id: title as string, href: permalink })}
+      {...tagLink({ id: (title as string != "" ? title as string : "[no title]"), href: permalink })}
       // END OBJECTIV
     >
       {subLabel && <div className="pagination-nav__sublabel">{subLabel}</div>}


### PR DESCRIPTION
If the title for the link in the `PaginatorNavLink` was empty, e.g. if the previous page has an empty title, the Tracker is not able to tag the link and throws a warning. This happens for instance on the first two pages of docs home.