### PR TITLE
Validation examples in v0.0.20

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,18 +1,19 @@
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import { makeApplicationContext } from "@objectiv/tracker-core";
+import { PressableContextWrapper, TrackedDiv, TrackedHeader, trackPressEvent } from "@objectiv/tracker-react";
 import Layout from '@theme/Layout';
 import clsx from 'clsx';
 import React, { useRef } from 'react';
+import AnimatedGif from '../components/animated-gif';
+import AnnouncementBar from '../components/announcement-bar';
+import BeforeAfterImage from '../components/before-after-image';
 import GitHubStargazers from '../components/github-stargazers';
 import IconHeader from '../components/icon-header';
-import BeforeAfterImage from '../components/before-after-image';
-import VimeoPlayer from '../components/vimeo-player';
-import AnimatedGif from '../components/animated-gif';
 import StarUsNotification, { StarUsAnchor } from '../components/star-us';
-import { TrackedDiv, TrackedHeader } from "@objectiv/tracker-react";
+import VimeoPlayer from '../components/vimeo-player';
 import { TrackedLink } from '../trackedComponents/TrackedLink';
 import styles from './styles.module.css';
-import AnnouncementBar from '../components/announcement-bar';
 
 export default function Home() {
   const context = useDocusaurusContext();
@@ -34,7 +35,29 @@ export default function Home() {
         ctaLink={'https://objectiv.io/docs/home/get-a-launchpad'}
         ctaText={'Learn more'} 
         icon={'icon-new-banner'} />
-      
+
+        <PressableContextWrapper id={'validation-example'}>
+          {(trackingContext) => (
+            <>
+              <div className={clsx('container', styles.heroContainer)}>
+                This interaction triggers two validation errors:
+                <button
+                  className={clsx("button", styles.ctaButton)}
+                  onClick={() => {
+                    trackPressEvent({
+                      ...trackingContext,
+                      globalContexts: [
+                        makeApplicationContext({id: 'application-id'})
+                      ]
+                    })
+                  }}
+                >Duplicated ApplicationContext and missing RootLocationContext</button>
+              </div>
+            </>
+            )}
+          </PressableContextWrapper>
+
+
       <TrackedHeader 
         id={'hero'} 
         className={clsx('hero hero--primary', styles.heroBanner)}>

--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -55,6 +55,7 @@ function Root({children}) {
     endpoint: trackerEndPoint as string,
     applicationId: trackerApplicationId as string,
     active: cookiebotStatisticsConsent,
+    trackRootLocationContextFromURL: false
   })
 
   // This Effect monitors the `cookiebotStatisticsConsent` and activates or deactivates our Tracker instances


### PR DESCRIPTION
This branch contains two examples of validation issues. 

## Missing RootLocationContext
The Tracker instance of the website has been configured to not track RootLocationContexts from URLs, but no alternative has been implemented to generate those. 

Since RootLocationContext is required by the Open Taxonomy, this will result in the validation reporting the issue:
![Screen Shot 2022-06-10 at 13 32 03](https://user-images.githubusercontent.com/567826/173056325-fcf97d3f-e6c4-4806-bc45-2930f493254b.png)

Note how the validation rules detected the platform we are running in and attached links to the documentation for React aimed at solving this particular type of validation error.

## Duplicated ApplicationContext
The second example simulates a low-level instrumentation gone wrong. The test button attempts to generate a custom ApplicationContext, but the Tracker has not been prevented from generating those automatically. Since ApplicationContext should only be present once in the list of Global Contexts, the validation reports the issue:
![Screen Shot 2022-06-10 at 13 31 22](https://user-images.githubusercontent.com/567826/173056594-601d8e59-a5ce-48fd-8be7-d12797ae3a48.png)

In this example we currently don't have any specific how-to links, but as we add more and more how-to's to our documentation we may introduce them later on. 
