### PR TITLE
Avoid re-creating the Tracker instance on re-render in Root.tsx

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -17,7 +17,7 @@
     "@docusaurus/preset-classic": "2.0.0-beta.18",
     "@docusaurus/theme-search-algolia": "^2.0.0-beta.18",
     "@mdx-js/react": "^1.6.21",
-    "@objectiv/tracker-browser": "^0.0.16",
+    "@objectiv/tracker-browser": "^0.0.19",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",
     "file-loader": "^6.2.0",

--- a/docs/src/theme/Root.tsx
+++ b/docs/src/theme/Root.tsx
@@ -35,6 +35,7 @@ const cookiebotConsentStatistics = (): boolean => {
 }
 
 function Root({children}) {
+  const [trackerInitialized, setTrackerInitialized] = useState<boolean>(false);
   const [cookiebotStatisticsConsent, setCookiebotStatisticsConsent] = useState<boolean>(cookiebotConsentStatistics());
   const { siteConfig } = useDocusaurusContext();
   const { trackerDocsApplicationId, trackerEndPoint, trackerConsoleEnabled } = siteConfig?.customFields ?? {};
@@ -47,7 +48,7 @@ function Root({children}) {
   })
 
   // Initialize Tracker only if we have all required configuration variables, and we are not in SSR.
-  if (trackerEndPoint && trackerDocsApplicationId && trackerEndPoint && windowExists()) {
+  if (!trackerInitialized && trackerEndPoint && trackerDocsApplicationId && trackerEndPoint && windowExists()) {
 
     // Configure TrackerConsole based on `trackerConsoleEnabled` from siteConfig.
     TrackerConsole.setImplementation(trackerConsoleEnabled ? console : NoopConsoleImplementation);
@@ -67,6 +68,8 @@ function Root({children}) {
         })
       ]
     });
+
+    setTrackerInitialized(true);
   }
 
   // This Effect monitors the `cookiebotStatisticsConsent` and activates or deactivates our Tracker instances

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -1671,61 +1671,48 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@objectiv/plugin-http-context@^0.0.16":
-  version "0.0.16"
-  resolved "https://registry.yarnpkg.com/@objectiv/plugin-http-context/-/plugin-http-context-0.0.16.tgz#6fd1d8869ebc3883013ee0f435280280ea27d29a"
-  integrity sha512-nr9Q8zWx0GrzTp4277R8HIzyXLeTZ2g2LxxbFp5D2j6InH1eWdMu9Xi7/UlgJYxlAC4vXVa48NtHMLCX8kE3dw==
+"@objectiv/plugin-http-context@^0.0.19":
+  version "0.0.19"
+  resolved "https://registry.yarnpkg.com/@objectiv/plugin-http-context/-/plugin-http-context-0.0.19.tgz#893af21ea654124b2ceb5455164dc6e8ae2fd69e"
+  integrity sha512-qBh8kQMDws2dSJ9MYqBSB9CLm/XHsXLQ1n+IXrlmdluQE0WZBbpx4grrxMRcWMBVxBMehgtNYA9EJiLwOa8fCg==
 
-"@objectiv/plugin-path-context-from-url@^0.0.16":
-  version "0.0.16"
-  resolved "https://registry.yarnpkg.com/@objectiv/plugin-path-context-from-url/-/plugin-path-context-from-url-0.0.16.tgz#c63a68483264ede5faaf03f38035787504a373a7"
-  integrity sha512-nrxwODzLSrsN5xchXGQlf28IHzrNN+2DRkskB9RXpSq3Gtguq7HUgQ/xzqSYMpCX2hJx759zpCxRZO/EEWjedw==
+"@objectiv/plugin-path-context-from-url@^0.0.19":
+  version "0.0.19"
+  resolved "https://registry.yarnpkg.com/@objectiv/plugin-path-context-from-url/-/plugin-path-context-from-url-0.0.19.tgz#e5c132996ee579ced363cc11d5c8e5c2566a7355"
+  integrity sha512-mVkHkaFy7/lnv80b+F0+AHaw0FAjjcXZA8Yn37guaMLZDjrqswDvvsC9Tn6oRlQQ4yPQVPRv9ZE7yiGyBnXlCg==
 
-"@objectiv/plugin-root-location-context-from-url@^0.0.16":
-  version "0.0.16"
-  resolved "https://registry.yarnpkg.com/@objectiv/plugin-root-location-context-from-url/-/plugin-root-location-context-from-url-0.0.16.tgz#d884c85c7427669bca0d6dd901d40d7bf252bb3b"
-  integrity sha512-4O1ydZ9rsbq3Ezo7M2i1yCEWITY12Ku//Oy7Vi+m0H9E2dY/O0orB3RhMtSQ47SuKGWoJSmCihJut71PahlgNg==
+"@objectiv/plugin-root-location-context-from-url@^0.0.19":
+  version "0.0.19"
+  resolved "https://registry.yarnpkg.com/@objectiv/plugin-root-location-context-from-url/-/plugin-root-location-context-from-url-0.0.19.tgz#de1ccd7980019a3597ad67aef96cfc15b8500e81"
+  integrity sha512-X0JxUkdXZ2v29lU2jYJZxatZNuafT04d0yCbxCHzcYMRZscxFvVT+zicJDufWOhbKsvWtY6JQQ4ytLAbyIfidw==
 
-"@objectiv/queue-local-storage@^0.0.16":
-  version "0.0.16"
-  resolved "https://registry.yarnpkg.com/@objectiv/queue-local-storage/-/queue-local-storage-0.0.16.tgz#3695bd4057c4822f9362cfcce651562b6ace9708"
-  integrity sha512-PqX0ujdBD60BMdAOexerRmALgRIhvPrnCM/6Y5Iqyk1Z+eP8slAlJ2vyjmKkauIdznSAwzVmdZabPERSY+cNKw==
+"@objectiv/queue-local-storage@^0.0.19":
+  version "0.0.19"
+  resolved "https://registry.yarnpkg.com/@objectiv/queue-local-storage/-/queue-local-storage-0.0.19.tgz#a29c9128b5258f0e00d4c031cd7393bf367d4934"
+  integrity sha512-WAy9Gp7et8P3HvVZZBqzXgZXxBLydredD/1CxeLPiGebXqndlznhjiMeUC3dEdiOO/ptgotNezL+pfswA8SNjA==
   dependencies:
-    "@objectiv/tracker-core" "~0.0.16"
-
-"@objectiv/schema@^0.0.16":
-  version "0.0.16"
-  resolved "https://registry.yarnpkg.com/@objectiv/schema/-/schema-0.0.16.tgz#cccadab3693b4232fa5a0cef7aefade4953f0924"
-  integrity sha512-avNaidxuNY3AMtF6j3/+Nlxz85WiSfl0p62Jl2GSy+oD0czItYLPAkcw4+KgZ/0HiEsym/ryMUy7UlH/Uk6eng==
+    "@objectiv/tracker-core" "~0.0.19"
 
 "@objectiv/schema@^0.0.19":
   version "0.0.19"
   resolved "https://registry.yarnpkg.com/@objectiv/schema/-/schema-0.0.19.tgz#ff67c47094858f92f0ded76c235f71f877c2e613"
   integrity sha512-HAgycbVgbcavUQVJXBxurSaE855Vvf5HylF7f7DD7a65FxUCMU6pnvkptO/OKV0wmLZddsXKlMNGu0w4gbgjYA==
 
-"@objectiv/tracker-browser@^0.0.16":
-  version "0.0.16"
-  resolved "https://registry.yarnpkg.com/@objectiv/tracker-browser/-/tracker-browser-0.0.16.tgz#c446bcd0396d1f5ef145cd5f8ffc90c759765dcf"
-  integrity sha512-AMJy5Cd9ZljRl7HK8KeCJDm3aBwb35/c41KwNuTc8pk8z+kE+TBB2JqR7nevYy9NOV+PzzOmVFRLfZvLpneO6A==
+"@objectiv/tracker-browser@^0.0.19":
+  version "0.0.19"
+  resolved "https://registry.yarnpkg.com/@objectiv/tracker-browser/-/tracker-browser-0.0.19.tgz#1b66535e638e7279345016915778450ffcdc9126"
+  integrity sha512-5T5lyWpY/pKeRA5V/J5KjPBrTEIgobObcU7wqv++P7ntH/S4C7S4sZqsC6CDoAbxIjdVDZqXXsVD3qoXIQPnQg==
   dependencies:
-    "@objectiv/plugin-http-context" "^0.0.16"
-    "@objectiv/plugin-path-context-from-url" "^0.0.16"
-    "@objectiv/plugin-root-location-context-from-url" "^0.0.16"
-    "@objectiv/queue-local-storage" "^0.0.16"
-    "@objectiv/tracker-core" "^0.0.16"
-    "@objectiv/transport-debug" "^0.0.16"
-    "@objectiv/transport-fetch" "^0.0.16"
-    "@objectiv/transport-xhr" "^0.0.16"
+    "@objectiv/plugin-http-context" "^0.0.19"
+    "@objectiv/plugin-path-context-from-url" "^0.0.19"
+    "@objectiv/plugin-root-location-context-from-url" "^0.0.19"
+    "@objectiv/queue-local-storage" "^0.0.19"
+    "@objectiv/tracker-core" "^0.0.19"
+    "@objectiv/transport-debug" "^0.0.19"
+    "@objectiv/transport-fetch" "^0.0.19"
+    "@objectiv/transport-xhr" "^0.0.19"
 
-"@objectiv/tracker-core@^0.0.16":
-  version "0.0.16"
-  resolved "https://registry.yarnpkg.com/@objectiv/tracker-core/-/tracker-core-0.0.16.tgz#e3baa1b55095657759a135f729eb5284f7adc9ad"
-  integrity sha512-70aiIbOk2BF2zytvA7a8fEpYttGn2E73BHNQMFTAWb7cbnGqByL6FtuXRci60XpZpiF4xEtmkMRC83P40TyBFg==
-  dependencies:
-    "@objectiv/schema" "^0.0.16"
-    uuid "^8.3.2"
-
-"@objectiv/tracker-core@~0.0.16":
+"@objectiv/tracker-core@^0.0.19", "@objectiv/tracker-core@~0.0.19":
   version "0.0.19"
   resolved "https://registry.yarnpkg.com/@objectiv/tracker-core/-/tracker-core-0.0.19.tgz#f20327dfb4254c50dc981eef53c30cda7b209fb0"
   integrity sha512-rq9sKEwPd6VDn/E1/OPmwJy1pqELCa6OZ/ELFc9FJT9s2+q6Yh0PCbB4wbYAYQSaltyJ/M2d+YwfjtxFBdWmPw==
@@ -1733,26 +1720,26 @@
     "@objectiv/schema" "^0.0.19"
     uuid "^8.3.2"
 
-"@objectiv/transport-debug@^0.0.16":
-  version "0.0.16"
-  resolved "https://registry.yarnpkg.com/@objectiv/transport-debug/-/transport-debug-0.0.16.tgz#c697efd5b0f8d35fa4171762c59a569ad7de35ec"
-  integrity sha512-zCGr7hh2BmikN66SzQFFNMcPCC7rCIuq19fVmGtTpCwujnft3mXJQnogxGUr0jOMr9xZMew6Bh9rN7kO2DgOyw==
+"@objectiv/transport-debug@^0.0.19":
+  version "0.0.19"
+  resolved "https://registry.yarnpkg.com/@objectiv/transport-debug/-/transport-debug-0.0.19.tgz#2555e5dab56f709ec0f4d9041164348fdfddff95"
+  integrity sha512-yP3NXhtcZ23VCy6X8vkRke4r1tNIJT8VSFl/vi2dc/ESKvfQdIeNi6wGh1Q3cnN0+YQxDnBJoORBKfy8RGhp9w==
   dependencies:
-    "@objectiv/tracker-core" "~0.0.16"
+    "@objectiv/tracker-core" "~0.0.19"
 
-"@objectiv/transport-fetch@^0.0.16":
-  version "0.0.16"
-  resolved "https://registry.yarnpkg.com/@objectiv/transport-fetch/-/transport-fetch-0.0.16.tgz#67d9c52b6c3e4a7a18bfe9e54761b8329c79a24b"
-  integrity sha512-b/llBccCIGjJWCZYuuo78mGqVN/H0oHDDxc+ffxpmM3VaNAJ3ZB3tP/PDF73huPcvSZdF/OHRYa5UvdGKhSVrA==
+"@objectiv/transport-fetch@^0.0.19":
+  version "0.0.19"
+  resolved "https://registry.yarnpkg.com/@objectiv/transport-fetch/-/transport-fetch-0.0.19.tgz#06cd961caa3b352bbcd3ba6532d6e8ff39f92ddb"
+  integrity sha512-b7n2wXEeT/fNvx9mBsJ7G868CsMGHyzVsWnUmgSUFEO+OlEIxjdJRIwAqCuZGIY0bfsFegSDrKQR14ATx33CnQ==
   dependencies:
-    "@objectiv/tracker-core" "~0.0.16"
+    "@objectiv/tracker-core" "~0.0.19"
 
-"@objectiv/transport-xhr@^0.0.16":
-  version "0.0.16"
-  resolved "https://registry.yarnpkg.com/@objectiv/transport-xhr/-/transport-xhr-0.0.16.tgz#6d64cef8a2fe3fcbcc566623681902e66ba8f6df"
-  integrity sha512-r6wk/J0+MWKw9oX3NhL9j13HaKi63e6TSy7n5AAPuZX+DvziOf9D70FlZR7IOY2afXkfx5urzwkmVBgNEmlEKw==
+"@objectiv/transport-xhr@^0.0.19":
+  version "0.0.19"
+  resolved "https://registry.yarnpkg.com/@objectiv/transport-xhr/-/transport-xhr-0.0.19.tgz#7ff4eacb87f1294115e8f61f8c59441fac47c032"
+  integrity sha512-y6XOlujerGvQWeDTiDaV6O/CU/jiOaEc1t6xJD+QMoZSDWTilUC7aFEM0GuxFxL4XKu+xrXH0mAYSjW9XEIHlg==
   dependencies:
-    "@objectiv/tracker-core" "~0.0.16"
+    "@objectiv/tracker-core" "~0.0.19"
 
 "@polka/url@^1.0.0-next.20":
   version "1.0.0-next.21"


### PR DESCRIPTION
@ivarpruijn This is the fix. Basically we should never re-create the Tracker. 
In this particular case the issue has been introduced because the configuration changes (the active bit is false on creation and true on re-render). I think we can improve this by ignoring the active bit, since that's something that can change at runtime.

Another issue is the custom plugin being an anonymous function. By definition that will change every time and cannot be compared.

I'll see if I can improve on both of these in the next version of the Browser Tracker. I've a couple of ideas.

Fixes https://github.com/objectiv/objectiv.io/issues/426