### PR TITLE
Ignore old Cookiebot cookies

### DIFF
--- a/docs/src/objectiv/CookieBanner.tsx
+++ b/docs/src/objectiv/CookieBanner.tsx
@@ -18,6 +18,11 @@ export const getCookieConsent = (): undefined | boolean =>  {
     return undefined;
   }
 
+  // Ignore cookies that don't contain either 'true' or 'false' (these are from Cookiebot)
+  if(cookieConsent !== 'true' && cookieConsent !== 'false') {
+    return undefined;
+  }
+
   return cookieConsent === 'true';
 }
 

--- a/src/objectiv/CookieBanner.tsx
+++ b/src/objectiv/CookieBanner.tsx
@@ -18,6 +18,11 @@ export const getCookieConsent = (): undefined | boolean =>  {
     return undefined;
   }
 
+  // Ignore cookies that don't contain either 'true' or 'false' (these are from Cookiebot)
+  if(cookieConsent !== 'true' && cookieConsent !== 'false') {
+    return undefined;
+  }
+
   return cookieConsent === 'true';
 }
 


### PR DESCRIPTION
@ivarpruijn This fixes the issue of old cookies from cookiebot being parsed as declines.

**Problem**:
Cookiebot had a cookie with the same name, but stored an object in it. 

When our cookie parser read the cookie, it checked for either the strings 'true' or 'false'. If a different value was found, like the old settings of cookiebot, it erroneously interpreted that as 'false'. False is always the default assumption, because we don't want to track unless we are certain of consent.

This means users that had previously accepted or declined cookies with Cookiebot, will now:
- not see a banner
- be considered as declined.

With the new code, instead, the users will be asked to re-confirm their choice via the new banner.