### PR TITLE
Don't show second icon in announcement bar on mobile

### DIFF
--- a/src/components/announcement-bar/styles.module.css
+++ b/src/components/announcement-bar/styles.module.css
@@ -21,7 +21,7 @@
   color: #a09536;
 }
 @media screen and (max-width: 768px) {
-  .announcement span.announcementStar {
+  .announcement span.announcementStarStart {
     display: block;
     margin-bottom: 10px;
   }


### PR DESCRIPTION
Small CSS fix.