### PR TITLE
Fix collision in blog images

### DIFF
--- a/src/components/blog-image/index.js
+++ b/src/components/blog-image/index.js
@@ -38,6 +38,9 @@ function BlogImage({
     classNames = clsx(styles.blogImage, styles.blogImageLarge)
   }
 
+  // ensure the tracked div has an ID even if there's no imageAlt (with links)
+  imageAlt = (imageAlt == '') ? url : imageAlt; 
+
   return (
     <TrackedDiv id={'image: ' + imageAlt}>
       <img src={useBaseUrl(url)} alt={imageAlt} className={classNames} />

--- a/src/components/blog-image/index.js
+++ b/src/components/blog-image/index.js
@@ -39,7 +39,7 @@ function BlogImage({
   }
 
   // ensure the tracked div has an ID even if there's no imageAlt (with links)
-  imageAlt = (imageAlt == '') ? url : imageAlt; 
+  imageAlt = (imageAlt === '') ? url : imageAlt; 
 
   return (
     <TrackedDiv id={'image: ' + imageAlt}>


### PR DESCRIPTION
If a blog image has no caption, and there are more than one of them, a collision occurs, such as is the case for the latest blog post. This PR fixes that.