### PR TITLE
Add validation video and collisions example to docs and blog post

### DIFF
--- a/blog/2022-06-14 Release Helpful messages to debug your tracking instrumentation.md
+++ b/blog/2022-06-14 Release Helpful messages to debug your tracking instrumentation.md
@@ -13,6 +13,7 @@ authors: ivarpruijn
 
 import BlogImage from '@site/src/components/blog-image'
 import JoinSlackLink from '@site/src/components/join-slack-link';
+import VimeoPlayer from '@site/src/components/vimeo-player';
 
 [taxonomy]: https://objectiv.io/docs/taxonomy/
 [collector]: https://objectiv.io/docs/tracking/collector
@@ -47,7 +48,8 @@ SDK's Validation messages, to help you debug your tracking instrumentation.
 
 <!--truncate-->
 
-<BlogImage url="/img/open-graph/og-validation-helpful-messages.png" size="normal" />
+<VimeoPlayer id="product-demo-validation" videoId="722912732" paddingBottom="45%" />
+
 
 # How does it work?
 We already support basic tracking validation in your IDE, the backend [Collector][collector], and the 
@@ -100,6 +102,7 @@ The backend [Collector][collector] also performs much of this validation as a fa
 [InteractiveEvent][interactive-event]s.
 
 :::
+
 
 # How to get it
 

--- a/blog/2022-06-14 Release Helpful messages to debug your tracking instrumentation.md
+++ b/blog/2022-06-14 Release Helpful messages to debug your tracking instrumentation.md
@@ -103,7 +103,6 @@ The backend [Collector][collector] also performs much of this validation as a fa
 
 :::
 
-
 # How to get it
 
 The new [`developer-tools`][developer-tools] package is available as a developer dependency for all SDKs. How 

--- a/docs/docs/tracking/core-concepts/validation.md
+++ b/docs/docs/tracking/core-concepts/validation.md
@@ -60,7 +60,7 @@ alternative has been implemented to generate those. Since
 [RootLocationContext](../../taxonomy/reference/location-contexts/RootLocationContext.md) is required by the 
 open analytics taxonomy, this will result in the validation reporting the issue:
 
-![IDE validation: property id](../../../static/img/docs/missing-rootlocationcontext.png)
+![Validation: Missing RootLocationContext](../../../static/img/docs/missing-rootlocationcontext.png)
 
 :::note
 
@@ -77,10 +77,19 @@ the Tracker has not been prevented from generating those automatically. Since
 once in the list of [Global Contexts](../../taxonomy/reference/global-contexts/overview.md), the validation 
 reports the issue:
 
-![IDE validation: property id](../../../static/img/docs/duplicated-applicationcontext.png)
+![Validation: Duplicated ApplicationContext](../../../static/img/docs/duplicated-applicationcontext.png)
 
 In this example we currently don't have any specific how-to links, but as we add more and more how-to's to 
 our documentation, we may introduce them later on.
+
+#### Example: Uniqueness (Collisions)
+To make modeling easier, every tracked Event should be uniquely identifiable through a combination of its 
+[location stack](../core-concepts/locations.md) and its `id`. 
+
+If this is not the case, validation will warn about colliding elements. For example:
+
+![Validation: Collisions](../../../static/img/docs/tracking-collision-browser-console.png)
+
 
 ## Collector validation
 As a final catch-all, Objectiv's [Collector](/tracking/collector/introduction.md) validates any incoming 

--- a/docs/docs/tracking/core-concepts/validation.md
+++ b/docs/docs/tracking/core-concepts/validation.md
@@ -4,6 +4,7 @@ title: Validation
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import VimeoPlayer from '@site/src/components/vimeo-player';
 
 Data tracked by Objectiv adheres to the [open analytics taxonomy](/taxonomy/introduction.md). This means it 
 can be validated early, at the first step of the pipeline. At the same time it makes instrumentation 
@@ -21,9 +22,14 @@ An example inline error in the IDE:
 ![IDE validation: property id](../../../static/img/docs/ide-typescript-validation.png)
 
 ## Run-time validation
+
 When you run your application, any **validation errors** are caught by the Objectiv debugger, and displayed 
 in the browser console. Warnings are thrown for unknown tagging/tracking calls, missing properties, or 
 wrongly typed properties.
+
+See the video below for a walkthrough.
+
+<VimeoPlayer id="product-demo-validation" videoId="722912732" paddingBottom="45%" />
 
 ### Developer Tools
 If you also import the [`developer-tools`](https://www.npmjs.com/package/@objectiv/developer-tools) package,

--- a/docs/src/components/vimeo-player/index.js
+++ b/docs/src/components/vimeo-player/index.js
@@ -1,5 +1,4 @@
 import BrowserOnly from '@docusaurus/BrowserOnly';
-import { default as Vimeo } from "@u-wave/react-vimeo";
 import React from "react";
 import clsx from "clsx";
 import styles from "./styles.module.css";

--- a/docs/src/components/vimeo-player/styles.module.css
+++ b/docs/src/components/vimeo-player/styles.module.css
@@ -1,0 +1,21 @@
+:local(.videoWrapper) {
+  position: relative;
+  padding-bottom: 58.25%; /* 16:9 = 56.25% */
+  height: 0 !important;
+  width: 100% !important;
+}
+
+:local(.videoWrapper iframe) {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+:local(.videoCaption) {
+  text-align: center;
+  margin-top: 5px;
+  margin-bottom: 25px !important;
+  font-style: italic;
+}


### PR DESCRIPTION
Adds the demo video about the new validation features to:
- The docs, under core-concepts > validation
- The blog post about the release, replacing the social image after the intro.

Also adds an example about collisions to the validation docs.