### PR TITLE
Docs: React Tracker configuration id normalization

### DIFF
--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedContentContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedContentContext.md
@@ -8,7 +8,8 @@ TrackedContentContext: (props: {
   children: ReactNode,
   Component: ComponentType | keyof ReactHTML,
   id: string,
-  forwardId?: boolean
+  forwardId?: boolean,
+  normalizeId?: boolean
 }) => ReactElement
 ```
 
@@ -25,6 +26,7 @@ We are currently working on improving these definitions to enable support for an
 | required | **Component** | ComponentType &vert; keyof ReactHTML |               |
 | required | **id**        | string                               |               |
 | optional | forwardId     | boolean                              | `false`       |
+| optional | normalizeId   | boolean                              | `true`        |
 
 ## Returns
 `ReactElement`
@@ -44,6 +46,16 @@ import { TrackedContentContext } from '@objectiv/tracker-react';
   <TrackedContentContext Component={'p'} id={'intro'}>
     ...
   </TrackedContentContext>
+</TrackedContentContext>
+```
+
+By default, all Tracked Context Components automatically normalize their Context identifiers to a kebab-cased format.
+
+This can be disabled via the  `normalizeId` option:
+
+```jsx
+<TrackedContentContext Component={'p'} id={'Body Section'} normalizeId={false}>
+...
 </TrackedContentContext>
 ```
 

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedExpandableContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedExpandableContext.md
@@ -9,7 +9,8 @@ TrackedExpandableContext: (props: {
   Component: ComponentType | keyof ReactHTML,
   id: string,
   forwardId?: boolean,
-  isVisible?: boolean
+  isVisible?: boolean,
+  normalizeId?: boolean
 }) => ReactElement
 ```
 
@@ -27,6 +28,7 @@ We are currently working on improving these definitions to enable support for an
 | required | **id**        | string                               |               |
 | optional | forwardId     | boolean                              | `false`       |
 | optional | isVisible     | boolean                              | `undefined`   |
+| optional | normalizeId   | boolean                              | `true`        |
 
 ## Returns
 `ReactElement`
@@ -35,7 +37,7 @@ We are currently working on improving these definitions to enable support for an
 - [HiddenEvent](/taxonomy/reference/events/HiddenEvent.md) when `isVisible` switches from `true` to `false`. 
 - [VisibleEvent](/taxonomy/reference/events/VisibleEvent.md) when `isVisible` switches from `false` to `true`.
 
-:::caution
+:::info
 The `isVisible` state of a TrackedExpandableContext is ignored on mount. Only actual changes and tracked.
 :::
 
@@ -48,6 +50,16 @@ import { TrackedExpandableContext } from '@objectiv/tracker-react';
 ```jsx
 <TrackedExpandableContext Component={'ul'} id={'list'}>
   ...
+</TrackedExpandableContext>
+```
+
+By default, all Tracked Context Components automatically normalize their Context identifiers to a kebab-cased format.
+
+This can be disabled via the  `normalizeId` option:
+
+```jsx
+<TrackedExpandableContext Component={'ul'} id={'Main Menu'} normalizeId={false}>
+...
 </TrackedExpandableContext>
 ```
 

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedInputContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedInputContext.md
@@ -7,7 +7,8 @@ TrackedInputContext: (props: {
   children: ReactNode,
   Component: ComponentType | keyof ReactHTML,
   id: string,
-  forwardId?: boolean
+  forwardId?: boolean,
+  normalizeId?: boolean
 }) => ReactElement
 ```
 
@@ -24,6 +25,7 @@ We are currently working on improving these definitions to enable support for an
 | required | **Component** | ComponentType &vert; keyof ReactHTML |               |
 | required | **id**        | string                               |               |
 | optional | forwardId     | boolean                              | `false`       |
+| optional | normalizeId   | boolean                              | `true`        |
 
 ## Returns
 `ReactElement`
@@ -39,6 +41,14 @@ import { TrackedInputContext } from '@objectiv/tracker-react';
 
 ```jsx
 <TrackedInputContext Component={'input'} type={'email'} id={'email'} />
+```
+
+By default, all Tracked Context Components automatically normalize their Context identifiers to a kebab-cased format.
+
+This can be disabled via the  `normalizeId` option:
+
+```jsx
+<TrackedInputContext Component={'input'} id={'First Name'} normalizeId={false} />
 ```
 
 :::caution Props forwarding

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedLinkContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedLinkContext.md
@@ -12,7 +12,8 @@ TrackedLinkContext: (props: {
   forwardHref?: boolean
   title?: string,
   forwardTitle?: boolean,
-  waitUntilTracked?: boolean
+  waitUntilTracked?: boolean,
+  normalizeId?: boolean
 }) => ReactElement
 ```
 
@@ -23,17 +24,18 @@ We are currently working on improving these definitions to enable support for an
 :::
 
 ## Parameters
-|          |                  | type                                 | default value                       |
-|:--------:|:-----------------|:-------------------------------------|:------------------------------------|
-| required | **children**     | ReactNode                            |                                     |
-| required | **Component**    | ComponentType &vert; keyof ReactHTML |                                     |
-| optional | id               | string                               | inferred from `children` or `title` |
-| optional | forwardId        | boolean                              | `false`                             |
-| required | **href**         | string                               |                                     |
-| optional | forwardHref      | boolean                              | `false`                             |
-| optional | title            | string                               |                                     |
-| optional | forwardTitle     | boolean                              | `false`                             |
-| optional | waitUntilTracked | boolean                              | `false`                             |
+|          |                  | type                                   | default value                       |
+|:--------:|:-----------------|:---------------------------------------|:------------------------------------|
+| required | **children**     | ReactNode                              |                                     |
+| required | **Component**    | ComponentType &vert; keyof ReactHTML   |                                     |
+| optional | id               | string                                 | inferred from `children` or `title` |
+| optional | forwardId        | boolean                                | `false`                             |
+| required | **href**         | string                                 |                                     |
+| optional | forwardHref      | boolean                                | `false`                             |
+| optional | title            | string                                 |                                     |
+| optional | forwardTitle     | boolean                                | `false`                             |
+| optional | waitUntilTracked | boolean                                | `false`                             |
+| optional | normalizeId      | boolean                                | `true`                              |
 
 ## Returns
 `ReactElement`
@@ -54,13 +56,31 @@ import { TrackedLinkContext } from '@objectiv/tracker-react';
   Privacy
 </TrackedLinkContext>
 
-// Whenever inferring 'id' is not possible, e.g. children without text, a `title` can be specified
+// A `title` can be specified whenever inferring 'id' is not possible 
 <TrackedLinkContext Component={'a'} href={'/privacy'} title={'privacy'}>
   <img src="/lock.jpg"/>
 </TrackedLinkContext>
 
 // Or just a manual `id`, either one will do the job
 <TrackedLinkContext Component={'a'} href={'/privacy'} id={'privacy'}>
+  <img src="/lock.jpg"/>
+</TrackedLinkContext>
+```
+
+By default, all Tracked Context Components automatically normalize their Context identifiers to a kebab-cased format.
+
+This can be disabled via the  `normalizeId` option:
+
+```jsx
+<TrackedLinkContext Component={'a'} href={'/privacy'} normalizeId={false}>
+  Privacy Policy
+</TrackedLinkContext>
+
+<TrackedLinkContext Component={'a'} href={'/privacy'} title={'Privacy Policy'} normalizeId={false}>
+  <img src="/lock.jpg"/>
+</TrackedLinkContext>
+
+<TrackedLinkContext Component={'a'} href={'/privacy'} id={'Privacy Policy'} normalizeId={false}>
   <img src="/lock.jpg"/>
 </TrackedLinkContext>
 ```

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedMediaPlayerContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedMediaPlayerContext.md
@@ -7,7 +7,8 @@ TrackedMediaPlayerContext: (props: {
   children: ReactNode,
   Component: ComponentType | keyof ReactHTML,
   id: string,
-  forwardId?: boolean
+  forwardId?: boolean,
+  normalizeId?: boolean
 }) => ReactElement
 ```
 
@@ -24,6 +25,7 @@ We are currently working on improving these definitions to enable support for an
 | required | **Component** | ComponentType &vert; keyof ReactHTML |               |
 | required | **id**        | string                               |               |
 | optional | forwardId     | boolean                              | `false`       |
+| optional | normalizeId   | boolean                              | `true`        |
 
 ## Returns
 `ReactElement`
@@ -39,6 +41,14 @@ import { TrackedMediaPlayerContext } from '@objectiv/tracker-react';
 
 ```jsx
 <TrackedMediaPlayerContext Component={'video'} id={'content'} />
+```
+
+By default, all Tracked Context Components automatically normalize their Context identifiers to a kebab-cased format.
+
+This can be disabled via the  `normalizeId` option:
+
+```jsx
+<TrackedMediaPlayerContext Component={'video'} id={'Media Player'} normalizeId={false} />
 ```
 
 :::caution Props forwarding

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedNavigationContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedNavigationContext.md
@@ -7,7 +7,8 @@ TrackedNavigationContext: (props: {
   children: ReactNode,
   Component: ComponentType | keyof ReactHTML,
   id: string,
-  forwardId?: boolean
+  forwardId?: boolean,
+  normalizeId?: boolean
 }) => ReactElement
 ```
 
@@ -24,6 +25,7 @@ We are currently working on improving these definitions to enable support for an
 | required | **Component** | ComponentType &vert; keyof ReactHTML |               |
 | required | **id**        | string                               |               |
 | optional | forwardId     | boolean                              | `false`       |
+| optional | normalizeId   | boolean                              | `true`        |
 
 ## Returns
 `ReactElement`
@@ -42,6 +44,16 @@ import { TrackedNavigationContext } from '@objectiv/tracker-react';
   <a href={'/'}>Homepage</a>
   <a href={'/privacy'}>Privacy</a>
   <a href={'/contact'}>Contact</a>
+</TrackedNavigationContext>
+```
+
+By default, all Tracked Context Components automatically normalize their Context identifiers to a kebab-cased format.
+
+This can be disabled via the  `normalizeId` option:
+
+```jsx
+<TrackedNavigationContext Component={'nav'} id={'Top Navigation'} normalizeId={false}>
+  ...
 </TrackedNavigationContext>
 ```
 

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedOverlayContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedOverlayContext.md
@@ -8,7 +8,8 @@ TrackedOverlayContext: (props: {
   Component: ComponentType | keyof ReactHTML,
   id: string,
   forwardId?: boolean,
-  isVisible?: boolean
+  isVisible?: boolean,
+  normalizeId?: boolean
 }) => ReactElement
 ```
 
@@ -25,6 +26,7 @@ We are currently working on improving these definitions to enable support for an
 | required | **Component** | ComponentType &vert; keyof ReactHTML |               |
 | required | **id**        | string                               |               |
 | optional | forwardId     | boolean                              | `false`       |
+| optional | normalizeId   | boolean                              | `true`        |
 
 ## Returns
 `ReactElement`
@@ -46,6 +48,16 @@ import { TrackedOverlayContext } from '@objectiv/tracker-react';
 
 ```jsx
 <TrackedOverlayContext Component={'div'} id={'modal'}>
+  ...
+</TrackedOverlayContext>
+```
+
+By default, all Tracked Context Components automatically normalize their Context identifiers to a kebab-cased format.
+
+This can be disabled via the  `normalizeId` option:
+
+```jsx
+<TrackedOverlayContext Component={'div'} id={'Login Modal'} normalizeId={false}>
   ...
 </TrackedOverlayContext>
 ```

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedPressableContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedPressableContext.md
@@ -10,7 +10,8 @@ TrackedPressableContext: (props: {
   forwardId?: boolean,
   title?: string,
   forwardTitle?: boolean,
-  waitUntilTracked?: boolean
+  waitUntilTracked?: boolean,
+  normalizeId?: boolean
 }) => ReactElement
 ```
 
@@ -21,15 +22,16 @@ We are currently working on improving these definitions to enable support for an
 :::
 
 ## Parameters
-|          |                   | type                                 | default value                       |
-|:--------:|:------------------|:-------------------------------------|:------------------------------------|
-| required | **children**      | ReactNode                            |                                     |
-| required | **Component**     | ComponentType &vert; keyof ReactHTML |                                     |
-| optional | id                | string                               | inferred from `children` or `title` |
-| optional | forwardId         | boolean                              | `false`                             |
-| optional | title             | string                               |                                     |
-| optional | forwardTitle      | boolean                              | `false`                             |
-| optional | waitUntilTracked  | boolean                              | `false`                             |
+|          |                  | type                                 | default value                       |
+|:--------:|:-----------------|:-------------------------------------|:------------------------------------|
+| required | **children**     | ReactNode                            |                                     |
+| required | **Component**    | ComponentType &vert; keyof ReactHTML |                                     |
+| optional | id               | string                               | inferred from `children` or `title` |
+| optional | forwardId        | boolean                              | `false`                             |
+| optional | title            | string                               |                                     |
+| optional | forwardTitle     | boolean                              | `false`                             |
+| optional | waitUntilTracked | boolean                              | `false`                             |
+| optional | normalizeId      | boolean                              | `true`                              |
 
 ## Returns
 `ReactElement`
@@ -48,13 +50,31 @@ import { TrackedPressableContext } from '@objectiv/tracker-react';
   Do it
 </TrackedPressableContext>
 
-// Whenever inferring 'id' is not possible, due to children not having any text, a `title` can be specified
+// A `title` can be specified whenever inferring 'id' is not possible
 <TrackedPressableContext Component={'button'} onClick={ () => doIt() } title={'Do it'}>
   <img src="/do-it.jpg"/>
 </TrackedPressableContext>
 
 // Or just a manual `id`, either one will do the job
 <TrackedPressableContext Component={'button'} onClick={ () => doIt() } id={'do-it'}>
+  <img src="/do-it.jpg"/>
+</TrackedPressableContext>
+```
+
+By default, all Tracked Context Components automatically normalize their Context identifiers to a kebab-cased format.
+
+This can be disabled via the  `normalizeId` option:
+
+```jsx
+<TrackedPressableContext Component={'button'} onClick={...} normalizeId={false}>
+  Do it
+</TrackedPressableContext>
+
+<TrackedPressableContext Component={'button'} onClick={...} title={'Do it'} normalizeId={false}>
+  <img src="/do-it.jpg"/>
+</TrackedPressableContext>
+
+<TrackedPressableContext Component={'button'} onClick={...} id={'Do it'} normalizeId={false}>
   <img src="/do-it.jpg"/>
 </TrackedPressableContext>
 ```

--- a/docs/docs/tracking/react/api-reference/trackedContexts/TrackedRootLocationContext.md
+++ b/docs/docs/tracking/react/api-reference/trackedContexts/TrackedRootLocationContext.md
@@ -7,7 +7,8 @@ TrackedRootLocationContext: (props: {
   children: ReactNode,
   Component: ComponentType | keyof ReactHTML,
   id: string,
-  forwardId?: boolean
+  forwardId?: boolean,
+  normalizeId?: boolean
 }) => ReactElement
 ```
 
@@ -38,7 +39,8 @@ We are currently working on improving these definitions to enable support for an
 | required | **Component** | ComponentType &vert; keyof ReactHTML |               |
 | required | **id**        | string                               |               |
 | optional | forwardId     | boolean                              | `false`       |
-
+| optional | normalizeId   | boolean                              | `true`        |
+    
 ## Returns
 `ReactElement`
 
@@ -56,6 +58,16 @@ import { TrackedRootLocationContext } from '@objectiv/tracker-react';
   <Layout>
     ...
   </Layout>
+</TrackedRootLocationContext>
+```
+
+By default, all Tracked Context Components automatically normalize their Context identifiers to a kebab-cased format.
+
+This can be disabled via the  `normalizeId` option:
+
+```jsx
+<TrackedRootLocationContext id={'Home Page'} normalizeId={false}>
+  ...
 </TrackedRootLocationContext>
 ```
 

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedAnchor.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedAnchor.md
@@ -11,7 +11,8 @@ TrackedAnchor: (props: {
   forwardHref?: boolean
   title?: string,
   forwardTitle?: boolean,
-  waitUntilTracked?: boolean
+  waitUntilTracked?: boolean,
+  normalizeId?: boolean
 }) => ReactElement
 ```
 
@@ -26,6 +27,7 @@ TrackedAnchor: (props: {
 | optional | title            | string    |                                     |
 | optional | forwardTitle     | boolean   | `false`                             |
 | optional | waitUntilTracked | boolean   | `false`                             |
+| optional | normalizeId      | boolean   | `true`                              |
 
 ## Returns
 `ReactElement`
@@ -62,6 +64,25 @@ import { TrackedAnchor } from '@objectiv/tracker-react';
   </footer>
 </div>
 ```
+
+By default, all Tracked Elements automatically normalize their Content identifiers to a kebab-cased format.
+
+This can be disabled via the  `normalizeId` option:
+
+```jsx
+<div>
+  <TrackedAnchor href={'/'} normalizeId={false}>Back to home</TrackedAnchor>
+  
+  <TrackedAnchor href={'/privacy'} title={'Privacy settings'} normalizeId={false}>
+    <img src="/lock.jpg"/>
+  </TrackedAnchor>
+
+  <TrackedAnchor href={'/profile'} id={'Profile settings'} normalizeId={false}>
+    <img src="/profile.jpg"/>
+  </TrackedAnchor>
+</div>
+```
+
 
 <br />
 

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedAnchor.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedAnchor.md
@@ -65,7 +65,7 @@ import { TrackedAnchor } from '@objectiv/tracker-react';
 </div>
 ```
 
-By default, all Tracked Elements automatically normalize their Content identifiers to a kebab-cased format.
+By default, all Tracked Elements automatically normalize their Context identifiers to a kebab-cased format.
 
 This can be disabled via the  `normalizeId` option:
 

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedButton.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedButton.md
@@ -63,7 +63,7 @@ import { TrackedButton } from '@objectiv/tracker-react';
 </div>
 ```
 
-By default, all Tracked Elements automatically normalize their Content identifiers to a kebab-cased format.
+By default, all Tracked Elements automatically normalize their Context identifiers to a kebab-cased format.
 
 This can be disabled via the  `normalizeId` option:
 

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedButton.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedButton.md
@@ -9,7 +9,8 @@ TrackedButton: (props: {
   forwardId?: boolean,
   title?: string,
   forwardTitle?: boolean,
-  waitUntilTracked?: boolean
+  waitUntilTracked?: boolean,
+  normalizeId?: boolean
 }) => ReactElement
 ```
 
@@ -22,6 +23,7 @@ TrackedButton: (props: {
 | optional | title            | string    |                                     |
 | optional | forwardTitle     | boolean   | `false`                             |
 | optional | waitUntilTracked | boolean   | `false`                             |
+| optional | normalizeId      | boolean   | `true`                              |
 
 ## Returns
 `ReactElement`
@@ -60,6 +62,29 @@ import { TrackedButton } from '@objectiv/tracker-react';
   </footer>
 </div>
 ```
+
+By default, all Tracked Elements automatically normalize their Content identifiers to a kebab-cased format.
+
+This can be disabled via the  `normalizeId` option:
+
+```jsx
+<div>
+  <TrackedButton onClick={ () => doIt() } normalizeId={false}>
+    Do it
+  </TrackedButton>
+
+  {/* Whenever inferring 'id' is not possible, due to children not having any text, a `title` can be specified */}
+  <TrackedButton onClick={ () => doIt() } title={'Do it'} normalizeId={false}>
+    <img src="/do-it.jpg"/>
+  </TrackedButton>
+    
+  {/* Or just a manual `id`, either one will do the job */}
+  <TrackedButton onClick={ () => doIt() } id={'Do it'} normalizeId={false}>
+    <img src="/button.jpg"/>
+  </TrackedButton>
+</div>
+```
+
 
 <br />
 

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedDiv.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedDiv.md
@@ -6,16 +6,18 @@ Generates a `<div>` Element wrapped in a [ContentContext](/taxonomy/reference/lo
 TrackedDiv: (props: {
   children: ReactNode,
   id: string,
-  forwardId?: boolean
+  forwardId?: boolean,
+  normalizeId?: boolean
 }) => ReactElement
 ```
 
 ## Parameters
-|          |               | type      | default value |
-|:--------:|:--------------|:----------|:--------------|
-| required | **children**  | ReactNode |               |
-| required | **id**        | string    |               |
-| optional | forwardId     | boolean   | `false`       |
+|          |              | type      | default value |
+|:--------:|:-------------|:----------|:--------------|
+| required | **children** | ReactNode |               |
+| required | **id**       | string    |               |
+| optional | forwardId    | boolean   | `false`       |
+| optional | normalizeId  | boolean   | `true`        |
 
 ## Returns
 `ReactElement`
@@ -33,6 +35,19 @@ import { TrackedDiv } from '@objectiv/tracker-react';
 <TrackedDiv id={'content'}>
   ...
   <TrackedDiv id={'details'}>
+    ...
+  </TrackedDiv>
+</TrackedDiv>
+```
+
+By default, all Tracked Elements automatically normalize their Content identifiers to a kebab-cased format.
+
+This can be disabled via the  `normalizeId` option:
+
+```jsx
+<TrackedDiv id={'content'}>
+  ...
+  <TrackedDiv id={'leave this as is'} normalizeId={false}>
     ...
   </TrackedDiv>
 </TrackedDiv>

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedDiv.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedDiv.md
@@ -40,7 +40,7 @@ import { TrackedDiv } from '@objectiv/tracker-react';
 </TrackedDiv>
 ```
 
-By default, all Tracked Elements automatically normalize their Content identifiers to a kebab-cased format.
+By default, all Tracked Elements automatically normalize their Context identifiers to a kebab-cased format.
 
 This can be disabled via the  `normalizeId` option:
 

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedFooter.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedFooter.md
@@ -49,7 +49,7 @@ import { TrackedFooter } from '@objectiv/tracker-react';
 </div>
 ```
 
-By default, all Tracked Elements automatically normalize their Content identifiers to a kebab-cased format.
+By default, all Tracked Elements automatically normalize their Context identifiers to a kebab-cased format.
 
 This can be disabled via the  `normalizeId` option:
 

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedFooter.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedFooter.md
@@ -6,16 +6,18 @@ Generates a `<footer>` Element wrapped in a [ContentContext](/taxonomy/reference
 TrackedFooter: (props: {
   children: ReactNode,
   id?: string,
-  forwardId?: boolean
+  forwardId?: boolean,
+  normalizeId?: boolean
 }) => ReactElement
 ```
 
 ## Parameters
-|          |              | type                                 | default value |
-|:--------:|:-------------|:-------------------------------------|:--------------|
-| required | **children** | ReactNode                            |               |
-| optional | id           | string                               | `footer`      |
-| optional | forwardId    | boolean                              | `false`       |
+|          |              | type      | default value |
+|:--------:|:-------------|:----------|:--------------|
+| required | **children** | ReactNode |               |
+| optional | id           | string    | `footer`      |
+| optional | forwardId    | boolean   | `false`       |
+| optional | normalizeId  | boolean   | `true`        |
 
 ## Returns
 `ReactElement`
@@ -38,6 +40,22 @@ import { TrackedFooter } from '@objectiv/tracker-react';
     ...
   </main>
   <TrackedFooter>
+    ...
+  </TrackedFooter>
+  
+  <TrackedFooter id={'Secondary Footer'}>
+    ...
+  </TrackedFooter>
+</div>
+```
+
+By default, all Tracked Elements automatically normalize their Content identifiers to a kebab-cased format.
+
+This can be disabled via the  `normalizeId` option:
+
+```jsx
+<div>
+  <TrackedFooter id={'Main Footer'} normalizeId={false}>
     ...
   </TrackedFooter>
 </div>

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedHeader.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedHeader.md
@@ -48,7 +48,7 @@ import { TrackedHeader } from '@objectiv/tracker-react';
 </div>
 ```
 
-By default, all Tracked Elements automatically normalize their Content identifiers to a kebab-cased format.
+By default, all Tracked Elements automatically normalize their Context identifiers to a kebab-cased format.
 
 This can be disabled via the  `normalizeId` option:
 

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedHeader.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedHeader.md
@@ -6,16 +6,18 @@ Generates a `<header>` Element wrapped in a [ContentContext](/taxonomy/reference
 TrackedHeader: (props: {
   children: ReactNode,
   id?: string,
-  forwardId?: boolean
+  forwardId?: boolean,
+  normalizeId?: boolean
 }) => ReactElement
 ```
 
 ## Parameters
-|          |              | type                                 | default value |
-|:--------:|:-------------|:-------------------------------------|:--------------|
-| required | **children** | ReactNode                            |               |
-| optional | id           | string                               | `header`      |
-| optional | forwardId    | boolean                              | `false`       |
+|          |              | type       | default value |
+|:--------:|:-------------|:-----------|:--------------|
+| required | **children** | ReactNode  |               |
+| optional | id           | string     | `header`      |
+| optional | forwardId    | boolean    | `false`       |
+| optional | normalizeId  | boolean    | `true`        |
 
 ## Returns
 `ReactElement`
@@ -34,12 +36,27 @@ import { TrackedHeader } from '@objectiv/tracker-react';
   <TrackedHeader>
     ...
   </TrackedHeader>
+  <TrackedHeader id={'Secondary Header'}>
+    ...
+  </TrackedHeader>
   <main>
     ...
   </main>
   <footer>
     ...
   </footer>
+</div>
+```
+
+By default, all Tracked Elements automatically normalize their Content identifiers to a kebab-cased format.
+
+This can be disabled via the  `normalizeId` option:
+
+```jsx
+<div>
+  <TrackedHeader id={'Main Header'} normalizeId={false}>
+    ...
+  </TrackedHeader>
 </div>
 ```
 

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedInput.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedInput.md
@@ -7,8 +7,9 @@ TrackedInput: (props: {
   children: ReactNode,
   id: string,
   forwardId?: boolean,
-  title?: string;
-  forwardTitle?: boolean;
+  title?: string,
+  forwardTitle?: boolean,
+  normalizeId?: boolean
 }) => ReactElement
 ```
 
@@ -20,6 +21,7 @@ TrackedInput: (props: {
 | optional | forwardId    | boolean   | `false`       |
 | optional | title        | string    |               |
 | optional | forwardTitle | boolean   | `false`       |
+| optional | normalizeId  | boolean   | `true`        |
 
 ## Returns
 `ReactElement`
@@ -48,6 +50,15 @@ import { TrackedInput } from '@objectiv/tracker-react';
 </div>
 ```
 
+By default, all Tracked Elements automatically normalize their Content identifiers to a kebab-cased format.
+
+This can be disabled via the  `normalizeId` option:
+
+```jsx
+<div>
+  <TrackedInput id={'Email Address'} normalizeId={false} name={'email'} />
+</div>
+```
 <br />
 
 :::tip Did you know ?

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedInput.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedInput.md
@@ -50,7 +50,7 @@ import { TrackedInput } from '@objectiv/tracker-react';
 </div>
 ```
 
-By default, all Tracked Elements automatically normalize their Content identifiers to a kebab-cased format.
+By default, all Tracked Elements automatically normalize their Context identifiers to a kebab-cased format.
 
 This can be disabled via the  `normalizeId` option:
 

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedMain.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedMain.md
@@ -48,7 +48,7 @@ import { TrackedMain } from '@objectiv/tracker-react';
 </div>
 ```
 
-By default, all Tracked Elements automatically normalize their Content identifiers to a kebab-cased format.
+By default, all Tracked Elements automatically normalize their Context identifiers to a kebab-cased format.
 
 This can be disabled via the  `normalizeId` option:
 

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedMain.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedMain.md
@@ -6,7 +6,8 @@ Generates a `<main>` Element wrapped in a [ContentContext](/taxonomy/reference/l
 TrackedMain: (props: {
   children: ReactNode,
   id?: string,
-  forwardId?: boolean
+  forwardId?: boolean,
+  normalizeId?: boolean
 }) => ReactElement
 ```
 
@@ -16,6 +17,7 @@ TrackedMain: (props: {
 | required | **children** | ReactNode |               |
 | optional | id           | string    | `main`        |
 | optional | forwardId    | boolean   | `false`       |
+| optional | normalizeId  | boolean   | `true`        |
 
 ## Returns
 `ReactElement`
@@ -37,9 +39,24 @@ import { TrackedMain } from '@objectiv/tracker-react';
   <TrackedMain>
     ...
   </TrackedMain>
+  <TrackedMain id={'Another Main Section'}>
+    ...
+  </TrackedMain>
   <footer>
     ...
   </footer>
+</div>
+```
+
+By default, all Tracked Elements automatically normalize their Content identifiers to a kebab-cased format.
+
+This can be disabled via the  `normalizeId` option:
+
+```jsx
+<div>
+  <TrackedMain id={'Main Section'} normalizeId={false}>
+    ...
+  </TrackedMain>
 </div>
 ```
 

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedNav.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedNav.md
@@ -57,7 +57,7 @@ import { TrackedNav } from '@objectiv/tracker-react';
 </div>
 ```
 
-By default, all Tracked Elements automatically normalize their Content identifiers to a kebab-cased format.
+By default, all Tracked Elements automatically normalize their Context identifiers to a kebab-cased format.
 
 This can be disabled via the  `normalizeId` option:
 

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedNav.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedNav.md
@@ -6,7 +6,8 @@ Generates a `<nav>` Element wrapped in a [NavigationContext](/taxonomy/reference
 TrackedNav: (props: {
   children: ReactNode,
   id?: string,
-  forwardId?: boolean
+  forwardId?: boolean,
+  normalizeId?: boolean
 }) => ReactElement
 ```
 
@@ -16,6 +17,7 @@ TrackedNav: (props: {
 | required | **children** | ReactNode |               |
 | optional | id           | string    | `nav`         |
 | optional | forwardId    | boolean   | `false`       |
+| optional | normalizeId  | boolean   | `true`        |
 
 ## Returns
 `ReactElement`
@@ -33,6 +35,11 @@ import { TrackedNav } from '@objectiv/tracker-react';
 <div>
   <header>
     ...
+    <TrackedNav>
+      <a href={'/'}>Homepage</a>
+      <a href={'/about'}>About us</a>
+      <a href={'/product'}>The Product</a>
+    </TrackedNav>
   </header>
   <main>
     ...
@@ -41,12 +48,24 @@ import { TrackedNav } from '@objectiv/tracker-react';
     ...
   </footer>
   <aside>
-    <TrackedNav>
+    <TrackedNav id={'Footer Navigation'}>
       <a href={'/'}>Homepage</a>
       <a href={'/privacy'}>Privacy</a>
       <a href={'/contact'}>Contact</a>
     </TrackedNav>
   </aside>
+</div>
+```
+
+By default, all Tracked Elements automatically normalize their Content identifiers to a kebab-cased format.
+
+This can be disabled via the  `normalizeId` option:
+
+```jsx
+<div>
+  <TrackedNav id={'Main Navigation'} normalizeId={false}>
+    ...
+  </TrackedNav>
 </div>
 ```
 

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedSection.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedSection.md
@@ -6,16 +6,18 @@ Generates a `<section>` Element wrapped in a [ContentContext](/taxonomy/referenc
 TrackedSection: (props: {
   children: ReactNode,
   id: string,
-  forwardId?: boolean
+  forwardId?: boolean,
+  normalizeId?: boolean
 }) => ReactElement
 ```
 
 ## Parameters
-|          |               | type                                 | default value |
-|:--------:|:--------------|:-------------------------------------|:--------------|
-| required | **children**  | ReactNode                            |               |
-| required | **id**        | string                               |               |
-| optional | forwardId     | boolean                              | `false`       |
+|          |              | type      | default value |
+|:--------:|:-------------|:----------|:--------------|
+| required | **children** | ReactNode |               |
+| required | **id**       | string    |               |
+| optional | forwardId    | boolean   | `false`       |
+| optional | normalizeId  | boolean   | `true`        |
 
 ## Returns
 `ReactElement`
@@ -36,6 +38,18 @@ import { TrackedSection } from '@objectiv/tracker-react';
     ...
   </TrackedSection>
 </TrackedSection>
+```
+
+By default, all Tracked Elements automatically normalize their Content identifiers to a kebab-cased format.
+
+This can be disabled via the  `normalizeId` option:
+
+```jsx
+<div>
+  <TrackedSection id={'Another Section'} normalizeId={false}>
+    ...
+  </TrackedSection>
+</div>
 ```
 
 <br />

--- a/docs/docs/tracking/react/api-reference/trackedElements/TrackedSection.md
+++ b/docs/docs/tracking/react/api-reference/trackedElements/TrackedSection.md
@@ -40,7 +40,7 @@ import { TrackedSection } from '@objectiv/tracker-react';
 </TrackedSection>
 ```
 
-By default, all Tracked Elements automatically normalize their Content identifiers to a kebab-cased format.
+By default, all Tracked Elements automatically normalize their Context identifiers to a kebab-cased format.
 
 This can be disabled via the  `normalizeId` option:
 


### PR DESCRIPTION
Documentation update reflecting the changes in https://github.com/objectiv/objectiv-analytics/pull/822